### PR TITLE
Add reattach!, copy(::Mechanism), fixed frame utilities that simplify mechanism manipulations

### DIFF
--- a/src/RigidBodyDynamics.jl
+++ b/src/RigidBodyDynamics.jl
@@ -94,6 +94,7 @@ export
     rand_mechanism,
     rand_chain_mechanism,
     rand_tree_mechanism,
+    rand_floating_tree_mechanism,
     configuration_vector,
     velocity_vector,
     state_vector,

--- a/src/RigidBodyDynamics.jl
+++ b/src/RigidBodyDynamics.jl
@@ -86,7 +86,7 @@ export
     setdirty!,
     add_body_fixed_frame!,
     attach!,
-    reroot_subtree!,
+    reattach!,
     submechanism,
     change_joint_type!,
     remove_fixed_joints!,

--- a/src/RigidBodyDynamics.jl
+++ b/src/RigidBodyDynamics.jl
@@ -4,7 +4,8 @@ module RigidBodyDynamics
 
 include("tree.jl")
 
-import Base: convert, zero, one, *, +, /, -, call, inv, get, findfirst, Random.rand, Random.rand!, hcat, show, showcompact, isapprox, dot, cross, unsafe_copy!, Array, eltype
+import Base: convert, zero, one, *, +, /, -, call, inv, get, findfirst, Random.rand, Random.rand!
+import Base: hcat, show, showcompact, isapprox, dot, cross, unsafe_copy!, Array, eltype, copy
 using StaticArrays
 using Quaternions
 using DataStructures

--- a/src/RigidBodyDynamics.jl
+++ b/src/RigidBodyDynamics.jl
@@ -86,6 +86,7 @@ export
     setdirty!,
     add_body_fixed_frame!,
     attach!,
+    reroot_subtree!,
     submechanism,
     change_joint_type!,
     remove_fixed_joints!,

--- a/src/frames.jl
+++ b/src/frames.jl
@@ -20,6 +20,9 @@ immutable CartesianFrame3D
 end
 name(frame::CartesianFrame3D) = frame_names[frame.id]
 show(io::IO, frame::CartesianFrame3D) = print(io, "CartesianFrame3D: \"$(name(frame))\"")
+function rename(frame::CartesianFrame3D, name::String)
+    frame_names[frame.id] = name
+end
 
 # enable/disable frame checks
 if isdefined(Main, :RIGID_BODY_DYNAMICS_RELEASE)

--- a/src/frames.jl
+++ b/src/frames.jl
@@ -54,6 +54,7 @@ for VectorType in (:FreeVector3D, :Point3D)
         rand{T}(::Type{$VectorType}, ::Type{T}, frame::CartesianFrame3D) = $VectorType(frame, rand(SVector{3, T}))
         show(io::IO, p::$VectorType) = print(io, "$($(VectorType).name.name) in \"$(name(p.frame))\": $(p.v)")
         isapprox(x::$VectorType, y::$VectorType; atol::Real = 1e-12) = x.frame == y.frame && isapprox(x.v, y.v; atol = atol)
+        copy(p::$VectorType) = $VectorType(p.frame, copy(p.v))
     end
 end
 

--- a/src/frames.jl
+++ b/src/frames.jl
@@ -20,9 +20,6 @@ immutable CartesianFrame3D
 end
 name(frame::CartesianFrame3D) = frame_names[frame.id]
 show(io::IO, frame::CartesianFrame3D) = print(io, "CartesianFrame3D: \"$(name(frame))\"")
-function rename(frame::CartesianFrame3D, name::String)
-    frame_names[frame.id] = name
-end
 
 # enable/disable frame checks
 if isdefined(Main, :RIGID_BODY_DYNAMICS_RELEASE)

--- a/src/joint.jl
+++ b/src/joint.jl
@@ -1,4 +1,5 @@
 abstract JointType{T<:Real}
+flip_direction{T}(jt::JointType{T}) = deepcopy(jt) # default behavior for flipping the direction of a joint
 
 type Joint{T<:Real}
     name::String
@@ -216,6 +217,8 @@ function rand{T}(::Type{Prismatic{T}})
     Prismatic(axis / norm(axis))
 end
 
+flip_direction(jt::Prismatic) = Prismatic(-jt.translation_axis)
+
 function _joint_transform(j::Joint, jt::Prismatic, q::AbstractVector)
     @inbounds translation = q[1] * jt.translation_axis
     Transform3D(j.frameAfter, j.frameBefore, translation)
@@ -248,6 +251,8 @@ function rand{T}(::Type{Revolute{T}})
     axis = rand(SVector{3, T})
     Revolute(axis / norm(axis))
 end
+
+flip_direction(jt::Revolute) = Revolute(-jt.rotation_axis)
 
 function _joint_transform{T<:Real, X<:Real}(j::Joint{T}, jt::Revolute{T}, q::AbstractVector{X})
     S = promote_type(T, X)

--- a/src/mechanism.jl
+++ b/src/mechanism.jl
@@ -32,6 +32,13 @@ is_fixed_to_body{M}(m::Mechanism{M}, frame::CartesianFrame3D, body::RigidBody{M}
 isinertial(m::Mechanism, frame::CartesianFrame3D) = is_fixed_to_body(m, frame, root_body(m))
 isroot{T}(m::Mechanism{T}, b::RigidBody{T}) = b == root_body(m)
 
+function default_frame{T}(m::Mechanism{T}, vertex::TreeVertex{RigidBody{T}, Joint{T}})
+     # allows standardization on a frame to reduce number of transformations required
+    isroot(vertex) ? vertex_data(vertex).frame : edge_to_parent_data(vertex).frameAfter
+end
+
+default_frame(m::Mechanism, body::RigidBody) = default_frame(m, findfirst(tree(m), body)) # TODO: potentially slow due to findfirst type instability
+
 function find_body_fixed_frame_definition{T}(m::Mechanism{T}, body::RigidBody{T}, frame::CartesianFrame3D)::Transform3D{T}
     for transform in m.bodyFixedFrameDefinitions[body]
         transform.from == frame && return transform
@@ -39,25 +46,56 @@ function find_body_fixed_frame_definition{T}(m::Mechanism{T}, body::RigidBody{T}
     error("$frame not found among body fixed frame definitions for $body")
 end
 
-function add_body_fixed_frame!{T}(m::Mechanism{T}, body::RigidBody{T}, transform::Transform3D{T})
-    fixedFrameDefinitions = m.bodyFixedFrameDefinitions[body]
-    any((t) -> t.from == transform.from, fixedFrameDefinitions) && error("frame $(transform.from) was already defined")
-    vertex = findfirst(tree(m), body)
-    defaultFrame = isroot(vertex) ? body.frame : edge_to_parent_data(vertex).frameAfter
-    if transform.to != defaultFrame
-        found = false
-        for t in fixedFrameDefinitions
-            if t.from == transform.to
-                found = true
-                transform = t * transform
-                break
-            end
-        end
-        !found && error("failed to add frame because transform doesn't connect to any known transforms")
+function find_body_fixed_frame_definition(m::Mechanism, frame::CartesianFrame3D)
+    find_body_fixed_frame_definition(m, m.bodyFixedFrameToBody[frame], frame)
+end
+
+function find_fixed_transform(m::Mechanism, from::CartesianFrame3D, to::CartesianFrame3D)
+    body = m.bodyFixedFrameToBody[from]
+    transform = find_body_fixed_frame_definition(m, body, from)
+    if transform.to != to
+        transform = inv(find_body_fixed_frame_definition(m, body, to)) * transform
     end
-    push!(fixedFrameDefinitions, transform)
+    transform
+end
+
+function add_body_fixed_frame!{T}(m::Mechanism{T}, body::RigidBody{T}, transform::Transform3D{T})
+    definitions = get!(Set{Transform3D{T}}, m.bodyFixedFrameDefinitions, body)
+    any((t) -> t.from == transform.from, definitions) && error("frame $(transform.from) was already defined")
+    if transform.to != default_frame(m, body)
+        transform = find_body_fixed_frame_definition(m, body, transform.to) * transform
+    end
+    push!(definitions, transform)
     m.bodyFixedFrameToBody[transform.from] = body
     return transform
+end
+
+function add_body_fixed_frame!{T}(m::Mechanism{T}, transform::Transform3D{T})
+    body = m.bodyFixedFrameToBody[transform.to]
+    body == nothing && error("unable to determine to what body $(transform.to) is attached")
+    add_body_fixed_frame!(m, body, transform)
+end
+
+function canonicalize_frame_definitions!{T}(m::Mechanism{T}, vertex::TreeVertex{RigidBody{T}, Joint{T}})
+    defaultFrame = default_frame(m, vertex)
+    body = vertex_data(vertex)
+
+    # set transform from joint to parent body's default frame
+    if !isroot(vertex)
+        parentDefaultFrame = default_frame(m, parent(vertex))
+        joint = edge_to_parent_data(vertex)
+        m.jointToJointTransforms[joint] = find_fixed_transform(m, joint.frameBefore, parentDefaultFrame)
+    end
+
+    # ensure that all body-fixed frame definitions map to default frame
+    oldDefinitions = m.bodyFixedFrameDefinitions[body]
+    newDefinitions = Set{Transform3D{T}}()
+    for transform in oldDefinitions
+        transform = transform.to == defaultFrame ? transform : find_fixed_transform(m, transform.to, default_frame(m, vertex)) * transform
+        push!(newDefinitions, transform)
+    end
+    m.bodyFixedFrameDefinitions[body] = newDefinitions
+    nothing
 end
 
 function recompute_ranges!(m::Mechanism)
@@ -71,30 +109,24 @@ function recompute_ranges!(m::Mechanism)
     end
 end
 
-function set_up_frames!{T}(m::Mechanism{T}, vertex::TreeVertex{RigidBody{T}, Joint{T}},
-        jointToParent::Transform3D{T}, bodyToJoint::Transform3D{T})
-    joint = edge_to_parent_data(vertex)
-    body = vertex_data(vertex)
-    parentBody = vertex_data(parent(vertex))
-
-    # add transform from frame before joint to parent body's default frame
-    m.jointToJointTransforms[joint] = add_body_fixed_frame!(m, parentBody, jointToParent)
-
-    # add transform from body to frame after joint to body fixed frame definitions
-    framecheck(bodyToJoint.from, body.frame)
-    framecheck(bodyToJoint.to, joint.frameAfter)
-    m.bodyFixedFrameToBody[joint.frameAfter] = body
-    m.bodyFixedFrameDefinitions[body] = Set([Transform3D(T, joint.frameAfter)])
-    if bodyToJoint.from != bodyToJoint.to
-        push!(m.bodyFixedFrameDefinitions[body], bodyToJoint)
-        m.bodyFixedFrameToBody[bodyToJoint.from] = body
-    end
-end
-
 function attach!{T}(m::Mechanism{T}, parentBody::RigidBody{T}, joint::Joint, jointToParent::Transform3D{T},
         childBody::RigidBody{T}, childToJoint::Transform3D{T} = Transform3D{T}(childBody.frame, joint.frameAfter))
     vertex = insert!(tree(m), childBody, joint, parentBody)
-    set_up_frames!(m, vertex, jointToParent, childToJoint)
+
+    # define where joint is attached on parent body
+    framecheck(jointToParent.from, joint.frameBefore)
+    add_body_fixed_frame!(m, parentBody, jointToParent)
+
+    # add identity transform from frame after joint to itself
+    add_body_fixed_frame!(m, childBody, Transform3D{T}(joint.frameAfter, joint.frameAfter))
+
+    # define where child is attached to joint
+    framecheck(childToJoint.from, childBody.frame)
+    if childToJoint.from != joint.frameAfter # we've already defined it
+        add_body_fixed_frame!(m, childBody, childToJoint)
+    end
+
+    canonicalize_frame_definitions!(m, vertex)
     m.toposortedTree = toposort(tree(m))
     recompute_ranges!(m)
     m
@@ -108,24 +140,22 @@ function attach!{T}(m::Mechanism{T}, parentBody::RigidBody{T}, childMechanism::M
     parentVertex = findfirst(tree(m), parentBody)
     childRootVertex = root_vertex(childMechanism)
     childRootBody = vertex_data(childRootVertex)
-    childRootBodyToParentBody = Transform3D{T}(childRootBody.frame, parentBody.frame) # identity
+
     for child in children(childRootVertex)
         vertex = insert_subtree!(parentVertex, child)
-        body = vertex_data(vertex)
-        joint = edge_to_parent_data(vertex)
-        jointToParent = childRootBodyToParentBody * childMechanism.jointToJointTransforms[joint]
-        bodyToJoint = find_body_fixed_frame_definition(childMechanism, body, body.frame)
-        set_up_frames!(m, vertex, jointToParent, bodyToJoint)
     end
-    m.toposortedTree = toposort(tree(m))
-    recompute_ranges!(m)
+
+    # define where child root body is located w.r.t parent body
+    add_body_fixed_frame!(m, parentBody, Transform3D{T}(childRootBody.frame, parentBody.frame)) # TODO: add optional function argument
 
     # add frames that were attached to childRootBody to parentBody
     for transform in childMechanism.bodyFixedFrameDefinitions[childRootBody]
-        if isempty(filter(t -> t.from == transform.from, m.bodyFixedFrameDefinitions[parentBody]))
-            add_body_fixed_frame!(m, parentBody, childRootBodyToParentBody * transform)
-        end
+        add_body_fixed_frame!(m, parentBody, transform)
     end
+
+    canonicalize_frame_definitions!(m, parentVertex)
+    m.toposortedTree = toposort(tree(m))
+    recompute_ranges!(m)
 
     # merge frame info for vertices whose parents haven't changed
     childRootJoints = Joint[edge_to_parent_data(child) for child in children(childRootVertex)]
@@ -162,6 +192,57 @@ function submechanism{T}(m::Mechanism{T}, submechanismRoot::RigidBody{T})
     end
 
     ret
+end
+
+#=
+Reroots the subtree of the root body to which newSubtreeRootBody belongs so that newSubtreeRootBody is attached to
+the root body with the given joint.
+=#
+function reroot_subtree!{T}(mechanism::Mechanism{T}, newSubtreeRootBody::RigidBody{T}, joint::Joint{T},
+        jointToWorld::Transform3D{T}, newSubTreeRootBodyToJoint::Transform3D{T})
+    # TODO: add option to prune frames related to old joints
+
+    newSubtreeRootBody == root_body(mechanism) && error("new subtree root must be part of a subtree of mechanism root")
+    newSubtreeRoot = findfirst(tree(mechanism), newSubtreeRootBody)
+
+    # modify tree
+    oldSubtreeRoot = newSubtreeRoot
+    while !isroot(parent(oldSubtreeRoot))
+        oldSubtreeRoot = parent(oldSubtreeRoot)
+    end
+    oldRootJoint = edge_to_parent_data(oldSubtreeRoot)
+    delete!(mechanism.jointToJointTransforms, oldRootJoint)
+    detach!(oldSubtreeRoot)
+    flippedJoints = Pair{Joint{T}, Joint{T}}[]
+    flipDirectionFunction = joint -> begin
+        flipped = Joint(joint.name * "Flipped", joint.jointType) # TODO
+        push!(flippedJoints, joint => flipped)
+        flipped
+    end
+    subtreeRerooted = reroot(newSubtreeRoot, flipDirectionFunction)
+    insert!(root_vertex(mechanism), subtreeRerooted, joint)
+
+    # define frames related to new joint
+    # TODO: replace with call to attach!
+    add_body_fixed_frame!(mechanism, root_body(mechanism), jointToWorld)
+#     add_body_fixed_frame!(mechanism, newSubtreeRootBody, Transform3D{T}(joint.frameAfter, joint.frameAfter)) TODO
+    add_body_fixed_frame!(mechanism, newSubtreeRootBody, inv(newSubTreeRootBodyToJoint))
+
+    # define identities between new frames and old frames
+    for pair in flippedJoints
+        oldJoint, newJoint = first(pair), last(pair)
+        add_body_fixed_frame!(mechanism, Transform3D{T}(newJoint.frameBefore, oldJoint.frameAfter))
+        add_body_fixed_frame!(mechanism, Transform3D{T}(newJoint.frameAfter, oldJoint.frameBefore))
+    end
+
+    # canonicalize frame definitions
+    for vertex in toposort(tree(mechanism))
+        canonicalize_frame_definitions!(mechanism, vertex)
+    end
+
+    mechanism.toposortedTree = toposort(tree(mechanism))
+    recompute_ranges!(mechanism)
+    mechanism
 end
 
 function change_joint_type!(m::Mechanism, joint::Joint, newType::JointType)
@@ -223,7 +304,6 @@ end
 joints(m::Mechanism) = [edge_to_parent_data(vertex) for vertex in non_root_vertices(m)] # TODO: make less expensive
 bodies{T}(m::Mechanism{T}) = [vertex_data(vertex)::RigidBody{T} for vertex in m.toposortedTree] # TODO: make less expensive
 non_root_bodies{T}(m::Mechanism{T}) = [vertex_data(vertex)::RigidBody{T} for vertex in non_root_vertices(m)] # TODO: make less expensive
-default_frame(m::Mechanism, body::RigidBody) = first(m.bodyFixedFrameDefinitions[body]).to # allows standardization on a frame to reduce number of transformations required
 
 num_positions(m::Mechanism) = num_positions(joints(m))
 num_velocities(m::Mechanism) = num_velocities(joints(m))

--- a/src/mechanism.jl
+++ b/src/mechanism.jl
@@ -15,11 +15,19 @@ type Mechanism{T<:Real}
         gravitationalAcceleration = FreeVector3D(rootBody.frame, gravity)
         qRanges = Dict{Joint{T}, UnitRange{Int64}}()
         vRanges = Dict{Joint{T}, UnitRange{Int64}}()
-        new(toposort(tree), bodyFixedFrameDefinitions, bodyFixedFrameToBody, jointToJointTransforms, gravitationalAcceleration, qRanges, vRanges)
+        new(toposort(tree), bodyFixedFrameDefinitions, bodyFixedFrameToBody,
+            jointToJointTransforms, gravitationalAcceleration, qRanges, vRanges)
+    end
+
+    function Mechanism(m::Mechanism{T})
+        new(toposort(copy(tree(m))), Dict(k => copy(v) for (k, v) in m.bodyFixedFrameDefinitions), copy(m.bodyFixedFrameToBody),
+            copy(m.jointToJointTransforms), copy(m.gravitationalAcceleration), copy(m.qRanges), copy(m.vRanges))
     end
 end
 
 Mechanism{T}(rootBody::RigidBody{T}; kwargs...) = Mechanism{T}(rootBody; kwargs...)
+Mechanism{T}(m::Mechanism{T}) = Mechanism{T}(m)
+copy(m::Mechanism) = Mechanism(m)
 eltype{T}(::Mechanism{T}) = T
 root_vertex(m::Mechanism) = m.toposortedTree[1]
 non_root_vertices(m::Mechanism) = view(m.toposortedTree, 2 : length(m.toposortedTree))

--- a/src/mechanism.jl
+++ b/src/mechanism.jl
@@ -334,6 +334,13 @@ end
 
 rand_chain_mechanism{T}(t::Type{T}, jointTypes...) = rand_mechanism(t, m::Mechanism -> vertex_data(m.toposortedTree[end]), jointTypes...)
 rand_tree_mechanism{T}(t::Type{T}, jointTypes...) = rand_mechanism(t, m::Mechanism -> rand(collect(bodies(m))), jointTypes...)
+function rand_floating_tree_mechanism{T}(t::Type{T}, nonFloatingJointTypes...)
+    parentSelector = (m::Mechanism) -> begin
+        only_root = length(bodies(m)) == 1
+        only_root ? root_body(m) : rand(collect(non_root_bodies(m)))
+    end
+    rand_mechanism(t, parentSelector, [QuaternionFloating{T}; nonFloatingJointTypes...]...)
+end
 
 function gravitational_spatial_acceleration{M}(m::Mechanism{M})
     frame = m.gravitationalAcceleration.frame

--- a/src/mechanism.jl
+++ b/src/mechanism.jl
@@ -215,7 +215,7 @@ function reattach!{T}(mechanism::Mechanism{T}, oldSubtreeRootBody::RigidBody{T},
     # reroot
     flippedJoints = Pair{Joint{T}, Joint{T}}[]
     flipDirectionFunction = joint -> begin
-        flipped = Joint(joint.name * "Flipped", joint.jointType) # TODO: flip direction of joint (probably?)
+        flipped = Joint(joint.name * "_flipped", flip_direction(joint.jointType))
         push!(flippedJoints, joint => flipped)
         flipped
     end

--- a/src/tree.jl
+++ b/src/tree.jl
@@ -1,6 +1,6 @@
 module TreeDataStructure
 
-import Base: showcompact, show, parent, findfirst, map!, insert!
+import Base: showcompact, show, parent, findfirst, map!, insert!, copy
 
 export
     # types
@@ -138,6 +138,14 @@ function insert!{V, E}(tree::Tree{V, E}, vertexData::V, edgeData::E, parentData:
     parentVertex = findfirst(tree, parentData)
     parentVertex == nothing && error("parent not found")
     insert!(parentVertex, vertexData, edgeData)
+end
+
+function copy{V, E}(v::TreeVertex{V, E})
+    ret = isroot(v) ? TreeVertex{V, E}(vertex_data(v)) : TreeVertex(vertex_data(v), parent(v), edge_to_parent_data(v))
+    for child in children(v)
+        insert!(ret, copy(child))
+    end
+    ret
 end
 
 function ancestors{V, E}(vertex::TreeVertex{V, E})

--- a/src/tree.jl
+++ b/src/tree.jl
@@ -75,7 +75,7 @@ function findfirst{V, E}(pred::Function, tree::Tree{V, E})
         vertex = findfirst(pred, child)
         vertex != nothing && return vertex
     end
-    return nothing
+    return nothing # TODO: turn into error
 end
 
 # TODO: not type stable
@@ -88,7 +88,7 @@ function findfirst{V, E}(tree::Tree{V, E}, vertexData::V)
         vertex = findfirst(child, vertexData)
         vertex != nothing && return vertex
     end
-    return nothing
+    return nothing # TODO: turn into error
 end
 
 function find{V, E}(pred::Function, tree::Tree{V, E}, result = Vector{TreeVertex{V, E}}())

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using Base.Test
 
 using RigidBodyDynamics
+using RigidBodyDynamics.TreeDataStructure
 using Quaternions
 using StaticArrays
 using Compat

--- a/test/test_mechanism_algorithms.jl
+++ b/test/test_mechanism_algorithms.jl
@@ -1,6 +1,4 @@
 @testset "mechanism algorithms" begin
-    import RigidBodyDynamics.TreeDataStructure: edge_to_parent_data, vertex_data, children
-
     mechanism = rand_tree_mechanism(Float64, [QuaternionFloating{Float64}; [Revolute{Float64} for i = 1 : 10]; [Fixed{Float64} for i = 1 : 5]; [Prismatic{Float64} for i = 1 : 10]]...)
     x = MechanismState(Float64, mechanism)
     rand!(x)

--- a/test/test_mechanism_manipulation.jl
+++ b/test/test_mechanism_manipulation.jl
@@ -105,34 +105,67 @@
     end
 
     @testset "reattach" begin
-    for testnum = 1 : 10
-        # create random floating mechanism
-        jointTypes = [[Prismatic{Float64} for i = 1 : 10]; [Revolute{Float64} for i = 1 : 10]; [Fixed{Float64} for i = 1 : 10]]
-        shuffle!(jointTypes)
-        mechanism = rand_floating_tree_mechanism(Float64, jointTypes)
-        subtreeRootVertex = children(root_vertex(mechanism))[1]
-        floatingJoint = edge_to_parent_data(subtreeRootVertex)
-        floatingBody = vertex_data(subtreeRootVertex)
+        for testnum = 1 : 10
+            # create random floating mechanism
+            jointTypes = [[Prismatic{Float64} for i = 1 : 10]; [Revolute{Float64} for i = 1 : 10]; [Fixed{Float64} for i = 1 : 10]]
+            shuffle!(jointTypes)
+            mechanism = rand_floating_tree_mechanism(Float64, jointTypes)
+            subtreeRootVertex = children(root_vertex(mechanism))[1]
+            floatingJoint = edge_to_parent_data(subtreeRootVertex)
+            floatingBody = vertex_data(subtreeRootVertex)
 
+            # reattach at different body
+            newFloatingBody = rand(non_root_bodies(mechanism))
+            newFloatingJoint = Joint("newFloating", QuaternionFloating{Float64}())
+            world = root_body(mechanism)
+            jointToWorld = Transform3D{Float64}(newFloatingJoint.frameBefore, world.frame)
+            bodyToJoint = Transform3D{Float64}(newFloatingBody.frame, newFloatingJoint.frameAfter)
+            rerooted = copy(mechanism)
+            flippedJointMapping = reattach!(rerooted, floatingBody, world, newFloatingJoint, jointToWorld, newFloatingBody, bodyToJoint)
 
-        # reattach at different body
-        newFloatingBody = rand(non_root_bodies(mechanism))
-        newFloatingJoint = Joint("newFloating", QuaternionFloating{Float64}())
-        world = root_body(mechanism)
-        jointToWorld = Transform3D{Float64}(newFloatingJoint.frameBefore, world.frame)
-        rerooted = reattach!(copy(mechanism), floatingBody, world, newFloatingJoint, jointToWorld, newFloatingBody)
+            # create random mechanism state
+            x = MechanismState(Float64, mechanism)
+            rand!(x)
 
-        # put mechanisms in the same state
-        x = MechanismState(Float64, mechanism)
-        rand!(x)
-        xRerooted = MechanismState(Float64, rerooted)
-        for joint in filter(j -> j != floatingJoint, joints(mechanism))
-            set_configuration!(xRerooted, joint, configuration(x, joint))
-        end
+            # mimic the same state for the rerooted mechanism
+            # copy non-floating joint configurations and velocities
+            xRerooted = MechanismState(Float64, rerooted)
+            for joint in filter(j -> j != floatingJoint, joints(mechanism))
+                jointRerooted = get(flippedJointMapping, joint, joint)
+                set_configuration!(xRerooted, jointRerooted, configuration(x, joint))
+                set_velocity!(xRerooted, jointRerooted, velocity(x, joint))
+            end
 
-        # make sure that joint accelerations for non-floating joints are the same
-        # result = DynamicsResult(Float64, mechanism)
-        # dynamics!(result, x)
-    end
+            # set configuration and velocity of new floating joint
+            newFloatingJointTransform = newFloatingJointTransform = inv(jointToWorld) * relative_transform(x, bodyToJoint.from, jointToWorld.to) * inv(bodyToJoint)
+            quat = newFloatingJointTransform.rot
+            trans = newFloatingJointTransform.trans
+            set_configuration!(xRerooted, newFloatingJoint, [quat.s; quat.v1; quat.v2; quat.v3; trans])# TODO: add Joint function that does mapping
 
-end
+            newFloatingJointTwist = transform(x, relative_twist(x, newFloatingBody, world), bodyToJoint.from)
+            newFloatingJointTwist = transform(newFloatingJointTwist, bodyToJoint)
+            set_velocity!(xRerooted, newFloatingJoint, [newFloatingJointTwist.angular; newFloatingJointTwist.linear]) # TODO: add Joint function that does mapping
+
+            # make sure that joint accelerations for non-floating joints are the same
+            result = DynamicsResult(Float64, mechanism)
+            dynamics!(result, x)
+
+            resultRerooted = DynamicsResult(Float64, rerooted)
+            dynamics!(resultRerooted, xRerooted)
+
+            for joint in filter(j -> j != floatingJoint, joints(mechanism))
+                jointRerooted = get(flippedJointMapping, joint, joint)
+                v̇Mechanism = view(result.v̇, mechanism.vRanges[joint])
+                v̇Rerooted = view(resultRerooted.v̇, rerooted.vRanges[jointRerooted])
+                @test isapprox(v̇Mechanism, v̇Rerooted)
+            end
+
+            for body in non_root_bodies(mechanism)
+                accel = relative_acceleration(x, body, world, result.v̇)
+                accel_rerooted = relative_acceleration(xRerooted, body, world, resultRerooted.v̇)
+                @test isapprox(accel.angular, accel_rerooted.angular)
+                @test isapprox(accel.linear, accel_rerooted.linear)
+            end
+        end # for
+    end # reattach
+end # mechanism manipulation

--- a/test/test_mechanism_manipulation.jl
+++ b/test/test_mechanism_manipulation.jl
@@ -103,4 +103,36 @@
             end
         end
     end
+
+    @testset "reattach" begin
+    for testnum = 1 : 10
+        # create random floating mechanism
+        jointTypes = [[Prismatic{Float64} for i = 1 : 10]; [Revolute{Float64} for i = 1 : 10]; [Fixed{Float64} for i = 1 : 10]]
+        shuffle!(jointTypes)
+        mechanism = rand_floating_tree_mechanism(Float64, jointTypes)
+        subtreeRootVertex = children(root_vertex(mechanism))[1]
+        floatingJoint = edge_to_parent_data(subtreeRootVertex)
+        floatingBody = vertex_data(subtreeRootVertex)
+
+
+        # reattach at different body
+        newFloatingBody = rand(non_root_bodies(mechanism))
+        newFloatingJoint = Joint("newFloating", QuaternionFloating{Float64}())
+        world = root_body(mechanism)
+        jointToWorld = Transform3D{Float64}(newFloatingJoint.frameBefore, world.frame)
+        rerooted = reattach!(copy(mechanism), floatingBody, world, newFloatingJoint, jointToWorld, newFloatingBody)
+
+        # put mechanisms in the same state
+        x = MechanismState(Float64, mechanism)
+        rand!(x)
+        xRerooted = MechanismState(Float64, rerooted)
+        for joint in filter(j -> j != floatingJoint, joints(mechanism))
+            set_configuration!(xRerooted, joint, configuration(x, joint))
+        end
+
+        # make sure that joint accelerations for non-floating joints are the same
+        # result = DynamicsResult(Float64, mechanism)
+        # dynamics!(result, x)
+    end
+
 end

--- a/test/test_tree.jl
+++ b/test/test_tree.jl
@@ -1,6 +1,4 @@
 @testset "tree" begin
-    using RigidBodyDynamics.TreeDataStructure
-
     let
         tree = v1 = Tree{Int64, Int32}(1);
         v2 = insert!(tree, 2, Int32(2), 1)


### PR DESCRIPTION
`reattach!` is quite a flexible function that can be used to detach any subtree from a mechanism and subsequently reattach it to a parent body that's not part of the subtree by adding a joint between the parent body and a specified body that is part of the subtree.

As an example, it can be used to transform a URDF-loaded Atlas:
```
Vertex: world (root)
  Vertex: pelvis, Edge: pelvis_to_world
    Vertex: ltorso, Edge: back_bkz
      Vertex: mtorso, Edge: back_bky
        Vertex: utorso, Edge: back_bkx
          Vertex: l_clav, Edge: l_arm_shz
            Vertex: l_scap, Edge: l_arm_shx
              Vertex: l_uarm, Edge: l_arm_ely
                Vertex: l_larm, Edge: l_arm_elx
                  Vertex: l_ufarm, Edge: l_arm_uwy
                    Vertex: l_lfarm, Edge: l_arm_mwx
                      Vertex: l_hand, Edge: l_arm_lwy
          Vertex: head, Edge: neck_ay
          Vertex: r_clav, Edge: r_arm_shz
            Vertex: r_scap, Edge: r_arm_shx
              Vertex: r_uarm, Edge: r_arm_ely
                Vertex: r_larm, Edge: r_arm_elx
                  Vertex: r_ufarm, Edge: r_arm_uwy
                    Vertex: r_lfarm, Edge: r_arm_mwx
                      Vertex: r_hand, Edge: r_arm_lwy
    Vertex: l_uglut, Edge: l_leg_hpz
      Vertex: l_lglut, Edge: l_leg_hpx
        Vertex: l_uleg, Edge: l_leg_hpy
          Vertex: l_lleg, Edge: l_leg_kny
            Vertex: l_talus, Edge: l_leg_aky
              Vertex: l_foot, Edge: l_leg_akx
    Vertex: r_uglut, Edge: r_leg_hpz
      Vertex: r_lglut, Edge: r_leg_hpx
        Vertex: r_uleg, Edge: r_leg_hpy
          Vertex: r_lleg, Edge: r_leg_kny
            Vertex: r_talus, Edge: r_leg_aky
              Vertex: r_foot, Edge: r_leg_akx
```
into one that's attached to the world by the left foot with a fixed joint:
```
Vertex: world (root)
  Vertex: l_foot, Edge: foot_to_world
    Vertex: l_talus, Edge: l_leg_akx
      Vertex: l_lleg, Edge: l_leg_aky
        Vertex: l_uleg, Edge: l_leg_kny
          Vertex: l_lglut, Edge: l_leg_hpy
            Vertex: l_uglut, Edge: l_leg_hpx
              Vertex: pelvis, Edge: l_leg_hpz
                Vertex: ltorso, Edge: back_bkz
                  Vertex: mtorso, Edge: back_bky
                    Vertex: utorso, Edge: back_bkx
                      Vertex: l_clav, Edge: l_arm_shz
                        Vertex: l_scap, Edge: l_arm_shx
                          Vertex: l_uarm, Edge: l_arm_ely
                            Vertex: l_larm, Edge: l_arm_elx
                              Vertex: l_ufarm, Edge: l_arm_uwy
                                Vertex: l_lfarm, Edge: l_arm_mwx
                                  Vertex: l_hand, Edge: l_arm_lwy
                      Vertex: head, Edge: neck_ay
                      Vertex: r_clav, Edge: r_arm_shz
                        Vertex: r_scap, Edge: r_arm_shx
                          Vertex: r_uarm, Edge: r_arm_ely
                            Vertex: r_larm, Edge: r_arm_elx
                              Vertex: r_ufarm, Edge: r_arm_uwy
                                Vertex: r_lfarm, Edge: r_arm_mwx
                                  Vertex: r_hand, Edge: r_arm_lwy
                Vertex: r_uglut, Edge: r_leg_hpz
                  Vertex: r_lglut, Edge: r_leg_hpx
                    Vertex: r_uleg, Edge: r_leg_hpy
                      Vertex: r_lleg, Edge: r_leg_kny
                        Vertex: r_talus, Edge: r_leg_aky
                          Vertex: r_foot, Edge: r_leg_akx
```

