### PR TITLE
Joint type dependent function macro

### DIFF
--- a/src/RigidBodyDynamics.jl
+++ b/src/RigidBodyDynamics.jl
@@ -66,7 +66,6 @@ export
     num_cols,
     joint_transform,
     motion_subspace,
-    has_fixed_motion_subspace,
     bias_acceleration,
     spatial_inertia,
     crb_inertia,

--- a/src/joint.jl
+++ b/src/joint.jl
@@ -11,30 +11,56 @@ end
 show(io::IO, joint::Joint) = print(io, "Joint \"$(joint.name)\": $(joint.jointType)")
 showcompact(io::IO, joint::Joint) = print(io, "$(joint.name)")
 
+"""
+Given a function signature f(args...), generates a function
+f(joint::Joint, args...) that delegates to a function
+f(joint::Joint, jointType::JointType, args...)
+which should be implemented by the implementor of a joint type
+"""
+macro joint_type_dependent_function(signature)
+    functionName = signature.args[1]
+    functionArgs = signature.args[2:end]
+    eval(quote
+        function $(functionName)(joint::Joint, $(functionArgs...))
+            $(functionName)(joint, joint.jointType, $(functionArgs...))
+        end
+    end)
+end
+
+@joint_type_dependent_function joint_transform(q::AbstractVector)
+@joint_type_dependent_function motion_subspace(q::AbstractVector)
+@joint_type_dependent_function num_positions()
+@joint_type_dependent_function num_velocities()
+@joint_type_dependent_function bias_acceleration(q::AbstractVector, v::AbstractVector)
+@joint_type_dependent_function configuration_derivative_to_velocity(q::AbstractVector, q̇::AbstractVector)
+@joint_type_dependent_function velocity_to_configuration_derivative(q::AbstractVector, v::AbstractVector)
+@joint_type_dependent_function zero_configuration(t::Type)
+@joint_type_dependent_function rand_configuration(t::Type)
+@joint_type_dependent_function joint_twist(q::AbstractVector, v::AbstractVector)
+
 immutable QuaternionFloating <: JointType
 end
 show(io::IO, jt::QuaternionFloating) = print(io, "Quaternion floating joint")
 rand(::Type{QuaternionFloating}) = QuaternionFloating()
 
-function joint_transform{T<:Real}(j::Joint, q::AbstractVector{T}, jt::QuaternionFloating = j.jointType)
+function joint_transform{T<:Real}(j::Joint, jt::QuaternionFloating, q::AbstractVector{T})
     rot = Quaternion(q[1], q[2 : 4])
     Quaternions.normalize(rot)
     trans = Vec(q[5], q[6], q[7])
     return Transform3D{T}(j.frameAfter, j.frameBefore, rot, trans)
 end
 
-function motion_subspace{T<:Real}(j::Joint, q::AbstractVector{T}, jt::QuaternionFloating = j.jointType)
+function motion_subspace{T<:Real}(j::Joint, jt::QuaternionFloating, q::AbstractVector{T})
     angular = hcat(eye(Mat{3, 3, T}), zero(Mat{3, 3, T}))
     linear = hcat(zero(Mat{3, 3, T}), eye(Mat{3, 3, T}))
     return GeometricJacobian(j.frameAfter, j.frameBefore, j.frameAfter, angular, linear)
 end
 
-num_positions(j::Joint, jt::QuaternionFloating = j.jointType) = 7::Int64
-num_velocities(j::Joint, jt::QuaternionFloating = j.jointType) = 6::Int64
-has_fixed_motion_subspace(j::Joint, jt::QuaternionFloating = j.jointType) = true
-bias_acceleration{T<:Real}(j::Joint, q::AbstractVector{T}, v::AbstractVector{T}, jt::QuaternionFloating = j.jointType) = zero(SpatialAcceleration{T}, j.frameAfter, j.frameBefore, j.frameAfter)
+num_positions(j::Joint, jt::QuaternionFloating) = 7::Int64
+num_velocities(j::Joint, jt::QuaternionFloating) = 6::Int64
+bias_acceleration{T<:Real}(j::Joint, jt::QuaternionFloating, q::AbstractVector{T}, v::AbstractVector{T}) = zero(SpatialAcceleration{T}, j.frameAfter, j.frameBefore, j.frameAfter)
 
-function configuration_derivative_to_velocity(j::Joint, q::AbstractVector, q̇::AbstractVector, jt::QuaternionFloating = j.jointType)
+function configuration_derivative_to_velocity(j::Joint, jt::QuaternionFloating, q::AbstractVector, q̇::AbstractVector)
     quat = Quaternion(q[1], q[2 : 4])
     Quaternions.normalize(quat)
     quatdot = Quaternion(q̇[1], q̇[2 : 4])
@@ -44,7 +70,7 @@ function configuration_derivative_to_velocity(j::Joint, q::AbstractVector, q̇::
     return [angularQuat.v1; angularQuat.v2; angularQuat.v3; linear...]
 end
 
-function velocity_to_configuration_derivative(j::Joint, q::AbstractVector, v::AbstractVector, jt::QuaternionFloating = j.jointType)
+function velocity_to_configuration_derivative(j::Joint, jt::QuaternionFloating, q::AbstractVector, v::AbstractVector)
     quat = Quaternion(q[1], q[2 : 4])
     Quaternions.normalize(quat)
     ωQuat = Quaternion(0, v[1], v[2], v[3])
@@ -54,15 +80,15 @@ function velocity_to_configuration_derivative(j::Joint, q::AbstractVector, v::Ab
     return [quatdot.s; quatdot.v1; quatdot.v2; quatdot.v3; posdot...]
 end
 
-function zero_configuration{T<:Real}(j::Joint, ::Type{T}, jt::QuaternionFloating = j.jointType)
+function zero_configuration{T<:Real}(j::Joint, jt::QuaternionFloating, ::Type{T})
     return [one(T); zeros(T, 6)]
 end
-function rand_configuration{T<:Real}(j::Joint, ::Type{T}, jt::QuaternionFloating = j.jointType)
+function rand_configuration{T<:Real}(j::Joint, jt::QuaternionFloating, ::Type{T})
     quat = nquatrand() # TODO: only works when T == Float64
     return [quat.s; quat.v1; quat.v2; quat.v3; rand(T, 3)]
 end
 
-function joint_twist{T<:Real}(j::Joint, q::AbstractVector{T}, v::AbstractVector{T}, jt::QuaternionFloating = j.jointType)
+function joint_twist{T<:Real}(j::Joint, jt::QuaternionFloating, q::AbstractVector{T}, v::AbstractVector{T})
     return Twist(j.frameAfter, j.frameBefore, j.frameAfter, Vec(v[1], v[2], v[3]), Vec(v[4], v[5], v[6]))
 end
 
@@ -75,13 +101,13 @@ end
 show(io::IO, jt::Prismatic) = print(io, "Prismatic joint with axis $(jt.translation_axis)")
 rand{T}(::Type{Prismatic{T}}) = Prismatic(FixedSizeArrays.normalize(rand(Vec{3, T})))
 
-joint_transform{T1<:Real, T2}(j::Joint, q::AbstractVector{T1}, jt::Prismatic{T2} = j.jointType) = Transform3D(j.frameAfter, j.frameBefore, q[1] * jt.translation_axis)
+joint_transform{T1<:Real, T2}(j::Joint, jt::Prismatic{T2}, q::AbstractVector{T1}) = Transform3D(j.frameAfter, j.frameBefore, q[1] * jt.translation_axis)
 
-function joint_twist{T<:Real}(j::Joint, q::AbstractVector{T}, v::AbstractVector{T}, jt::Prismatic = j.jointType)
+function joint_twist{T<:Real}(j::Joint, jt::Prismatic, q::AbstractVector{T}, v::AbstractVector{T})
     return Twist(j.frameAfter, j.frameBefore, j.frameAfter, zero(Vec{3, T}), jt.translation_axis * v[1])
 end
 
-function motion_subspace{T<:Real}(j::Joint, q::AbstractVector{T}, jt::Prismatic = j.jointType)
+function motion_subspace{T<:Real}(j::Joint, jt::Prismatic, q::AbstractVector{T})
     linear = Mat(jt.translation_axis)
     return GeometricJacobian(j.frameAfter, j.frameBefore, j.frameAfter, zero(linear), linear)
 end
@@ -93,7 +119,7 @@ end
 show(io::IO, jt::Revolute) = print(io, "Revolute joint with axis $(jt.rotation_axis)")
 rand{T}(::Type{Revolute{T}}) = Revolute(FixedSizeArrays.normalize(rand(Vec{3, T})))
 
-function joint_transform{T1, T2}(j::Joint, q::AbstractVector{T1}, jt::Revolute{T2} = j.jointType)
+function joint_transform{T1, T2}(j::Joint, jt::Revolute{T2}, q::AbstractVector{T1})
     T = promote_type(T1, T2)
     arg = q[1] / T(2)
     s = sin(arg)
@@ -102,44 +128,42 @@ function joint_transform{T1, T2}(j::Joint, q::AbstractVector{T1}, jt::Revolute{T
     Transform3D(j.frameAfter, j.frameBefore, rot)
 end
 
-function joint_twist{T<:Real}(j::Joint, q::AbstractVector{T}, v::AbstractVector{T}, jt::Revolute = j.jointType)
+function joint_twist{T<:Real}(j::Joint, jt::Revolute, q::AbstractVector{T}, v::AbstractVector{T})
     return Twist(j.frameAfter, j.frameBefore, j.frameAfter, jt.rotation_axis * v[1], zero(Vec{3, T}))
 end
 
-function motion_subspace{T<:Real}(j::Joint, q::AbstractVector{T}, jt::Revolute = j.jointType)
+function motion_subspace{T<:Real}(j::Joint, jt::Revolute, q::AbstractVector{T})
     angular = Mat(jt.rotation_axis)
     return GeometricJacobian(j.frameAfter, j.frameBefore, j.frameAfter, angular, zero(angular))
 end
 
-num_positions(j::Joint, jt::OneDegreeOfFreedomFixedAxis = j.jointType) = 1::Int64
-num_velocities(j::Joint, jt::OneDegreeOfFreedomFixedAxis = j.jointType) = 1::Int64
-zero_configuration{T<:Real}(j::Joint, ::Type{T}, jt::OneDegreeOfFreedomFixedAxis = j.jointType) = [zero(T)]
-rand_configuration{T<:Real}(j::Joint, ::Type{T}, jt::OneDegreeOfFreedomFixedAxis = j.jointType) = [rand(T)]
-has_fixed_motion_subspace(j::Joint, jt::OneDegreeOfFreedomFixedAxis = j.jointType) = true
-bias_acceleration{T<:Real}(j::Joint, q::AbstractVector{T}, v::AbstractVector{T}, jt::OneDegreeOfFreedomFixedAxis = j.jointType) = zero(SpatialAcceleration{T}, j.frameAfter, j.frameBefore, j.frameAfter)
-configuration_derivative_to_velocity(j::Joint, q::AbstractVector, q̇::AbstractVector, jt::OneDegreeOfFreedomFixedAxis = j.jointType) = q̇
-velocity_to_configuration_derivative(j::Joint, q::AbstractVector, v::AbstractVector, jt::OneDegreeOfFreedomFixedAxis = j.jointType) = v
+num_positions(j::Joint, jt::OneDegreeOfFreedomFixedAxis) = 1::Int64
+num_velocities(j::Joint, jt::OneDegreeOfFreedomFixedAxis) = 1::Int64
+zero_configuration{T<:Real}(j::Joint, jt::OneDegreeOfFreedomFixedAxis, ::Type{T}) = [zero(T)]
+rand_configuration{T<:Real}(j::Joint, jt::OneDegreeOfFreedomFixedAxis, ::Type{T}) = [rand(T)]
+bias_acceleration{T<:Real}(j::Joint, jt::OneDegreeOfFreedomFixedAxis, q::AbstractVector{T}, v::AbstractVector{T}) = zero(SpatialAcceleration{T}, j.frameAfter, j.frameBefore, j.frameAfter)
+configuration_derivative_to_velocity(j::Joint, jt::OneDegreeOfFreedomFixedAxis, q::AbstractVector, q̇::AbstractVector) = q̇
+velocity_to_configuration_derivative(j::Joint, jt::OneDegreeOfFreedomFixedAxis, q::AbstractVector, v::AbstractVector) = v
 
 
 immutable Fixed <: JointType
 end
 show(io::IO, jt::Fixed) = print(io, "Fixed joint")
 rand(::Type{Fixed}) = Fixed()
-joint_transform{T}(j::Joint, q::AbstractVector{T}, jt::Fixed = j.jointType) = Transform3D(T, j.frameAfter, j.frameBefore)
-function joint_twist{T<:Real}(j::Joint, q::AbstractVector{T}, v::AbstractVector{T}, jt::Fixed = j.jointType)
+joint_transform{T}(j::Joint, jt::Fixed, q::AbstractVector{T}) = Transform3D(T, j.frameAfter, j.frameBefore)
+function joint_twist{T<:Real}(j::Joint, jt::Fixed, q::AbstractVector{T}, v::AbstractVector{T})
     return zero(Twist{T}, j.frameAfter, j.frameBefore, j.frameAfter)
 end
-function motion_subspace{T<:Real}(j::Joint, q::AbstractVector{T}, jt::Fixed = j.jointType)
+function motion_subspace{T<:Real}(j::Joint, jt::Fixed, q::AbstractVector{T})
     return GeometricJacobian(j.frameAfter, j.frameBefore, j.frameAfter, Mat{3, 0, T}(), Mat{3, 0, T}())
 end
-num_positions(j::Joint, jt::Fixed = j.jointType) = 0::Int64
-num_velocities(j::Joint, jt::Fixed = j.jointType) = 0::Int64
-zero_configuration{T<:Real}(j::Joint, ::Type{T}, jt::Fixed = j.jointType) = zeros(T, 0, 1)
-rand_configuration{T<:Real}(j::Joint, ::Type{T}, jt::Fixed = j.jointType) = zeros(T, 0, 1)
-has_fixed_motion_subspace(j::Joint, jt::Fixed = j.jointType) = true
-bias_acceleration{T<:Real}(j::Joint, q::AbstractVector{T}, v::AbstractVector{T}, jt::Fixed = j.jointType) = zero(SpatialAcceleration{T}, j.frameAfter, j.frameBefore, j.frameAfter)
-configuration_derivative_to_velocity(j::Joint, q::AbstractVector, q̇::AbstractVector, jt::Fixed = j.jointType) = q̇
-velocity_to_configuration_derivative(j::Joint, q::AbstractVector, v::AbstractVector, jt::Fixed = j.jointType) = v
+num_positions(j::Joint, jt::Fixed) = 0::Int64
+num_velocities(j::Joint, jt::Fixed) = 0::Int64
+zero_configuration{T<:Real}(j::Joint, jt::Fixed, ::Type{T}) = zeros(T, 0, 1)
+rand_configuration{T<:Real}(j::Joint, jt::Fixed, ::Type{T}) = zeros(T, 0, 1)
+bias_acceleration{T<:Real}(j::Joint, jt::Fixed, q::AbstractVector{T}, v::AbstractVector{T}) = zero(SpatialAcceleration{T}, j.frameAfter, j.frameBefore, j.frameAfter)
+configuration_derivative_to_velocity(j::Joint, jt::Fixed, q::AbstractVector, q̇::AbstractVector) = q̇
+velocity_to_configuration_derivative(j::Joint, jt::Fixed, q::AbstractVector, v::AbstractVector) = v
 
 
 num_positions(itr) = reduce((val, joint) -> val + num_positions(joint), 0, itr)


### PR DESCRIPTION
Instead of doing the hacky default argument thing (which julia 0.5 didn't like), use a simple macro to create a joint method that delegates to joint type dependent methods.