### PR TITLE
remove_fixed_joints! of Atlas in benchmark

### DIFF
--- a/perf/runbenchmarks.jl
+++ b/perf/runbenchmarks.jl
@@ -28,6 +28,7 @@ end
 function create_benchmark_suite()
     suite = BenchmarkGroup()
     mechanism = create_floating_atlas()
+    remove_fixed_joints!(mechanism)
 
     let
         state = MechanismState(Float64, mechanism)


### PR DESCRIPTION
Significant speedup.

Before removing fixed joints:
```
3-element BenchmarkTools.BenchmarkGroup:
  tags: []
  "inverse_dynamics" => BenchmarkTools.Trial: 
  samples:          6071
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  95.19 kb
  allocs estimate:  1752
  minimum time:     608.65 μs (0.00% GC)
  median time:      653.28 μs (0.00% GC)
  mean time:        696.94 μs (1.53% GC)
  maximum time:     4.65 ms (76.68% GC)
  "dynamics" => BenchmarkTools.Trial: 
  samples:          7429
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  154.20 kb
  allocs estimate:  3520
  minimum time:     492.09 μs (0.00% GC)
  median time:      508.40 μs (0.00% GC)
  mean time:        551.53 μs (4.46% GC)
  maximum time:     4.41 ms (83.76% GC)
  "mass_matrix" => BenchmarkTools.Trial: 
  samples:          10000
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  124.55 kb
  allocs estimate:  2903
  minimum time:     306.73 μs (0.00% GC)
  median time:      331.34 μs (0.00% GC)
  mean time:        377.79 μs (5.21% GC)
  maximum time:     13.70 ms (91.95% GC)
```

After:
```
3-element BenchmarkTools.BenchmarkGroup:
  tags: []
  "inverse_dynamics" => BenchmarkTools.Trial: 
  samples:          10000
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  53.95 kb
  allocs estimate:  969
  minimum time:     312.04 μs (0.00% GC)
  median time:      324.61 μs (0.00% GC)
  mean time:        345.11 μs (2.07% GC)
  maximum time:     4.45 ms (84.64% GC)
  "dynamics" => BenchmarkTools.Trial: 
  samples:          8371
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  126.56 kb
  allocs estimate:  3085
  minimum time:     410.13 μs (0.00% GC)
  median time:      427.39 μs (0.00% GC)
  mean time:        490.18 μs (3.84% GC)
  maximum time:     7.89 ms (87.15% GC)
  "mass_matrix" => BenchmarkTools.Trial: 
  samples:          10000
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  110.95 kb
  allocs estimate:  2758
  minimum time:     285.64 μs (0.00% GC)
  median time:      302.43 μs (0.00% GC)
  mean time:        332.88 μs (4.27% GC)
  maximum time:     4.65 ms (85.31% GC)
```
