### PR TITLE
JointType dependent method updates

### DIFF
--- a/perf/runbenchmarks.jl
+++ b/perf/runbenchmarks.jl
@@ -55,6 +55,7 @@ end
 function runbenchmarks()
     suite = create_benchmark_suite()
     tune!(suite)
+    Profile.clear_malloc_data()
     results = run(suite, verbose = true)
     showall(results)
     println()


### PR DESCRIPTION
Just pass frame before and frame after to joint type dependent methods, instead of passing the joint (untangles things a bit)