### PR TITLE
Improve URDF parsing for root rigid bodies

### DIFF
--- a/perf/runbenchmarks.jl
+++ b/perf/runbenchmarks.jl
@@ -18,11 +18,11 @@ end
 
 function create_floating_atlas()
     atlas = parse_urdf(Float64, get_atlas_urdf())
-    world = RigidBody{Float64}("world")
-    floating_atlas = Mechanism(world)
-    floating_joint = Joint("floating", QuaternionFloating())
-    attach!(floating_atlas, world, floating_joint, Transform3D{Float64}(floating_joint.frameBefore, world.frame), atlas)
-    floating_atlas
+    for child in root_vertex(atlas).children
+        joint = child.edgeToParentData
+        change_joint_type!(atlas, joint, QuaternionFloating())
+    end
+    atlas
 end
 
 function create_benchmark_suite()

--- a/src/RigidBodyDynamics.jl
+++ b/src/RigidBodyDynamics.jl
@@ -89,6 +89,7 @@ export
     setdirty!,
     add_body_fixed_frame!,
     attach!,
+    change_joint_type!,
     rand_mechanism,
     rand_chain_mechanism,
     rand_tree_mechanism,

--- a/src/mechanism.jl
+++ b/src/mechanism.jl
@@ -129,7 +129,7 @@ function attach!{T}(m::Mechanism{T}, parentBody::RigidBody{T}, childMechanism::M
 end
 
 function change_joint_type!(m::Mechanism, joint::Joint, newType::JointType)
-    joint.jointType = QuaternionFloating()
+    joint.jointType = newType
     recompute_ranges!(m::Mechanism)
     m
 end

--- a/src/mechanism.jl
+++ b/src/mechanism.jl
@@ -128,6 +128,12 @@ function attach!{T}(m::Mechanism{T}, parentBody::RigidBody{T}, childMechanism::M
     m
 end
 
+function change_joint_type!(m::Mechanism, joint::Joint, newType::JointType)
+    joint.jointType = QuaternionFloating()
+    recompute_ranges!(m::Mechanism)
+    m
+end
+
 joints(m::Mechanism) = [vertex.edgeToParentData::Joint for vertex in non_root_vertices(m)] # TODO: make less expensive
 bodies{T}(m::Mechanism{T}) = [vertex.vertexData::RigidBody{T} for vertex in m.toposortedTree] # TODO: make less expensive
 non_root_bodies{T}(m::Mechanism{T}) = [vertex.vertexData::RigidBody{T} for vertex in non_root_vertices(m)] # TODO: make less expensive

--- a/src/mechanism_algorithms.jl
+++ b/src/mechanism_algorithms.jl
@@ -83,9 +83,11 @@ function center_of_mass{X, M, C}(state::MechanismState{X, M, C}, itr)
     mass = zero(C)
     for body in itr
         inertia = spatial_inertia(body)
-        bodyCom = center_of_mass(inertia)
-        com += inertia.mass * FreeVector3D(transform(state, bodyCom, frame))
-        mass += inertia.mass
+        if inertia.mass > zero(C)
+            bodyCom = center_of_mass(inertia)
+            com += inertia.mass * FreeVector3D(transform(state, bodyCom, frame))
+            mass += inertia.mass
+        end
     end
     com /= mass
     return com

--- a/src/parse_urdf.jl
+++ b/src/parse_urdf.jl
@@ -69,15 +69,22 @@ function parse_body{T}(::Type{T}, xmlLink::XMLElement, frame::CartesianFrame3D =
 end
 
 function parse_vertex{T}(mechanism::Mechanism{T}, vertex::TreeVertex{XMLElement, XMLElement})
-    isroot(vertex) && error("unexpected non-root body")
-    xmlJoint, xmlLink = vertex.edgeToParentData, vertex.vertexData
-    parentName = attribute(find_element(xmlJoint, "parent"), "link")
-    parent = findfirst(v -> RigidBodyDynamics.name(v.vertexData) == parentName, tree(mechanism)).vertexData
-    joint = parse_joint(T, xmlJoint)
-    pose = parse_pose(T, find_element(xmlJoint, "origin"))
-    jointToParent = Transform3D(joint.frameBefore, default_frame(mechanism, parent), pose...)
-    child = parse_body(T, xmlLink, joint.frameAfter)
-    attach!(mechanism, parent, joint, jointToParent, child)
+    xmlLink = vertex.vertexData
+    if isroot(vertex)
+        parent = root_body(mechanism)
+        body = parse_body(T, xmlLink)
+        joint = Joint("$(name(body))_to_world", Fixed())
+        jointToParent = Transform3D{T}(joint.frameBefore, parent.frame)
+    else
+        xmlJoint = vertex.edgeToParentData
+        parentName = attribute(find_element(xmlJoint, "parent"), "link")
+        parent = findfirst(v -> RigidBodyDynamics.name(v.vertexData) == parentName, tree(mechanism)).vertexData
+        joint = parse_joint(T, xmlJoint)
+        pose = parse_pose(T, find_element(xmlJoint, "origin"))
+        jointToParent = Transform3D(joint.frameBefore, default_frame(mechanism, parent), pose...)
+        body = parse_body(T, xmlLink, joint.frameAfter)
+    end
+    attach!(mechanism, parent, joint, jointToParent, body)
 end
 
 function parse_urdf{T}(::Type{T}, filename)
@@ -103,9 +110,9 @@ function parse_urdf{T}(::Type{T}, filename)
     tree = roots[1]
 
     # create mechanism from tree structure of XML elements
-    rootBody = parse_body(T, tree.vertexData)
+    rootBody = RigidBody{T}("world")
     mechanism = Mechanism(rootBody)
-    for vertex in toposort(tree)[2 : end]
+    for vertex in toposort(tree)
         parse_vertex(mechanism, vertex)
     end
     mechanism


### PR DESCRIPTION
Previously, rigid bodies defined in the URDF without a parent joint were made root rigid bodies of the constructed Mechanism (with an error thrown if there were multiple such bodies). This change constructs a dedicated root rigid body with undefined inertia, and then attaches these bodies to the root with a fixed joint.

Also added functionality to change the type of a Joint after construction of the Mechanism, reenabling the creation of floating base versions of a mechanism loaded from a URDF.

cc: @rdeits