### PR TITLE
Make motion_subspace type stable

### DIFF
--- a/src/joint.jl
+++ b/src/joint.jl
@@ -38,8 +38,7 @@ function joint_transform{M, X}(joint::Joint{M}, q::AbstractVector{X})::Transform
     _joint_transform(joint.jointType, joint.frameAfter, joint.frameBefore, q)
 end
 
-# TODO: currently not type stable (should probably return a fixed-maximum-size GeometricJacobian)
-function motion_subspace(joint::Joint, q::AbstractVector)
+function motion_subspace{M, X}(joint::Joint{M}, q::AbstractVector{X})::MotionSubspace{promote_type(M, X)}
     @boundscheck check_num_positions(joint, q)
     _motion_subspace(joint.jointType, joint.frameAfter, joint.frameBefore, q)
 end
@@ -110,7 +109,7 @@ function _motion_subspace{T<:Real, X<:Real}(
     S = promote_type(T, X)
     angular = hcat(eye(SMatrix{3, 3, S}), zeros(SMatrix{3, 3, S}))
     linear = hcat(zeros(SMatrix{3, 3, S}), eye(SMatrix{3, 3, S}))
-    GeometricJacobian(frameAfter, frameBefore, frameAfter, angular, linear)
+    MotionSubspace(frameAfter, frameBefore, frameAfter, angular, linear)
 end
 
 function _bias_acceleration{T<:Real, X<:Real}(
@@ -241,7 +240,7 @@ function _motion_subspace{T<:Real, X<:Real}(
     S = promote_type(T, X)
     angular = zeros(SMatrix{3, 1, X})
     linear = SMatrix{3, 1, X}(jt.translation_axis)
-    GeometricJacobian(frameAfter, frameBefore, frameAfter, angular, linear)
+    MotionSubspace(frameAfter, frameBefore, frameAfter, angular, linear)
 end
 
 function _joint_torque!(jt::Prismatic, τ::AbstractVector, q::AbstractVector, joint_wrench::Wrench)
@@ -283,7 +282,7 @@ function _motion_subspace{T<:Real, X<:Real}(
     S = promote_type(T, X)
     angular = SMatrix{3, 1, S}(jt.rotation_axis)
     linear = zeros(SMatrix{3, 1, S})
-    GeometricJacobian(frameAfter, frameBefore, frameAfter, angular, linear)
+    MotionSubspace(frameAfter, frameBefore, frameAfter, angular, linear)
 end
 
 function _joint_torque!(jt::Revolute, τ::AbstractVector, q::AbstractVector, joint_wrench::Wrench)
@@ -312,7 +311,7 @@ end
 function _motion_subspace{T<:Real, X<:Real}(
         jt::Fixed{T}, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector{X})
     S = promote_type(T, X)
-    GeometricJacobian(frameAfter, frameBefore, frameAfter, zeros(SMatrix{3, 0, S}), zeros(SMatrix{3, 0, S}))
+    MotionSubspace(frameAfter, frameBefore, frameAfter, zeros(SMatrix{3, 0, S}), zeros(SMatrix{3, 0, S}))
 end
 
 _zero_configuration!(::Fixed, q::AbstractVector) = nothing

--- a/src/mechanism_state.jl
+++ b/src/mechanism_state.jl
@@ -60,7 +60,7 @@ immutable MechanismState{X<:Real, M<:Real, C<:Real} # immutable, but can change 
     v::Vector{X}
     transformCache::TransformCache{C}
     twistsAndBiases::Dict{RigidBody{M}, CacheElement{Tuple{Twist{C}, SpatialAcceleration{C}}, UpdateTwistAndBias{M, C}}}
-    motionSubspaces::Dict{Joint{M}, CacheElement{GeometricJacobian}}
+    motionSubspaces::Dict{Joint{M}, CacheElement{MotionSubspace{C}}}
     spatialInertias::Dict{RigidBody{M}, CacheElement{SpatialInertia{C}, UpdateSpatialInertiaInWorld{M, C}}}
     crbInertias::Dict{RigidBody{M}, CacheElement{SpatialInertia{C}, UpdateCompositeRigidBodyInertia{M, C}}}
 
@@ -69,7 +69,7 @@ immutable MechanismState{X<:Real, M<:Real, C<:Real} # immutable, but can change 
         v = zeros(X, num_velocities(m))
         transformCache = TransformCache(m, q)
         twistsAndBiases = Dict{RigidBody{M}, CacheElement{Tuple{Twist{C}, SpatialAcceleration{C}}, UpdateTwistAndBias{M, C}}}()
-        motionSubspaces = Dict{Joint{M}, CacheElement{GeometricJacobian}}()
+        motionSubspaces = Dict{Joint{M}, CacheElement{MotionSubspace{C}}}()
         spatialInertias = Dict{RigidBody{M}, CacheElement{SpatialInertia{C}, UpdateSpatialInertiaInWorld{M, C}}}()
         crbInertias = Dict{RigidBody{M}, CacheElement{SpatialInertia{C}, UpdateCompositeRigidBodyInertia{M, C}}}()
         new(m, q, v, transformCache, twistsAndBiases, motionSubspaces, spatialInertias, crbInertias)
@@ -188,7 +188,7 @@ function MechanismState{X, M}(::Type{X}, m::Mechanism{M})
                 S = transform(motion_subspace(joint, qJoint), get(transformToRootCache))
                 GeometricJacobian(S.body, parentFrame, S.frame, S.angular, S.linear) # to make frames line up
             end
-            state.motionSubspaces[joint] = CacheElement(GeometricJacobian, update_motion_subspace)
+            state.motionSubspaces[joint] = CacheElement(MotionSubspace{C}, update_motion_subspace)
         else
             rootTwist = zero(Twist{C}, root.frame, root.frame, root.frame)
             rootBias = zero(SpatialAcceleration{C}, root.frame, root.frame, root.frame)

--- a/src/spatial.jl
+++ b/src/spatial.jl
@@ -202,6 +202,7 @@ typealias MotionSubspace{T} GeometricJacobian{SubArray{T,2,StaticArrays.SMatrix{
 @generated function MotionSubspace{N, T}(body::CartesianFrame3D, base::CartesianFrame3D, frame::CartesianFrame3D, angular::SMatrix{3, N, T}, linear::SMatrix{3, N, T})
     fillerSize = 6 - N
     return quote
+        $(Expr(:meta, :inline))
         filler = fill(NaN, SMatrix{3, $fillerSize, T})
         angularData = hcat(angular, filler)::SMatrix{3,6,T,18}
         linearData = hcat(linear, filler)::SMatrix{3,6,T,18}

--- a/src/third_party_addendum.jl
+++ b/src/third_party_addendum.jl
@@ -37,3 +37,53 @@ function rpy_to_quaternion(rpy::Vector)
     @inbounds qz = c[1]*c[2]*s[3] - s[1]*s[2]*c[3]
     Quaternion(qs, qx, qy, qz)
 end
+
+# Some operators involving a view of an SMatrix.
+# TODO: make more efficient and less specific, or remove once StaticArrays does this.
+import Base: *, +, -
+
+typealias ContiguousSMatrixColumnView{S1, S2, T, L} SubArray{T,2,SMatrix{S1, S2, T, L},Tuple{Colon,UnitRange{Int64}},true}
+
+function *{S1, S2, T, L}(A::StaticMatrix, B::ContiguousSMatrixColumnView{S1, S2, T, L})
+    data = A * parent(B)
+    view(data, B.indexes[1], B.indexes[2])
+end
+
+function +{S1, S2, T, L}(A::ContiguousSMatrixColumnView{S1, S2, T, L}, B::ContiguousSMatrixColumnView{S1, S2, T, L})
+    @boundscheck size(A) == size(B)
+    data = parent(A) + parent(B)
+    view(data, A.indexes[1], A.indexes[2])
+end
+
+function -{S1, S2, T, L}(A::ContiguousSMatrixColumnView{S1, S2, T, L}, B::ContiguousSMatrixColumnView{S1, S2, T, L})
+    @boundscheck size(A) == size(B)
+    data = parent(A) - parent(B)
+    view(data, A.indexes[1], A.indexes[2])
+end
+
+function -{S1, S2, T, L}(A::ContiguousSMatrixColumnView{S1, S2, T, L})
+    data = -parent(A)
+    view(data, A.indexes[1], A.indexes[2])
+end
+
+function *{S1, S2, T, L}(s::Number, A::ContiguousSMatrixColumnView{S1, S2, T, L})
+    data = s * parent(A)
+    view(data, A.indexes[1], A.indexes[2])
+end
+
+# FIXME: hack to get around ambiguities
+_mul(a, b) = a * b
+
+# TODO: too specific
+function _mul{S1, S2, TA, L, Tb}(
+        A::Union{SMatrix{S1, S2, TA, L}, ContiguousSMatrixColumnView{S1, S2, TA, L}},
+        b::StridedVector{Tb})
+    @boundscheck @assert size(A, 2) == size(b, 1)
+    ret = zeros(SVector{S1, promote_type(TA, Tb)})
+    for i = 1 : size(A, 2)
+        @inbounds bi = b[i]
+        Acol = SVector{S1, TA}(view(A, :, i))
+        ret = ret + Acol * bi
+    end
+    ret
+end

--- a/src/third_party_addendum.jl
+++ b/src/third_party_addendum.jl
@@ -76,7 +76,7 @@ _mul(a, b) = a * b
 
 # TODO: too specific
 function _mul{S1, S2, TA, L, Tb}(
-        A::Union{SMatrix{S1, S2, TA, L}, ContiguousSMatrixColumnView{S1, S2, TA, L}},
+        A::ContiguousSMatrixColumnView{S1, S2, TA, L},
         b::StridedVector{Tb})
     @boundscheck @assert size(A, 2) == size(b, 1)
     ret = zeros(SVector{S1, promote_type(TA, Tb)})


### PR DESCRIPTION
Fixes https://github.com/tkoolen/RigidBodyDynamics.jl/issues/84 by always returning a `GeometricJacobian` that uses a `SubArray` of an `SMatrix{3, 6}` as the underlying type.

On laptop, before:
```
  "inverse_dynamics" => BenchmarkTools.Trial: 
  samples:          10000
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  60.67 kb
  allocs estimate:  1246
  minimum time:     331.88 μs (0.00% GC)
  median time:      358.99 μs (0.00% GC)
  mean time:        397.22 μs (1.87% GC)
  maximum time:     3.74 ms (86.89% GC)
  "dynamics" => BenchmarkTools.Trial: 
  samples:          10000
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  68.27 kb
  allocs estimate:  1245
  minimum time:     320.61 μs (0.00% GC)
  median time:      330.85 μs (0.00% GC)
  mean time:        372.35 μs (2.17% GC)
  maximum time:     4.15 ms (82.81% GC)
  "mass_matrix" => BenchmarkTools.Trial: 
  samples:          10000
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  50.98 kb
  allocs estimate:  803
  minimum time:     195.55 μs (0.00% GC)
  median time:      209.60 μs (0.00% GC)
  mean time:        224.22 μs (2.27% GC)
  maximum time:     3.23 ms (89.51% GC)
```
after:
```
  "inverse_dynamics" => BenchmarkTools.Trial: 
  samples:          10000
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  60.86 kb
  allocs estimate:  869
  minimum time:     115.65 μs (0.00% GC)
  median time:      124.50 μs (0.00% GC)
  mean time:        136.79 μs (4.98% GC)
  maximum time:     3.50 ms (92.61% GC)
  "dynamics" => BenchmarkTools.Trial: 
  samples:          10000
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  75.22 kb
  allocs estimate:  1116
  minimum time:     211.93 μs (0.00% GC)
  median time:      216.91 μs (0.00% GC)
  mean time:        249.27 μs (3.63% GC)
  maximum time:     4.06 ms (87.02% GC)
  "mass_matrix" => BenchmarkTools.Trial: 
  samples:          10000
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  57.94 kb
  allocs estimate:  674
  minimum time:     94.70 μs (0.00% GC)
  median time:      100.92 μs (0.00% GC)
  mean time:        112.62 μs (4.70% GC)
  maximum time:     2.52 ms (93.57% GC)
```