### PR TITLE
fix parsing when vector contains multiple space characters

### DIFF
--- a/src/parse_urdf.jl
+++ b/src/parse_urdf.jl
@@ -8,7 +8,7 @@ end
 
 function parse_vector{T}(::Type{T}, e::Union{XMLElement, Void}, name::ASCIIString, default::ASCIIString)
     usedefault = e == nothing || attribute(e, name) == nothing # TODO: better handling of required attributes
-    [T(parse(str)) for str in split(usedefault ? default : attribute(e, name), " ")]
+    [T(parse(str)) for str in split(usedefault ? default : attribute(e, name))]
 end
 
 function parse_inertia{T}(::Type{T}, xmlInertia::XMLElement)


### PR DESCRIPTION
Some URDFs might contain `origin` vectors with multiple spaces separating elements, like:

```
origin = "1 2  3"
```

which currently breaks the parser, since it gets split into:

```
["1", "2", "", "3"]
```

Not passing a second argument to `split` just does the right thing: it splits on any space character and discards any resulting entries which are empty. 