### PR TITLE
GeometricJacobian and MomentumMatrix parameterized on underlying array type

### DIFF
--- a/src/RigidBodyDynamics.jl
+++ b/src/RigidBodyDynamics.jl
@@ -2,7 +2,7 @@
 
 module RigidBodyDynamics
 
-import Base: convert, zero, one, *, +, /, -, call, inv, get, findfirst, Random.rand, Random.rand!, hcat, show, showcompact, isapprox, dot, cross, unsafe_copy!, Array
+import Base: convert, zero, one, *, +, /, -, call, inv, get, findfirst, Random.rand, Random.rand!, hcat, show, showcompact, isapprox, dot, cross, unsafe_copy!, Array, eltype
 using StaticArrays
 using Quaternions
 using DataStructures

--- a/src/mechanism_algorithms.jl
+++ b/src/mechanism_algorithms.jl
@@ -97,7 +97,7 @@ center_of_mass(state::MechanismState) = center_of_mass(state, bodies(state.mecha
 
 function geometric_jacobian{X, M, C}(state::MechanismState{X, M, C}, path::Path{RigidBody{M}, Joint})
     copysign = (motionSubspace::GeometricJacobian, sign::Int64) -> sign < 0 ? -motionSubspace : motionSubspace
-    motionSubspaces = [copysign(motion_subspace(state, joint), sign)::GeometricJacobian{C} for (joint, sign) in zip(path.edgeData, path.directions)]
+    motionSubspaces = [copysign(motion_subspace(state, joint), sign)::GeometricJacobian for (joint, sign) in zip(path.edgeData, path.directions)]
     return hcat(motionSubspaces...)
 end
 

--- a/src/mechanism_state.jl
+++ b/src/mechanism_state.jl
@@ -60,7 +60,7 @@ immutable MechanismState{X<:Real, M<:Real, C<:Real} # immutable, but can change 
     v::Vector{X}
     transformCache::TransformCache{C}
     twistsAndBiases::Dict{RigidBody{M}, CacheElement{Tuple{Twist{C}, SpatialAcceleration{C}}, UpdateTwistAndBias{C}}}
-    motionSubspaces::Dict{Joint, CacheElement{GeometricJacobian{C}}}
+    motionSubspaces::Dict{Joint, CacheElement{GeometricJacobian}}
     spatialInertias::Dict{RigidBody{M}, CacheElement{SpatialInertia{C}, UpdateSpatialInertiaInWorld{M, C}}}
     crbInertias::Dict{RigidBody{M}, CacheElement{SpatialInertia{C}, UpdateCompositeRigidBodyInertia{M, C}}}
 
@@ -179,7 +179,7 @@ function MechanismState{X, M}(::Type{X}, m::Mechanism{M})
                 S = transform(motion_subspace(joint, qJoint), get(transformToRootCache))
                 GeometricJacobian(S.body, parentFrame, S.frame, S.angular, S.linear) # to make frames line up
             end
-            state.motionSubspaces[joint] = CacheElement(GeometricJacobian{C}, update_motion_subspace)
+            state.motionSubspaces[joint] = CacheElement(GeometricJacobian, update_motion_subspace)
         else
             rootTwist = zero(Twist{C}, root.frame, root.frame, root.frame)
             rootBias = zero(SpatialAcceleration{C}, root.frame, root.frame, root.frame)

--- a/test/test_spatial.jl
+++ b/test/test_spatial.jl
@@ -55,7 +55,8 @@ facts("momentum") do
 end
 
 facts("geometric jacobian, power") do
-    J = GeometricJacobian(f2, f1, f3, rand(6, 14))
+    n = 14
+    J = GeometricJacobian(f2, f1, f3, rand(SMatrix{3, n}), rand(SMatrix{3, n}))
     v = rand(num_cols(J))
     W = rand(Wrench{Float64}, f3)
     T = Twist(J, v)
@@ -71,7 +72,8 @@ facts("geometric jacobian, power") do
 end
 
 facts("momentum matrix") do
-    A = MomentumMatrix(f3, rand(6, 13))
+    n = 13
+    A = MomentumMatrix(f3, rand(SMatrix{3, n}), rand(SMatrix{3, n}))
     v = rand(num_cols(A))
     h = Momentum(A, v)
     H = rand(Transform3D{Float64}, f3, f1)


### PR DESCRIPTION
This was actually only meant to improve flexibility and allow modifiable GeometricJacobians for future endeavors, but ended up speeding things up quite a bit again (still not as fast as with 0.4, but not as terrible anymore).