### PR TITLE
Tree updates

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,5 +3,4 @@ StaticArrays 0.0.4
 Quaternions
 DataStructures
 LightXML
-Compat 0.8.3
 ODE 0.2.1

--- a/examples/Frames.ipynb
+++ b/examples/Frames.ipynb
@@ -8,10 +8,8 @@
    },
    "outputs": [],
    "source": [
-    "push!(LOAD_PATH, \"../src\")\n",
-    "using Quaternions\n",
-    "using StaticArrays\n",
-    "using RigidBodyDynamics"
+    "using RigidBodyDynamics\n",
+    "using StaticArrays: SVector"
    ]
   },
   {

--- a/examples/Joints.ipynb
+++ b/examples/Joints.ipynb
@@ -8,10 +8,8 @@
    },
    "outputs": [],
    "source": [
-    "push!(LOAD_PATH, \"../src\")\n",
-    "using Quaternions\n",
-    "using StaticArrays\n",
-    "using RigidBodyDynamics"
+    "using RigidBodyDynamics\n",
+    "using StaticArrays: SVector"
    ]
   },
   {
@@ -22,7 +20,7 @@
    },
    "outputs": [],
    "source": [
-    "j1 = Joint(\"1\", QuaternionFloating())"
+    "j1 = Joint(\"1\", QuaternionFloating{Float64}())"
    ]
   },
   {
@@ -33,7 +31,9 @@
    },
    "outputs": [],
    "source": [
-    "joint_transform(j1, rand_configuration(j1, Float64))"
+    "q1 = Vector{Float64}(num_positions(j1))\n",
+    "rand_configuration!(j1, q1)\n",
+    "joint_transform(j1, q1)"
    ]
   },
   {
@@ -55,7 +55,8 @@
    },
    "outputs": [],
    "source": [
-    "joint_transform(j2, [3.0])"
+    "q2 = [3.0]\n",
+    "joint_transform(j2, q2)"
    ]
   },
   {
@@ -66,7 +67,8 @@
    },
    "outputs": [],
    "source": [
-    "q = zero_configuration(j1, Float64)"
+    "zero_configuration!(j1, q1)\n",
+    "q1"
    ]
   },
   {
@@ -77,7 +79,8 @@
    },
    "outputs": [],
    "source": [
-    "q = zero_configuration(j2, Float64)"
+    "zero_configuration!(j2, q2)\n",
+    "q2"
    ]
   },
   {

--- a/examples/Mechanism.ipynb
+++ b/examples/Mechanism.ipynb
@@ -8,10 +8,8 @@
    },
    "outputs": [],
    "source": [
-    "push!(LOAD_PATH, \"../src\")\n",
-    "using Quaternions\n",
-    "using StaticArrays\n",
-    "using RigidBodyDynamics"
+    "using RigidBodyDynamics\n",
+    "using StaticArrays: SVector"
    ]
   },
   {
@@ -35,7 +33,7 @@
    "outputs": [],
    "source": [
     "body1 = RigidBody(rand(SpatialInertia{Float64}, CartesianFrame3D(\"body1\")));\n",
-    "joint1 = Joint(\"joint1\", QuaternionFloating());\n",
+    "joint1 = Joint(\"joint1\", QuaternionFloating{Float64}());\n",
     "joint1ToBase = rand(Transform3D{Float64}, joint1.frameBefore, base.frame)\n",
     "body1ToJoint1 = rand(Transform3D{Float64}, body1.frame, joint1.frameAfter)\n",
     "attach!(mechanism, base, joint1, joint1ToBase, body1, body1ToJoint1);"
@@ -290,37 +288,8 @@
    },
    "outputs": [],
    "source": [
-    "# create a floating version of the same mechanism\n",
-    "world = RigidBody{Float64}(\"world\")\n",
-    "floatingMechanism = Mechanism(world)\n",
-    "floatingJoint = Joint(\"floating\", QuaternionFloating())\n",
-    "attach!(floatingMechanism, world, floatingJoint, Transform3D{Float64}(floatingJoint.frameBefore, world.frame), mechanism)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "x = MechanismState(Float64, floatingMechanism)\n",
-    "rand!(x)\n",
-    "H = mass_matrix(x)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
     "# random chain\n",
-    "rand_chain_mechanism(Float64, QuaternionFloating, Revolute{Float64}, Revolute{Float64})"
+    "rand_chain_mechanism(Float64, QuaternionFloating{Float64}, Revolute{Float64}, Revolute{Float64})"
    ]
   },
   {
@@ -332,8 +301,17 @@
    "outputs": [],
    "source": [
     "# random tree\n",
-    "rand_tree_mechanism(Float64, [QuaternionFloating; [Revolute{Float64} for i = 1 : 10]]...)"
+    "rand_tree_mechanism(Float64, [QuaternionFloating{Float64}; [Revolute{Float64} for i = 1 : 10]]...)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/examples/Trees.ipynb
+++ b/examples/Trees.ipynb
@@ -8,10 +8,7 @@
    },
    "outputs": [],
    "source": [
-    "push!(LOAD_PATH, \"../src\")\n",
-    "using Quaternions\n",
-    "using RigidBodyDynamics\n",
-    "import RigidBodyDynamics: Tree, insert!, toposort, leaves, ancestors, path"
+    "using RigidBodyDynamics.TreeDataStructure"
    ]
   },
   {
@@ -99,7 +96,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 0.5.0-rc0",
+   "display_name": "Julia 0.5.0",
    "language": "julia",
    "name": "julia-0.5"
   },

--- a/examples/URDF.ipynb
+++ b/examples/URDF.ipynb
@@ -8,7 +8,6 @@
    },
    "outputs": [],
    "source": [
-    "push!(LOAD_PATH, \"../src\")\n",
     "using RigidBodyDynamics"
    ]
   },

--- a/perf/runbenchmarks.jl
+++ b/perf/runbenchmarks.jl
@@ -1,5 +1,6 @@
 using RigidBodyDynamics
 using BenchmarkTools
+import RigidBodyDynamics.TreeDataStructure: children, edge_to_parent_data
 
 function get_atlas_urdf()
     atlas_urdf_filename = "atlas.urdf"

--- a/perf/runbenchmarks.jl
+++ b/perf/runbenchmarks.jl
@@ -19,7 +19,7 @@ end
 function create_floating_atlas()
     atlas = parse_urdf(Float64, get_atlas_urdf())
     for child in children(root_vertex(atlas))
-        joint = child.edgeToParentData
+        joint = edge_to_parent_data(child)
         change_joint_type!(atlas, joint, QuaternionFloating{Float64}())
     end
     atlas

--- a/perf/runbenchmarks.jl
+++ b/perf/runbenchmarks.jl
@@ -18,7 +18,7 @@ end
 
 function create_floating_atlas()
     atlas = parse_urdf(Float64, get_atlas_urdf())
-    for child in root_vertex(atlas).children
+    for child in children(root_vertex(atlas))
         joint = child.edgeToParentData
         change_joint_type!(atlas, joint, QuaternionFloating{Float64}())
     end

--- a/src/RigidBodyDynamics.jl
+++ b/src/RigidBodyDynamics.jl
@@ -2,7 +2,7 @@
 
 module RigidBodyDynamics
 
-import Base: convert, zero, one, *, +, /, -, call, inv, get, findfirst, Random.rand, Random.rand!, hcat, show, showcompact, isapprox, dot, cross, unsafe_copy!, Array, eltype
+import Base: convert, zero, one, *, +, /, -, call, inv, get, findfirst, Random.rand, Random.rand!, hcat, show, showcompact, isapprox, dot, cross, unsafe_copy!, Array, eltype, parent
 using StaticArrays
 using Quaternions
 using DataStructures

--- a/src/RigidBodyDynamics.jl
+++ b/src/RigidBodyDynamics.jl
@@ -2,30 +2,26 @@
 
 module RigidBodyDynamics
 
-import Base: convert, zero, one, *, +, /, -, call, inv, get, findfirst, Random.rand, Random.rand!, hcat, show, showcompact, isapprox, dot, cross, unsafe_copy!, Array, eltype, parent
+include("tree.jl")
+
+import Base: convert, zero, one, *, +, /, -, call, inv, get, findfirst, Random.rand, Random.rand!, hcat, show, showcompact, isapprox, dot, cross, unsafe_copy!, Array, eltype
 using StaticArrays
 using Quaternions
 using DataStructures
 using LightXML
 import ODE: ode45
 
-# Julia version compatibility
-using Compat
-import Compat.String
-
-if !isdefined(Base, :view)
-    const view = slice
-end
-
 include("util.jl")
 include("third_party_addendum.jl")
+
 include("frames.jl")
 include("spatial.jl")
 include("rigid_body.jl")
 include("joint.jl")
-include("tree.jl")
-include("mechanism.jl")
 include("cache_element.jl")
+
+importall .TreeDataStructure
+include("mechanism.jl")
 include("transform_cache.jl")
 include("mechanism_state.jl")
 include("mechanism_algorithms.jl")
@@ -127,4 +123,5 @@ export
     dynamics!,
     parse_urdf,
     simulate
-end
+
+end # module

--- a/src/mechanism_state.jl
+++ b/src/mechanism_state.jl
@@ -167,10 +167,10 @@ function MechanismState{X, M}(::Type{X}, m::Mechanism{M})
     zero!(state)
 
     for vertex in m.toposortedTree
-        body = vertex.vertexData
+        body = vertex_data(vertex)
         if !isroot(vertex)
             parentVertex = vertex.parent
-            parentBody = parentVertex.vertexData
+            parentBody = vertex_data(parentVertex)
             joint = vertex.edgeToParentData
             parentFrame = default_frame(m, parentBody)
 
@@ -198,7 +198,7 @@ function MechanismState{X, M}(::Type{X}, m::Mechanism{M})
         if !isroot(vertex)
             # spatial inertias needs to be done after adding additional body fixed frames
             # because they may be expressed in one of those frames
-            parentBody = vertex.parent.vertexData
+            parentBody = vertex_data(vertex.parent)
 
             # inertias
             transformBodyToRootCache = state.transformCache.transformsToRoot[spatial_inertia(body).frame]
@@ -210,8 +210,8 @@ function MechanismState{X, M}(::Type{X}, m::Mechanism{M})
     # crb inertias
     for i = length(m.toposortedTree) : -1 : 2
         vertex = m.toposortedTree[i]
-        body = vertex.vertexData
-        children = [state.crbInertias[v.vertexData] for v in vertex.children]
+        body = vertex_data(vertex)
+        children = [state.crbInertias[vertex_data(v)] for v in children(vertex)]
         state.crbInertias[body] = CacheElement(SpatialInertia{C}, UpdateCompositeRigidBodyInertia(state.spatialInertias[body], children))
     end
 

--- a/src/mechanism_state.jl
+++ b/src/mechanism_state.jl
@@ -169,9 +169,9 @@ function MechanismState{X, M}(::Type{X}, m::Mechanism{M})
     for vertex in m.toposortedTree
         body = vertex_data(vertex)
         if !isroot(vertex)
-            parentVertex = vertex.parent
+            parentVertex = parent(vertex)
             parentBody = vertex_data(parentVertex)
-            joint = vertex.edgeToParentData
+            joint = edge_to_parent_data(vertex)
             parentFrame = default_frame(m, parentBody)
 
             qJoint = view(state.q, state.mechanism.qRanges[joint])
@@ -198,7 +198,7 @@ function MechanismState{X, M}(::Type{X}, m::Mechanism{M})
         if !isroot(vertex)
             # spatial inertias needs to be done after adding additional body fixed frames
             # because they may be expressed in one of those frames
-            parentBody = vertex_data(vertex.parent)
+            parentBody = vertex_data(parent(vertex))
 
             # inertias
             transformBodyToRootCache = state.transformCache.transformsToRoot[spatial_inertia(body).frame]
@@ -211,8 +211,8 @@ function MechanismState{X, M}(::Type{X}, m::Mechanism{M})
     for i = length(m.toposortedTree) : -1 : 2
         vertex = m.toposortedTree[i]
         body = vertex_data(vertex)
-        children = [state.crbInertias[vertex_data(v)] for v in children(vertex)]
-        state.crbInertias[body] = CacheElement(SpatialInertia{C}, UpdateCompositeRigidBodyInertia(state.spatialInertias[body], children))
+        childCrbs = [state.crbInertias[vertex_data(v)] for v in children(vertex)]
+        state.crbInertias[body] = CacheElement(SpatialInertia{C}, UpdateCompositeRigidBodyInertia(state.spatialInertias[body], childCrbs))
     end
 
     setdirty!(state)

--- a/src/mechanism_state.jl
+++ b/src/mechanism_state.jl
@@ -11,7 +11,7 @@ immutable UpdateTwistAndBias{M, C}
         new(parentFrame, joint, qJoint, vJoint, transformToRootCache, parentCache)
     end
 end
-@compat function (functor::UpdateTwistAndBias)()
+function (functor::UpdateTwistAndBias)()
     parentFrame = functor.parentFrame
     joint = functor.joint
     qJoint = functor.qJoint
@@ -38,7 +38,7 @@ immutable UpdateSpatialInertiaInWorld{M, C}
     body::RigidBody{M}
     transformToRootCache::CacheElement{Transform3D{C}, UpdateTransformToRoot{C}}
 end
-@compat function (functor::UpdateSpatialInertiaInWorld)()
+function (functor::UpdateSpatialInertiaInWorld)()
     transform(spatial_inertia(functor.body), get(functor.transformToRootCache))
 end
 
@@ -46,7 +46,7 @@ immutable UpdateCompositeRigidBodyInertia{M, C}
     this::CacheElement{SpatialInertia{C}, UpdateSpatialInertiaInWorld{M, C}}
     children::Vector{CacheElement{SpatialInertia{C}, UpdateCompositeRigidBodyInertia{M, C}}}
 end
-@compat function (functor::UpdateCompositeRigidBodyInertia)()
+function (functor::UpdateCompositeRigidBodyInertia)()
     ret = get(functor.this)
     for child in functor.children
         ret += get(child)

--- a/src/parse_urdf.jl
+++ b/src/parse_urdf.jl
@@ -76,7 +76,7 @@ function parse_vertex{T}(mechanism::Mechanism{T}, vertex::TreeVertex{XMLElement,
         joint = Joint("$(name(body))_to_world", Fixed{T}())
         jointToParent = Transform3D{T}(joint.frameBefore, parent.frame)
     else
-        xmlJoint = vertex.edgeToParentData
+        xmlJoint = edge_to_parent_data(vertex)
         parentName = attribute(find_element(xmlJoint, "parent"), "link")
         parent = vertex_data(findfirst(v -> RigidBodyDynamics.name(vertex_data(v)) == parentName, tree(mechanism)))
         joint = parse_joint(T, xmlJoint)
@@ -101,8 +101,7 @@ function parse_urdf{T}(::Type{T}, filename)
     for xmlJoint in xmlJoints
         parent = nameToVertex[attribute(find_element(xmlJoint, "parent"), "link")]
         child = nameToVertex[attribute(find_element(xmlJoint, "child"), "link")]
-        child.edgeToParentData = xmlJoint
-        insert!(parent, child)
+        insert!(parent, child, xmlJoint)
     end
     roots = filter(isroot, vertices)
     length(roots) != 1 && error("Can only handle a single root")

--- a/src/transform_cache.jl
+++ b/src/transform_cache.jl
@@ -56,7 +56,7 @@ function TransformCache{M, Q}(m::Mechanism{M}, q::Vector{Q})
     for vertex in m.toposortedTree
         body = vertex_data(vertex)
         if !isroot(vertex)
-            joint = vertex.edgeToParentData
+            joint = edge_to_parent_data(vertex)
             add_frame!(cache, m.jointToJointTransforms[joint])
             qJoint = view(q, m.qRanges[joint])
             add_frame!(cache, () -> joint_transform(joint, qJoint))

--- a/src/transform_cache.jl
+++ b/src/transform_cache.jl
@@ -6,7 +6,7 @@ immutable UpdateTransformToRoot{C}
         new(parentToRootCache, toParentCache)
     end
 end
-@compat function (functor::UpdateTransformToRoot)()
+function (functor::UpdateTransformToRoot)()
     get(functor.parentToRootCache) * get(functor.toParentCache)
 end
 

--- a/src/transform_cache.jl
+++ b/src/transform_cache.jl
@@ -54,7 +54,7 @@ function TransformCache{M, Q}(m::Mechanism{M}, q::Vector{Q})
     cache = TransformCache{C}()
 
     for vertex in m.toposortedTree
-        body = vertex.vertexData
+        body = vertex_data(vertex)
         if !isroot(vertex)
             joint = vertex.edgeToParentData
             add_frame!(cache, m.jointToJointTransforms[joint])

--- a/src/tree.jl
+++ b/src/tree.jl
@@ -109,12 +109,20 @@ function toposort{V, E}(tree::Tree{V, E}, result = Vector{TreeVertex{V, E}}())
     return result
 end
 
+function detach!{V, E}(vertex::TreeVertex{V, E})
+    if !isroot(vertex)
+        index = findfirst(parent(vertex).children, vertex)
+        if index > 0
+            deleteat!(parent(vertex).children, index)
+        end
+    end
+    vertex.parentAndEdgeData = Nullable{Pair{TreeVertex{V, E}, E}}()
+    vertex
+end
+
 function insert!{V, E}(parentVertex::TreeVertex{V, E}, childVertex::TreeVertex{V, E}, edgeData::E = edge_to_parent_data(childVertex))
     # Note: removes any previously existing parent/child relationship for childVertex
-    if !isroot(childVertex)
-        parentsChildren = children(parent(vertex))
-        deleteat!(parentsChildren, findfirst(parentsChildren, vertex))
-    end
+    detach!(childVertex)
     childVertex.parentAndEdgeData = parentVertex => edgeData
     push!(children(parentVertex), childVertex)
     childVertex
@@ -130,17 +138,6 @@ function insert!{V, E}(tree::Tree{V, E}, vertexData::V, edgeData::E, parentData:
     parentVertex = findfirst(tree, parentData)
     parentVertex == nothing && error("parent not found")
     insert!(parentVertex, vertexData, edgeData)
-end
-
-function detach!{V, E}(vertex::TreeVertex{V, E})
-    if !isroot(vertex)
-        index = findfirst(parent(vertex).children, vertex)
-        if index > 0
-            deleteat!(parent(vertex).children, index)
-        end
-    end
-    vertex.parentAndEdgeData = Nullable{Pair{TreeVertex{V, E}, E}}()
-    vertex
 end
 
 function ancestors{V, E}(vertex::TreeVertex{V, E})

--- a/src/tree.jl
+++ b/src/tree.jl
@@ -1,3 +1,29 @@
+module TreeDataStructure
+
+import Base: showcompact, show, parent, findfirst, map!, insert!
+
+export
+    # types
+    Tree,
+    TreeVertex,
+    Path,
+
+    # functions
+    isroot,
+    isleaf,
+    toposort,
+    detach!,
+    ancestors,
+    leaves,
+    path,
+    insert_subtree!,
+    subtree,
+    reroot,
+    merge_into_parent!,
+    vertex_data,
+    children,
+    edge_to_parent_data
+
 type TreeVertex{V, E}
     vertexData::V
     children::Vector{TreeVertex{V, E}}
@@ -247,3 +273,5 @@ function path{V, E}(from::TreeVertex{V, E}, to::TreeVertex{V, E})
     end
     return Path(vertexData, edgeData, directions)
 end
+
+end # module TreeDataStructure

--- a/src/tree.jl
+++ b/src/tree.jl
@@ -231,7 +231,7 @@ end
 
 function show(io::IO, p::Path)
     println(io, "Path:")
-    println(io, "Vertices: $(vertex_data(p))")
+    println(io, "Vertices: $(p.vertexData)")
     println(io, "Edges: $(p.edgeData)")
     print(io, "Directions: $(p.directions)")
 end

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,2 @@
-#IJulia
+IJulia
 ForwardDiff 0.2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,8 +6,6 @@ using StaticArrays
 using Compat
 import ForwardDiff
 
-import RigidBodyDynamics: Tree, insert!, toposort, leaves, ancestors, path, subtree, reroot, vertex_data, edge_to_parent_data, children
-
 include("test_tree.jl")
 include("test_frames.jl")
 include("test_spatial.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,10 +13,11 @@ include("test_double_pendulum.jl")
 include("test_mechanism_algorithms.jl")
 include("test_mechanism_manipulation.jl")
 
-# using IJulia
-# run notebooks
-# jupyter = IJulia.jupyter
-# for f in filter(x -> endswith(x, "ipynb"), readdir("../examples"))
-#     notebook = "../examples/" * f
-#     run(`$jupyter nbconvert --to notebook --execute $notebook --output $notebook`)
-# end
+@testset "example notebooks" begin
+    using IJulia
+    jupyter = IJulia.jupyter
+    for f in filter(x -> endswith(x, "ipynb"), readdir("../examples"))
+        notebook = "../examples/" * f
+        run(`$jupyter nbconvert --to notebook --execute $notebook --output $notebook`)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,11 +13,13 @@ include("test_double_pendulum.jl")
 include("test_mechanism_algorithms.jl")
 include("test_mechanism_manipulation.jl")
 
-@testset "example notebooks" begin
-    using IJulia
-    jupyter = IJulia.jupyter
-    for f in filter(x -> endswith(x, "ipynb"), readdir("../examples"))
-        notebook = "../examples/" * f
-        run(`$jupyter nbconvert --to notebook --execute $notebook --output $notebook`)
+if VERSION < v"0.6-dev"
+    @testset "example notebooks" begin
+        using IJulia
+        jupyter = IJulia.jupyter
+        for f in filter(x -> endswith(x, "ipynb"), readdir("../examples"))
+            notebook = "../examples/" * f
+            run(`$jupyter nbconvert --to notebook --execute $notebook --output $notebook`)
+        end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,8 @@ using StaticArrays
 using Compat
 import ForwardDiff
 
+import RigidBodyDynamics: Tree, insert!, toposort, leaves, ancestors, path, subtree, reroot, vertex_data, edge_to_parent_data, children
+
 include("test_tree.jl")
 include("test_frames.jl")
 include("test_spatial.jl")

--- a/test/test_mechanism_algorithms.jl
+++ b/test/test_mechanism_algorithms.jl
@@ -4,8 +4,8 @@
     rand!(x)
 
     @testset "basic stuff" begin
-        q = vcat([configuration(x, vertex.edgeToParentData) for vertex in non_root_vertices(mechanism)]...)
-        v = vcat([velocity(x, vertex.edgeToParentData) for vertex in non_root_vertices(mechanism)]...)
+        q = vcat([configuration(x, edge_to_parent_data(vertex)) for vertex in non_root_vertices(mechanism)]...)
+        v = vcat([velocity(x, edge_to_parent_data(vertex)) for vertex in non_root_vertices(mechanism)]...)
 
         @test q == configuration_vector(x)
         @test v == velocity_vector(x)
@@ -103,8 +103,8 @@
     @testset "motion subspace / twist wrt world" begin
         for vertex in non_root_vertices(mechanism)
             body = vertex_data(vertex)
-            joint = vertex.edgeToParentData
-            parentBody = vertex_data(vertex.parent)
+            joint = edge_to_parent_data(vertex)
+            parentBody = vertex_data(parent(vertex))
             @test isapprox(relative_twist(x, body, parentBody), Twist(motion_subspace(x, joint), velocity(x, joint)); atol = 1e-12)
         end
     end
@@ -123,7 +123,7 @@
         Amat = Array(A)
         for vertex in non_root_vertices(mechanism)
             body = vertex_data(vertex)
-            joint = vertex.edgeToParentData
+            joint = edge_to_parent_data(vertex)
             Ajoint = Amat[:, mechanism.vRanges[joint]]
             @test isapprox(Array(crb_inertia(x, body) * motion_subspace(x, joint)), Ajoint; atol = 1e-12)
         end
@@ -233,8 +233,8 @@
         externalWrenches = Dict(body => rand(Wrench{Float64}, root_frame(mechanism)) for body in non_root_bodies(mechanism))
         τ = inverse_dynamics(x, v̇, externalWrenches)
         floatingBodyVertex = children(root_vertex(mechanism))[1]
-        floatingJoint = floatingBodyVertex.edgeToParentData
-        floatingJointWrench = Wrench(floatingBodyVertex.edgeToParentData.frameAfter, τ[mechanism.vRanges[floatingJoint]])
+        floatingJoint = edge_to_parent_data(floatingBodyVertex)
+        floatingJointWrench = Wrench(edge_to_parent_data(floatingBodyVertex).frameAfter, τ[mechanism.vRanges[floatingJoint]])
         floatingJointWrench = transform(x, floatingJointWrench, root_frame(mechanism))
 
         create_autodiff = (z, dz) -> [ForwardDiff.Dual(z[i]::Float64, dz[i]::Float64) for i in 1 : length(z)]

--- a/test/test_mechanism_algorithms.jl
+++ b/test/test_mechanism_algorithms.jl
@@ -102,19 +102,19 @@
 
     @testset "motion subspace / twist wrt world" begin
         for vertex in non_root_vertices(mechanism)
-            body = vertex.vertexData
+            body = vertex_data(vertex)
             joint = vertex.edgeToParentData
-            parentBody = vertex.parent.vertexData
+            parentBody = vertex_data(vertex.parent)
             @test isapprox(relative_twist(x, body, parentBody), Twist(motion_subspace(x, joint), velocity(x, joint)); atol = 1e-12)
         end
     end
 
     @testset "composite rigid body inertias" begin
         for vertex in non_root_vertices(mechanism)
-            body = vertex.vertexData
+            body = vertex_data(vertex)
             crb = crb_inertia(x, body)
             subtree = toposort(vertex)
-            @test isapprox(sum((b::RigidBody) -> spatial_inertia(x, b), [v.vertexData for v in subtree]), crb; atol = 1e-12)
+            @test isapprox(sum((b::RigidBody) -> spatial_inertia(x, b), [vertex_data(v) for v in subtree]), crb; atol = 1e-12)
         end
     end
 
@@ -122,7 +122,7 @@
         A = momentum_matrix(x)
         Amat = Array(A)
         for vertex in non_root_vertices(mechanism)
-            body = vertex.vertexData
+            body = vertex_data(vertex)
             joint = vertex.edgeToParentData
             Ajoint = Amat[:, mechanism.vRanges[joint]]
             @test isapprox(Array(crb_inertia(x, body) * motion_subspace(x, joint)), Ajoint; atol = 1e-12)
@@ -232,7 +232,7 @@
         v̇ = rand(num_velocities(mechanism))
         externalWrenches = Dict(body => rand(Wrench{Float64}, root_frame(mechanism)) for body in non_root_bodies(mechanism))
         τ = inverse_dynamics(x, v̇, externalWrenches)
-        floatingBodyVertex = root_vertex(mechanism).children[1]
+        floatingBodyVertex = children(root_vertex(mechanism))[1]
         floatingJoint = floatingBodyVertex.edgeToParentData
         floatingJointWrench = Wrench(floatingBodyVertex.edgeToParentData.frameAfter, τ[mechanism.vRanges[floatingJoint]])
         floatingJointWrench = transform(x, floatingJointWrench, root_frame(mechanism))

--- a/test/test_mechanism_algorithms.jl
+++ b/test/test_mechanism_algorithms.jl
@@ -1,4 +1,6 @@
 @testset "mechanism algorithms" begin
+    import RigidBodyDynamics.TreeDataStructure: edge_to_parent_data, vertex_data, children
+
     mechanism = rand_tree_mechanism(Float64, [QuaternionFloating{Float64}; [Revolute{Float64} for i = 1 : 10]; [Fixed{Float64} for i = 1 : 5]; [Prismatic{Float64} for i = 1 : 10]]...)
     x = MechanismState(Float64, mechanism)
     rand!(x)

--- a/test/test_mechanism_manipulation.jl
+++ b/test/test_mechanism_manipulation.jl
@@ -64,7 +64,7 @@
         rand!(state)
         q = configuration_vector(state)
         M = mass_matrix(state)
-        nonFixedJointVertices = filter(v -> !isa(v.edgeToParentData.jointType, Fixed), non_root_vertices(mechanism))
+        nonFixedJointVertices = filter(v -> !isa(edge_to_parent_data(v).jointType, Fixed), non_root_vertices(mechanism))
 
         remove_fixed_joints!(mechanism)
         @test non_root_vertices(mechanism) == nonFixedJointVertices
@@ -95,7 +95,7 @@
             end
             Msub = mass_matrix(substate)
             if !isleaf(root_vertex(mechanismPart))
-                firstJoint = children(root_vertex(mechanismPart))[1].edgeToParentData
+                firstJoint = edge_to_parent_data(children(root_vertex(mechanismPart))[1])
                 offset = first(mechanism.vRanges[firstJoint]) - 1
 
                 vRange = (1 : num_velocities(mechanismPart)) + offset

--- a/test/test_mechanism_manipulation.jl
+++ b/test/test_mechanism_manipulation.jl
@@ -95,8 +95,7 @@
             end
             Msub = mass_matrix(substate)
             if !isleaf(root_vertex(mechanismPart))
-
-                firstJoint = root_vertex(mechanismPart).children[1].edgeToParentData
+                firstJoint = children(root_vertex(mechanismPart))[1].edgeToParentData
                 offset = first(mechanism.vRanges[firstJoint]) - 1
 
                 vRange = (1 : num_velocities(mechanismPart)) + offset

--- a/test/test_tree.jl
+++ b/test/test_tree.jl
@@ -1,5 +1,3 @@
-import RigidBodyDynamics: Tree, insert!, toposort, leaves, ancestors, path, subtree, reroot
-
 @testset "tree" begin
     let
         tree = v1 = Tree{Int64, Int32}(1);
@@ -17,7 +15,7 @@ import RigidBodyDynamics: Tree, insert!, toposort, leaves, ancestors, path, subt
                 if isroot(vertex)
                     @test index == 1
                 else
-                    @test index > findfirst(toposortedTree, vertex.parent)
+                    @test index > findfirst(toposortedTree, parent(vertex))
                 end
             end
         end
@@ -49,7 +47,7 @@ import RigidBodyDynamics: Tree, insert!, toposort, leaves, ancestors, path, subt
             for oldNonAncestor in oldNonAncestors
                 newTreeVertex = findfirst(rerooted, vertex_data(oldNonAncestor))
                 if !isroot(newTreeVertex)
-                    @test newTreeVertex.edgeToParentData > 0
+                    @test edge_to_parent_data(newTreeVertex) > 0
                 end
             end
         end

--- a/test/test_tree.jl
+++ b/test/test_tree.jl
@@ -32,7 +32,7 @@ import RigidBodyDynamics: Tree, insert!, toposort, leaves, ancestors, path, subt
         @testset "reroot" begin
             oldRoot = tree
             newRoot = rerooted = reroot(v7, -)
-            @test rerooted.vertexData == v7.vertexData
+            @test vertex_data(rerooted) == vertex_data(v7)
             @test length(toposort(rerooted)) == length(toposort(tree))
             for vertex in toposort(rerooted)
                 @test all(path(newRoot, vertex).directions .== 1)
@@ -41,13 +41,13 @@ import RigidBodyDynamics: Tree, insert!, toposort, leaves, ancestors, path, subt
             # ensure that edgeDirectionChangeFunction was applied correctly
             oldAncestors = ancestors(v7)
             for oldTreeVertex in oldAncestors
-                newTreeVertex = findfirst(rerooted, oldTreeVertex.vertexData)
+                newTreeVertex = findfirst(rerooted, vertex_data(oldTreeVertex))
                 @test all(path(newRoot, newTreeVertex).edgeData .< 0)
             end
 
             oldNonAncestors = setdiff(toposort(tree), oldAncestors)
             for oldNonAncestor in oldNonAncestors
-                newTreeVertex = findfirst(rerooted, oldNonAncestor.vertexData)
+                newTreeVertex = findfirst(rerooted, vertex_data(oldNonAncestor))
                 if !isroot(newTreeVertex)
                     @test newTreeVertex.edgeToParentData > 0
                 end

--- a/test/test_tree.jl
+++ b/test/test_tree.jl
@@ -1,4 +1,6 @@
 @testset "tree" begin
+    using RigidBodyDynamics.TreeDataStructure
+
     let
         tree = v1 = Tree{Int64, Int32}(1);
         v2 = insert!(tree, 2, Int32(2), 1)


### PR DESCRIPTION
* Make parent and edge to parent data a Nullable pair instead of two separate (possibly undefined) fields. Makes it possible to remove the parent, and ensures that there are no weird situations where the data associated with the edge to parent is defined but the parent is not, and vice versa.
* Create separate nested TreeDataStructure module.
* Fix example notebooks, test them again