### PR TITLE
joint_torque! method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ os:
   - linux
   - osx
 julia:
+  - 0.5
   - nightly
 notifications:
   email: false

--- a/src/RigidBodyDynamics.jl
+++ b/src/RigidBodyDynamics.jl
@@ -58,6 +58,7 @@ export
     transform,
     newton_euler,
     joint_torque,
+    joint_torque!,
     root_body,
     root_frame,
     root_vertex,

--- a/src/joint.jl
+++ b/src/joint.jl
@@ -107,6 +107,7 @@ function joint_torque!(j::Joint, jt::QuaternionFloating, q::AbstractVector, join
     length(τ) == num_velocities(j, jt) || error("τ has wrong size")
     @inbounds τ[1 : 3] = joint_wrench.angular
     @inbounds τ[4 : 6] = joint_wrench.linear
+    nothing
 end
 
 
@@ -146,6 +147,7 @@ function joint_torque!(j::Joint, jt::Prismatic, q::AbstractVector, joint_wrench:
     framecheck(joint_wrench.frame, j.frameAfter)
     length(τ) == num_velocities(j, jt) || error("τ has wrong size")
     @inbounds τ[1] = dot(joint_wrench.linear, jt.translation_axis)
+    nothing
 end
 
 
@@ -182,6 +184,7 @@ function joint_torque!(j::Joint, jt::Revolute, q::AbstractVector, joint_wrench::
     framecheck(joint_wrench.frame, j.frameAfter)
     length(τ) == num_velocities(j, jt) || error("τ has wrong size")
     @inbounds τ[1] = dot(joint_wrench.angular, jt.rotation_axis)
+    nothing
 end
 
 immutable Fixed <: JointType

--- a/src/joint.jl
+++ b/src/joint.jl
@@ -37,7 +37,7 @@ end
 @joint_type_dependent_function zero_configuration(t::Type)
 @joint_type_dependent_function rand_configuration(t::Type)
 @joint_type_dependent_function joint_twist(q::AbstractVector, v::AbstractVector)
-@joint_type_dependent_function joint_torque!(q::AbstractVector, joint_wrench::Wrench, τ::AbstractVector)
+@joint_type_dependent_function joint_torque!(τ::AbstractVector, q::AbstractVector, joint_wrench::Wrench)
 
 immutable QuaternionFloating <: JointType
 end
@@ -102,7 +102,7 @@ function joint_twist{T<:Real}(j::Joint, jt::QuaternionFloating, q::AbstractVecto
     ret
 end
 
-function joint_torque!(j::Joint, jt::QuaternionFloating, q::AbstractVector, joint_wrench::Wrench, τ::AbstractVector)
+function joint_torque!(j::Joint, jt::QuaternionFloating, τ::AbstractVector, q::AbstractVector, joint_wrench::Wrench)
     framecheck(joint_wrench.frame, j.frameAfter)
     length(τ) == num_velocities(j, jt) || error("τ has wrong size")
     @inbounds τ[1 : 3] = joint_wrench.angular
@@ -143,7 +143,7 @@ function motion_subspace{T<:Real}(j::Joint, jt::Prismatic, q::AbstractVector{T})
     return GeometricJacobian(j.frameAfter, j.frameBefore, j.frameAfter, angular, linear)
 end
 
-function joint_torque!(j::Joint, jt::Prismatic, q::AbstractVector, joint_wrench::Wrench, τ::AbstractVector)
+function joint_torque!(j::Joint, jt::Prismatic, τ::AbstractVector, q::AbstractVector, joint_wrench::Wrench)
     framecheck(joint_wrench.frame, j.frameAfter)
     length(τ) == num_velocities(j, jt) || error("τ has wrong size")
     @inbounds τ[1] = dot(joint_wrench.linear, jt.translation_axis)
@@ -180,7 +180,7 @@ function motion_subspace{T<:Real}(j::Joint, jt::Revolute, q::AbstractVector{T})
     return GeometricJacobian(j.frameAfter, j.frameBefore, j.frameAfter, angular, linear)
 end
 
-function joint_torque!(j::Joint, jt::Revolute, q::AbstractVector, joint_wrench::Wrench, τ::AbstractVector)
+function joint_torque!(j::Joint, jt::Revolute, τ::AbstractVector, q::AbstractVector, joint_wrench::Wrench)
     framecheck(joint_wrench.frame, j.frameAfter)
     length(τ) == num_velocities(j, jt) || error("τ has wrong size")
     @inbounds τ[1] = dot(joint_wrench.angular, jt.rotation_axis)
@@ -205,7 +205,7 @@ rand_configuration{T<:Real}(j::Joint, jt::Fixed, ::Type{T}) = zeros(T, 0, 1)
 bias_acceleration{T<:Real}(j::Joint, jt::Fixed, q::AbstractVector{T}, v::AbstractVector{T}) = zero(SpatialAcceleration{T}, j.frameAfter, j.frameBefore, j.frameAfter)
 configuration_derivative_to_velocity(j::Joint, jt::Fixed, q::AbstractVector, q̇::AbstractVector) = q̇
 velocity_to_configuration_derivative(j::Joint, jt::Fixed, q::AbstractVector, v::AbstractVector) = v
-joint_torque!(j::Joint, jt::Fixed, q::AbstractVector, joint_wrench::Wrench, τ::AbstractVector) = nothing
+joint_torque!(j::Joint, jt::Fixed, τ::AbstractVector, q::AbstractVector, joint_wrench::Wrench) = nothing
 
 
 num_positions(itr) = reduce((val, joint) -> val + num_positions(joint), 0, itr)

--- a/src/joint.jl
+++ b/src/joint.jl
@@ -37,6 +37,7 @@ end
 @joint_type_dependent_function zero_configuration(t::Type)
 @joint_type_dependent_function rand_configuration(t::Type)
 @joint_type_dependent_function joint_twist(q::AbstractVector, v::AbstractVector)
+@joint_type_dependent_function joint_torque!(q::AbstractVector, joint_wrench::Wrench, τ::AbstractVector)
 
 immutable QuaternionFloating <: JointType
 end
@@ -101,7 +102,23 @@ function joint_twist{T<:Real}(j::Joint, jt::QuaternionFloating, q::AbstractVecto
     ret
 end
 
+function joint_torque!(j::Joint, jt::QuaternionFloating, q::AbstractVector, joint_wrench::Wrench, τ::AbstractVector)
+    framecheck(joint_wrench.frame, j.frameAfter)
+    length(τ) == num_velocities(j, jt) || error("τ has wrong size")
+    @inbounds τ[1 : 3] = joint_wrench.angular
+    @inbounds τ[4 : 6] = joint_wrench.linear
+end
+
+
 abstract OneDegreeOfFreedomFixedAxis <: JointType
+num_positions(j::Joint, jt::OneDegreeOfFreedomFixedAxis) = 1::Int64
+num_velocities(j::Joint, jt::OneDegreeOfFreedomFixedAxis) = 1::Int64
+zero_configuration{T<:Real}(j::Joint, jt::OneDegreeOfFreedomFixedAxis, ::Type{T}) = [zero(T)]
+rand_configuration{T<:Real}(j::Joint, jt::OneDegreeOfFreedomFixedAxis, ::Type{T}) = [rand(T)]
+bias_acceleration{T<:Real}(j::Joint, jt::OneDegreeOfFreedomFixedAxis, q::AbstractVector{T}, v::AbstractVector{T}) = zero(SpatialAcceleration{T}, j.frameAfter, j.frameBefore, j.frameAfter)
+configuration_derivative_to_velocity(j::Joint, jt::OneDegreeOfFreedomFixedAxis, q::AbstractVector, q̇::AbstractVector) = q̇
+velocity_to_configuration_derivative(j::Joint, jt::OneDegreeOfFreedomFixedAxis, q::AbstractVector, v::AbstractVector) = v
+
 
 immutable Prismatic{T<:Real} <: OneDegreeOfFreedomFixedAxis
     translation_axis::SVector{3, T}
@@ -125,10 +142,17 @@ function motion_subspace{T<:Real}(j::Joint, jt::Prismatic, q::AbstractVector{T})
     return GeometricJacobian(j.frameAfter, j.frameBefore, j.frameAfter, angular, linear)
 end
 
+function joint_torque!(j::Joint, jt::Prismatic, q::AbstractVector, joint_wrench::Wrench, τ::AbstractVector)
+    framecheck(joint_wrench.frame, j.frameAfter)
+    length(τ) == num_velocities(j, jt) || error("τ has wrong size")
+    @inbounds τ[1] = dot(joint_wrench.linear, jt.translation_axis)
+end
+
+
 immutable Revolute{T<:Real} <: OneDegreeOfFreedomFixedAxis
     rotation_axis::SVector{3, T}
 end
-# Revolute{T}(rotation_axis::SVector{3, T}) = Revolute{T}(rotation_axis)
+
 show(io::IO, jt::Revolute) = print(io, "Revolute joint with axis $(jt.rotation_axis)")
 function rand{T}(::Type{Revolute{T}})
     axis = rand(SVector{3, T})
@@ -154,14 +178,11 @@ function motion_subspace{T<:Real}(j::Joint, jt::Revolute, q::AbstractVector{T})
     return GeometricJacobian(j.frameAfter, j.frameBefore, j.frameAfter, angular, linear)
 end
 
-num_positions(j::Joint, jt::OneDegreeOfFreedomFixedAxis) = 1::Int64
-num_velocities(j::Joint, jt::OneDegreeOfFreedomFixedAxis) = 1::Int64
-zero_configuration{T<:Real}(j::Joint, jt::OneDegreeOfFreedomFixedAxis, ::Type{T}) = [zero(T)]
-rand_configuration{T<:Real}(j::Joint, jt::OneDegreeOfFreedomFixedAxis, ::Type{T}) = [rand(T)]
-bias_acceleration{T<:Real}(j::Joint, jt::OneDegreeOfFreedomFixedAxis, q::AbstractVector{T}, v::AbstractVector{T}) = zero(SpatialAcceleration{T}, j.frameAfter, j.frameBefore, j.frameAfter)
-configuration_derivative_to_velocity(j::Joint, jt::OneDegreeOfFreedomFixedAxis, q::AbstractVector, q̇::AbstractVector) = q̇
-velocity_to_configuration_derivative(j::Joint, jt::OneDegreeOfFreedomFixedAxis, q::AbstractVector, v::AbstractVector) = v
-
+function joint_torque!(j::Joint, jt::Revolute, q::AbstractVector, joint_wrench::Wrench, τ::AbstractVector)
+    framecheck(joint_wrench.frame, j.frameAfter)
+    length(τ) == num_velocities(j, jt) || error("τ has wrong size")
+    @inbounds τ[1] = dot(joint_wrench.angular, jt.rotation_axis)
+end
 
 immutable Fixed <: JointType
 end
@@ -181,6 +202,7 @@ rand_configuration{T<:Real}(j::Joint, jt::Fixed, ::Type{T}) = zeros(T, 0, 1)
 bias_acceleration{T<:Real}(j::Joint, jt::Fixed, q::AbstractVector{T}, v::AbstractVector{T}) = zero(SpatialAcceleration{T}, j.frameAfter, j.frameBefore, j.frameAfter)
 configuration_derivative_to_velocity(j::Joint, jt::Fixed, q::AbstractVector, q̇::AbstractVector) = q̇
 velocity_to_configuration_derivative(j::Joint, jt::Fixed, q::AbstractVector, v::AbstractVector) = v
+joint_torque!(j::Joint, jt::Fixed, q::AbstractVector, joint_wrench::Wrench, τ::AbstractVector) = nothing
 
 
 num_positions(itr) = reduce((val, joint) -> val + num_positions(joint), 0, itr)

--- a/src/mechanism_algorithms.jl
+++ b/src/mechanism_algorithms.jl
@@ -241,11 +241,12 @@ function joint_wrenches_and_torques!{T, X, M}(
         body = vertex.vertexData
         parentBody = vertex.parent.vertexData
         jointWrench = netWrenchesInJointWrenchesOut[body]
-        S = motion_subspace(state, joint)
-        view(torquesOut, mechanism.vRanges[joint])[:] = joint_torque(S, jointWrench)
         if !isroot(parentBody)
             netWrenchesInJointWrenchesOut[parentBody] = netWrenchesInJointWrenchesOut[parentBody] + jointWrench # action = -reaction
         end
+        jointWrench = transform(state, jointWrench, joint.frameAfter)
+        τjoint = view(torquesOut, mechanism.vRanges[joint])
+        joint_torque!(joint, configuration(state, joint), jointWrench, τjoint)
     end
 end
 

--- a/src/mechanism_algorithms.jl
+++ b/src/mechanism_algorithms.jl
@@ -246,7 +246,7 @@ function joint_wrenches_and_torques!{T, X, M}(
         end
         jointWrench = transform(state, jointWrench, joint.frameAfter)
         τjoint = view(torquesOut, mechanism.vRanges[joint])
-        joint_torque!(joint, configuration(state, joint), jointWrench, τjoint)
+        joint_torque!(joint, τjoint, configuration(state, joint), jointWrench)
     end
 end
 

--- a/src/mechanism_state.jl
+++ b/src/mechanism_state.jl
@@ -81,8 +81,8 @@ num_velocities(state::MechanismState) = length(state.v)
 state_vector_eltype{X, M, C}(state::MechanismState{X, M, C}) = X
 mechanism_eltype{X, M, C}(state::MechanismState{X, M, C}) = M
 cache_eltype{X, M, C}(state::MechanismState{X, M, C}) = C
-configuration(state::MechanismState, joint::Joint) = state.q[state.mechanism.qRanges[joint]] #view(state.q, state.qRanges[joint])
-velocity(state::MechanismState, joint::Joint) = state.v[state.mechanism.vRanges[joint]] #view(state.v, state.vRanges[joint])
+configuration(state::MechanismState, joint::Joint) = view(state.q, state.mechanism.qRanges[joint])
+velocity(state::MechanismState, joint::Joint) = view(state.v, state.mechanism.vRanges[joint])
 
 function setdirty!(state::MechanismState)
     setdirty!(state.transformCache)
@@ -122,27 +122,27 @@ state_vector(state::MechanismState) = [configuration_vector(state); velocity_vec
 configuration_vector{T}(state::MechanismState, path::Path{RigidBody{T}, Joint}) = vcat([state.q[state.mechanism.qRanges[joint]] for joint in path.edgeData]...)
 velocity_vector{T}(state::MechanismState, path::Path{RigidBody{T}, Joint}) = vcat([state.v[state.mechanism.vRanges[joint]] for joint in path.edgeData]...)
 
-function set_configuration!(state::MechanismState, joint::Joint, q::Vector)
+function set_configuration!(state::MechanismState, joint::Joint, q::AbstractVector)
     view(state.q, state.mechanism.qRanges[joint])[:] = q
     setdirty!(state)
 end
 
-function set_velocity!(state::MechanismState, joint::Joint, v::Vector)
+function set_velocity!(state::MechanismState, joint::Joint, v::AbstractVector)
     view(state.v, state.mechanism.vRanges[joint])[:] = v
     setdirty!(state)
 end
 
-function set_configuration!(state::MechanismState, q::Vector)
+function set_configuration!(state::MechanismState, q::AbstractVector)
     copy!(state.q, q)
     setdirty!(state)
 end
 
-function set_velocity!(state::MechanismState, v::Vector)
+function set_velocity!(state::MechanismState, v::AbstractVector)
     copy!(state.v, v)
     setdirty!(state)
 end
 
-function set!(state::MechanismState, x::Vector)
+function set!(state::MechanismState, x::AbstractVector)
     nq = num_positions(state)
     nv = num_velocities(state)
     length(x) == nq + nv || error("wrong size")

--- a/test/test_mechanism.jl
+++ b/test/test_mechanism.jl
@@ -54,7 +54,7 @@ facts("joint_torque! / geometric_jacobian") do
         qjoint = configuration(x, joint)
         wrench = rand(Wrench{Float64}, joint.frameAfter)
         τ = Vector{Float64}(num_velocities(joint))
-        joint_torque!(joint, qjoint, wrench, τ)
+        joint_torque!(joint, τ, qjoint, wrench)
         S = motion_subspace(joint, qjoint)
         @fact τ --> roughly(joint_torque(S, wrench))
     end

--- a/test/test_mechanism.jl
+++ b/test/test_mechanism.jl
@@ -49,6 +49,17 @@ facts("q̇ <-> v") do
     end
 end
 
+facts("joint_torque! / geometric_jacobian") do
+    for joint in joints(mechanism)
+        qjoint = configuration(x, joint)
+        wrench = rand(Wrench{Float64}, joint.frameAfter)
+        τ = Vector{Float64}(num_velocities(joint))
+        joint_torque!(joint, qjoint, wrench, τ)
+        S = motion_subspace(joint, qjoint)
+        @fact τ --> roughly(joint_torque(S, wrench))
+    end
+end
+
 facts("geometric_jacobian / relative_twist") do
     bs = Set(bodies(mechanism))
     body = rand([bs...])
@@ -256,3 +267,5 @@ facts("dynamics / inverse dynamics") do
     τ = inverse_dynamics(x, result.v̇, externalWrenches)
     @fact τ --> roughly(zeros(num_velocities(mechanism)); atol = 1e-12)
 end
+
+nothing


### PR DESCRIPTION
Add `joint_torque!` method, which enables a reduction in allocations, gets rid of some multiplications by zero, and is a step towards removing abstract GeometricJacobian types from the MechanismState cache.