### PR TITLE
Work around #93

### DIFF
--- a/src/RigidBodyDynamics.jl
+++ b/src/RigidBodyDynamics.jl
@@ -18,6 +18,7 @@ include("third_party_addendum.jl")
 include("frames.jl")
 include("spatial.jl")
 include("rigid_body.jl")
+include("joint_types.jl")
 include("joint.jl")
 include("cache_element.jl")
 

--- a/src/joint.jl
+++ b/src/joint.jl
@@ -1,6 +1,3 @@
-abstract JointType{T<:Real}
-flip_direction{T}(jt::JointType{T}) = deepcopy(jt) # default behavior for flipping the direction of a joint
-
 type Joint{T<:Real}
     name::String
     frameBefore::CartesianFrame3D
@@ -21,377 +18,68 @@ num_velocities(joint::Joint) = num_velocities(joint.jointType)::Int64
 num_positions(itr) = reduce((val, joint) -> val + num_positions(joint), 0, itr)
 num_velocities(itr) = reduce((val, joint) -> val + num_velocities(joint), 0, itr)
 
-function check_num_positions(joint::Joint, vec::AbstractVector)
+@inline function check_num_positions(joint::Joint, vec::AbstractVector)
     length(vec) == num_positions(joint) || error("wrong size")
     nothing
 end
 
-function check_num_velocities(joint::Joint, vec::AbstractVector)
+@inline function check_num_velocities(joint::Joint, vec::AbstractVector)
     length(vec) == num_velocities(joint) || error("wrong size")
     nothing
 end
 
-# Return type annotations below because of https://groups.google.com/forum/#!topic/julia-users/OBs0fmNmjCU
-# They might not be completely necessary at this point.
+
+# 'RTTI'-style dispatch inspired by https://groups.google.com/d/msg/julia-users/ude2-MUiFLM/z-MuQ9nhAAAJ, hopefully a short-term solution.
+# See https://github.com/tkoolen/RigidBodyDynamics.jl/issues/93.
 function joint_transform{M, X}(joint::Joint{M}, q::AbstractVector{X})::Transform3D{promote_type(M, X)}
     @boundscheck check_num_positions(joint, q)
-    if isa(joint.jointType, QuaternionFloating{M})
-        return _joint_transform(joint.jointType::QuaternionFloating{M}, joint.frameAfter, joint.frameBefore, q)
-    elseif isa(joint.jointType, Revolute{M})
-        return _joint_transform(joint.jointType::Revolute{M}, joint.frameAfter, joint.frameBefore, q)
-    elseif isa(joint.jointType, Prismatic{M})
-        return _joint_transform(joint.jointType::Prismatic{M}, joint.frameAfter, joint.frameBefore, q)
-    elseif isa(joint.jointType, Fixed{M})
-        return _joint_transform(joint.jointType::Fixed{M}, joint.frameAfter, joint.frameBefore, q)
-    else
-        error("joint type not recognized")
-    end
+    @rtti_dispatch Union{QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}} _joint_transform(joint.jointType, joint.frameAfter, joint.frameBefore, q)
 end
 
 function motion_subspace{M, X}(joint::Joint{M}, q::AbstractVector{X})::MotionSubspace{promote_type(M, X)}
     @boundscheck check_num_positions(joint, q)
-    if isa(joint.jointType, QuaternionFloating{M})
-        return _motion_subspace(joint.jointType::QuaternionFloating{M}, joint.frameAfter, joint.frameBefore, q)
-    elseif isa(joint.jointType, Revolute{M})
-        return _motion_subspace(joint.jointType::Revolute{M}, joint.frameAfter, joint.frameBefore, q)
-    elseif isa(joint.jointType, Prismatic{M})
-        return _motion_subspace(joint.jointType::Prismatic{M}, joint.frameAfter, joint.frameBefore, q)
-    elseif isa(joint.jointType, Fixed{M})
-        return _motion_subspace(joint.jointType::Fixed{M}, joint.frameAfter, joint.frameBefore, q)
-    else
-        error("joint type not recognized")
-    end
+    @rtti_dispatch Union{QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}} _motion_subspace(joint.jointType, joint.frameAfter, joint.frameBefore, q)
 end
 
 function bias_acceleration{M, X}(joint::Joint{M}, q::AbstractVector{X}, v::AbstractVector{X})::SpatialAcceleration{promote_type(M, X)}
     @boundscheck check_num_positions(joint, q)
     @boundscheck check_num_velocities(joint, v)
-    if isa(joint.jointType, QuaternionFloating{M})
-        return _bias_acceleration(joint.jointType::QuaternionFloating{M}, joint.frameAfter, joint.frameBefore, q, v)
-    elseif isa(joint.jointType, Revolute{M})
-        return _bias_acceleration(joint.jointType::Revolute{M}, joint.frameAfter, joint.frameBefore, q, v)
-    elseif isa(joint.jointType, Prismatic{M})
-        return _bias_acceleration(joint.jointType::Prismatic{M}, joint.frameAfter, joint.frameBefore, q, v)
-    elseif isa(joint.jointType, Fixed{M})
-        return _bias_acceleration(joint.jointType::Fixed{M}, joint.frameAfter, joint.frameBefore, q, v)
-    else
-        error("joint type not recognized")
-    end
+    @rtti_dispatch Union{QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}} _bias_acceleration(joint.jointType, joint.frameAfter, joint.frameBefore, q, v)
 end
 
 function configuration_derivative_to_velocity!{M}(joint::Joint{M}, v::AbstractVector, q::AbstractVector, q̇::AbstractVector)::Void
     @boundscheck check_num_velocities(joint, v)
     @boundscheck check_num_positions(joint, q)
     @boundscheck check_num_positions(joint, q̇)
-    if isa(joint.jointType, QuaternionFloating{M})
-        return _configuration_derivative_to_velocity!(joint.jointType::QuaternionFloating{M}, v, q, q̇)
-    elseif isa(joint.jointType, Revolute{M})
-        return _configuration_derivative_to_velocity!(joint.jointType::Revolute{M}, v, q, q̇)
-    elseif isa(joint.jointType, Prismatic{M})
-        return _configuration_derivative_to_velocity!(joint.jointType::Prismatic{M}, v, q, q̇)
-    elseif isa(joint.jointType, Fixed{M})
-        return _configuration_derivative_to_velocity!(joint.jointType::Fixed{M}, v, q, q̇)
-    else
-        error("joint type not recognized")
-    end
+    @rtti_dispatch Union{QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}} _configuration_derivative_to_velocity!(joint.jointType, v, q, q̇)
 end
 
 function velocity_to_configuration_derivative!{M}(joint::Joint{M}, q̇::AbstractVector, q::AbstractVector, v::AbstractVector)::Void
     @boundscheck check_num_positions(joint, q̇)
     @boundscheck check_num_positions(joint, q)
     @boundscheck check_num_velocities(joint, v)
-    if isa(joint.jointType, QuaternionFloating{M})
-        return _velocity_to_configuration_derivative!(joint.jointType::QuaternionFloating{M}, q̇, q, v)
-    elseif isa(joint.jointType, Revolute{M})
-        return _velocity_to_configuration_derivative!(joint.jointType::Revolute{M}, q̇, q, v)
-    elseif isa(joint.jointType, Prismatic{M})
-        return _velocity_to_configuration_derivative!(joint.jointType::Prismatic{M}, q̇, q, v)
-    elseif isa(joint.jointType, Fixed{M})
-        return _velocity_to_configuration_derivative!(joint.jointType::Fixed{M}, q̇, q, v)
-    else
-        error("joint type not recognized")
-    end
+    @rtti_dispatch Union{QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}} _velocity_to_configuration_derivative!(joint.jointType, q̇, q, v)
 end
 
-function zero_configuration!(joint::Joint, q::AbstractVector)::Void
+function zero_configuration!{M}(joint::Joint{M}, q::AbstractVector)::Void
     @boundscheck check_num_positions(joint, q)
-    _zero_configuration!(joint.jointType, q) # TODO
+    @rtti_dispatch Union{QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}} _zero_configuration!(joint.jointType, q)
 end
 
-function rand_configuration!(joint::Joint, q::AbstractVector)::Void
+function rand_configuration!{M}(joint::Joint{M}, q::AbstractVector)::Void
     @boundscheck check_num_positions(joint, q)
-    _rand_configuration!(joint.jointType, q) # TODO
+    @rtti_dispatch Union{QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}} _rand_configuration!(joint.jointType, q)
 end
 
 function joint_twist{M, X}(joint::Joint{M}, q::AbstractVector{X}, v::AbstractVector{X})::Twist{promote_type(M, X)}
     @boundscheck check_num_positions(joint, q)
     @boundscheck check_num_velocities(joint, v)
-    if isa(joint.jointType, QuaternionFloating{M})
-        return _joint_twist(joint.jointType::QuaternionFloating{M}, joint.frameAfter, joint.frameBefore, q, v)
-    elseif isa(joint.jointType, Revolute{M})
-        return _joint_twist(joint.jointType::Revolute{M}, joint.frameAfter, joint.frameBefore, q, v)
-    elseif isa(joint.jointType, Prismatic{M})
-        return _joint_twist(joint.jointType::Prismatic{M}, joint.frameAfter, joint.frameBefore, q, v)
-    elseif isa(joint.jointType, Fixed{M})
-        return _joint_twist(joint.jointType::Fixed{M}, joint.frameAfter, joint.frameBefore, q, v)
-    else
-        error("joint type not recognized")
-    end
+    @rtti_dispatch Union{QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}} _joint_twist(joint.jointType, joint.frameAfter, joint.frameBefore, q, v)
 end
 
 function joint_torque!{M}(joint::Joint{M}, τ::AbstractVector, q::AbstractVector, joint_wrench::Wrench)::Void
     @boundscheck check_num_velocities(joint, τ)
     @boundscheck check_num_positions(joint, q)
     framecheck(joint_wrench.frame, joint.frameAfter)
-    if isa(joint.jointType, QuaternionFloating{M})
-        return _joint_torque!(joint.jointType::QuaternionFloating{M}, τ, q, joint_wrench)
-    elseif isa(joint.jointType, Revolute{M})
-        return _joint_torque!(joint.jointType::Revolute{M}, τ, q, joint_wrench)
-    elseif isa(joint.jointType, Prismatic{M})
-        return _joint_torque!(joint.jointType::Prismatic{M}, τ, q, joint_wrench)
-    elseif isa(joint.jointType, Fixed{M})
-        return _joint_torque!(joint.jointType::Fixed{M}, τ, q, joint_wrench)
-    else
-        error("joint type not recognized")
-    end
+    @rtti_dispatch Union{QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}} _joint_torque!(joint.jointType, τ, q, joint_wrench)
 end
-
-immutable QuaternionFloating{T} <: JointType{T}
-end
-
-show(io::IO, jt::QuaternionFloating) = print(io, "Quaternion floating joint")
-rand{T}(::Type{QuaternionFloating{T}}) = QuaternionFloating{T}()
-
-num_positions(::QuaternionFloating) = 7
-num_velocities(::QuaternionFloating) = 6
-
-function _joint_transform{T<:Real, X<:Real}(
-        jt::QuaternionFloating{T}, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector{X})
-    S = promote_type(T, X)
-    @inbounds rot = Quaternion(q[1], q[2], q[3], q[4])
-    Quaternions.normalize(rot)
-    @inbounds trans = SVector{3}(q[5], q[6], q[7])
-    Transform3D(frameAfter, frameBefore, convert(Quaternion{S}, rot), convert(SVector{3, S}, trans))
-end
-
-function _motion_subspace{T<:Real, X<:Real}(
-        jt::QuaternionFloating{T}, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector{X})
-    S = promote_type(T, X)
-    angular = hcat(eye(SMatrix{3, 3, S}), zeros(SMatrix{3, 3, S}))
-    linear = hcat(zeros(SMatrix{3, 3, S}), eye(SMatrix{3, 3, S}))
-    MotionSubspace(frameAfter, frameBefore, frameAfter, angular, linear)
-end
-
-function _bias_acceleration{T<:Real, X<:Real}(
-        jt::QuaternionFloating{T}, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector{X}, v::AbstractVector{X})
-    S = promote_type(T, X)
-    zero(SpatialAcceleration{S}, frameAfter, frameBefore, frameAfter)
-end
-
-function _configuration_derivative_to_velocity!(jt::QuaternionFloating, v::AbstractVector, q::AbstractVector, q̇::AbstractVector)
-    @inbounds quat = Quaternion(q[1], q[2], q[3], q[4])
-    invquat = inv(quat)
-    Quaternions.normalize(quat)
-    @inbounds quatdot = Quaternion(q̇[1], q̇[2], q̇[3], q̇[4])
-    @inbounds posdot = SVector{3}(q̇[5], q̇[6], q̇[7])
-    linear = rotate(posdot, invquat)
-    angularQuat = 2 * invquat * quatdot
-    @inbounds v[1] = angularQuat.v1
-    @inbounds v[2] = angularQuat.v2
-    @inbounds v[3] = angularQuat.v3
-    @inbounds v[4] = linear[1]
-    @inbounds v[5] = linear[2]
-    @inbounds v[6] = linear[3]
-    nothing
-end
-
-function _velocity_to_configuration_derivative!(jt::QuaternionFloating, q̇::AbstractVector, q::AbstractVector, v::AbstractVector)
-    @inbounds quat = Quaternion(q[1], q[2], q[3], q[4])
-    Quaternions.normalize(quat)
-    @inbounds ωQuat = Quaternion(0, v[1], v[2], v[3])
-    @inbounds linear = SVector{3}(v[4], v[5], v[6])
-    quatdot = 1/2 * quat * ωQuat
-    posdot = rotate(linear, quat)
-    @inbounds q̇[1] = quatdot.s
-    @inbounds q̇[2] = quatdot.v1
-    @inbounds q̇[3] = quatdot.v2
-    @inbounds q̇[4] = quatdot.v3
-    @inbounds copy!(view(q̇, 5 : 7), posdot)
-    nothing
-end
-
-function _zero_configuration!(jt::QuaternionFloating, q::AbstractVector)
-    @inbounds q[1] = 1
-    @inbounds fill!(view(q, 2 : 7), 0)
-    nothing
-end
-
-function _rand_configuration!(jt::QuaternionFloating, q::AbstractVector)
-    quat = nquatrand()
-    @inbounds q[1] = quat.s
-    @inbounds q[2] = quat.v1
-    @inbounds q[3] = quat.v2
-    @inbounds q[4] = quat.v3
-    @inbounds randn!(view(q, 5 : 7))
-    nothing
-end
-
-function _joint_twist{T<:Real, X<:Real}(
-        jt::QuaternionFloating{T}, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector{X}, v::AbstractVector{X})
-    S = promote_type(T, X)
-    @inbounds ret = Twist(frameAfter, frameBefore, frameAfter, SVector{3, S}(v[1], v[2], v[3]), SVector{3, S}(v[4], v[5], v[6]))
-    ret
-end
-
-function _joint_torque!(jt::QuaternionFloating, τ::AbstractVector, q::AbstractVector, joint_wrench::Wrench)
-    @inbounds copy!(view(τ, 1 : 3), joint_wrench.angular)
-    @inbounds copy!(view(τ, 4 : 6), joint_wrench.linear)
-    nothing
-end
-
-
-abstract OneDegreeOfFreedomFixedAxis{T<:Real} <: JointType{T}
-
-num_positions(::OneDegreeOfFreedomFixedAxis) = 1
-num_velocities(::OneDegreeOfFreedomFixedAxis) = 1
-
-function _zero_configuration!(::OneDegreeOfFreedomFixedAxis, q::AbstractVector)
-    fill!(q, zero(eltype(q)))
-    nothing
-end
-
-function _rand_configuration!(::OneDegreeOfFreedomFixedAxis, q::AbstractVector)
-    randn!(q)
-    nothing
- end
-
-function _bias_acceleration{T<:Real, X<:Real}(
-        jt::OneDegreeOfFreedomFixedAxis{T}, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector{X}, v::AbstractVector{X})
-    zero(SpatialAcceleration{promote_type(T, X)}, frameAfter, frameBefore, frameAfter)
-end
-
-function _configuration_derivative_to_velocity!(::OneDegreeOfFreedomFixedAxis, v::AbstractVector, q::AbstractVector, q̇::AbstractVector)
-    v[:] = q̇
-    nothing
-end
-
-function _velocity_to_configuration_derivative!(::OneDegreeOfFreedomFixedAxis, q̇::AbstractVector, q::AbstractVector, v::AbstractVector)
-    q̇[:] = v
-    nothing
-end
-
-
-immutable Prismatic{T<:Real} <: OneDegreeOfFreedomFixedAxis{T}
-    translation_axis::SVector{3, T}
-end
-
-show(io::IO, jt::Prismatic) = print(io, "Prismatic joint with axis $(jt.translation_axis)")
-function rand{T}(::Type{Prismatic{T}})
-    axis = rand(SVector{3, T})
-    Prismatic(axis / norm(axis))
-end
-
-flip_direction(jt::Prismatic) = Prismatic(-jt.translation_axis)
-
-function _joint_transform(
-        jt::Prismatic, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector)
-    @inbounds translation = q[1] * jt.translation_axis
-    Transform3D(frameAfter, frameBefore, translation)
-end
-
-function _joint_twist(
-        jt::Prismatic, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector, v::AbstractVector)
-    @inbounds linear = jt.translation_axis * v[1]
-    Twist(frameAfter, frameBefore, frameAfter, zeros(linear), linear)
-end
-
-function _motion_subspace{T<:Real, X<:Real}(
-        jt::Prismatic{T}, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector{X})
-    S = promote_type(T, X)
-    angular = zeros(SMatrix{3, 1, X})
-    linear = SMatrix{3, 1, X}(jt.translation_axis)
-    MotionSubspace(frameAfter, frameBefore, frameAfter, angular, linear)
-end
-
-function _joint_torque!(jt::Prismatic, τ::AbstractVector, q::AbstractVector, joint_wrench::Wrench)
-    @inbounds τ[1] = dot(joint_wrench.linear, jt.translation_axis)
-    nothing
-end
-
-
-immutable Revolute{T<:Real} <: OneDegreeOfFreedomFixedAxis{T}
-    rotation_axis::SVector{3, T}
-end
-
-show(io::IO, jt::Revolute) = print(io, "Revolute joint with axis $(jt.rotation_axis)")
-function rand{T}(::Type{Revolute{T}})
-    axis = rand(SVector{3, T})
-    Revolute(axis / norm(axis))
-end
-
-flip_direction(jt::Revolute) = Revolute(-jt.rotation_axis)
-
-function _joint_transform{T<:Real, X<:Real}(
-        jt::Revolute{T}, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector{X})
-    S = promote_type(T, X)
-    @inbounds arg = q[1] / X(2)
-    s = sin(arg)
-    axis = jt.rotation_axis
-    @inbounds rot = Quaternion(cos(arg), s * axis[1], s * axis[2], s * axis[3], true)
-    Transform3D(frameAfter, frameBefore, rot)
-end
-
-function _joint_twist(
-        jt::Revolute, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector, v::AbstractVector)
-    @inbounds angular_velocity = jt.rotation_axis * v[1]
-    Twist(frameAfter, frameBefore, frameAfter, angular_velocity, zeros(angular_velocity))
-end
-
-function _motion_subspace{T<:Real, X<:Real}(
-        jt::Revolute{T}, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector{X})
-    S = promote_type(T, X)
-    angular = SMatrix{3, 1, S}(jt.rotation_axis)
-    linear = zeros(SMatrix{3, 1, S})
-    MotionSubspace(frameAfter, frameBefore, frameAfter, angular, linear)
-end
-
-function _joint_torque!(jt::Revolute, τ::AbstractVector, q::AbstractVector, joint_wrench::Wrench)
-    @inbounds τ[1] = dot(joint_wrench.angular, jt.rotation_axis)
-    nothing
-end
-
-immutable Fixed{T<:Real} <: JointType{T}
-end
-show(io::IO, jt::Fixed) = print(io, "Fixed joint")
-rand{T}(::Type{Fixed{T}}) = Fixed{T}()
-
-num_positions(::Fixed) = 0
-num_velocities(::Fixed) = 0
-
-function _joint_transform{T<:Real, X<:Real}(
-        jt::Fixed{T}, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector{X})
-    Transform3D(promote_type(T, X), frameAfter, frameBefore)
-end
-
-function _joint_twist{T<:Real, X<:Real}(
-        jt::Fixed{T}, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector{X}, v::AbstractVector{X})
-    zero(Twist{promote_type(T, X)}, frameAfter, frameBefore, frameAfter)
-end
-
-function _motion_subspace{T<:Real, X<:Real}(
-        jt::Fixed{T}, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector{X})
-    S = promote_type(T, X)
-    MotionSubspace(frameAfter, frameBefore, frameAfter, zeros(SMatrix{3, 0, S}), zeros(SMatrix{3, 0, S}))
-end
-
-_zero_configuration!(::Fixed, q::AbstractVector) = nothing
-_rand_configuration!(::Fixed, q::AbstractVector) = nothing
-
-function _bias_acceleration{T<:Real, X<:Real}(
-        jt::Fixed{T}, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector{X}, v::AbstractVector{X})
-    zero(SpatialAcceleration{promote_type(T, X)}, frameAfter, frameBefore, frameAfter)
-end
-
-_configuration_derivative_to_velocity!(::Fixed, v::AbstractVector, q::AbstractVector, q̇::AbstractVector) = nothing
-_velocity_to_configuration_derivative!(::Fixed, q̇::AbstractVector, q::AbstractVector, v::AbstractVector) = nothing
-_joint_torque!(jt::Fixed, τ::AbstractVector, q::AbstractVector, joint_wrench::Wrench) = nothing

--- a/src/joint.jl
+++ b/src/joint.jl
@@ -35,55 +35,125 @@ end
 # They might not be completely necessary at this point.
 function joint_transform{M, X}(joint::Joint{M}, q::AbstractVector{X})::Transform3D{promote_type(M, X)}
     @boundscheck check_num_positions(joint, q)
-    _joint_transform(joint.jointType, joint.frameAfter, joint.frameBefore, q)
+    if isa(joint.jointType, QuaternionFloating{M})
+        return _joint_transform(joint.jointType::QuaternionFloating{M}, joint.frameAfter, joint.frameBefore, q)
+    elseif isa(joint.jointType, Revolute{M})
+        return _joint_transform(joint.jointType::Revolute{M}, joint.frameAfter, joint.frameBefore, q)
+    elseif isa(joint.jointType, Prismatic{M})
+        return _joint_transform(joint.jointType::Prismatic{M}, joint.frameAfter, joint.frameBefore, q)
+    elseif isa(joint.jointType, Fixed{M})
+        return _joint_transform(joint.jointType::Fixed{M}, joint.frameAfter, joint.frameBefore, q)
+    else
+        error("joint type not recognized")
+    end
 end
 
 function motion_subspace{M, X}(joint::Joint{M}, q::AbstractVector{X})::MotionSubspace{promote_type(M, X)}
     @boundscheck check_num_positions(joint, q)
-    _motion_subspace(joint.jointType, joint.frameAfter, joint.frameBefore, q)
+    if isa(joint.jointType, QuaternionFloating{M})
+        return _motion_subspace(joint.jointType::QuaternionFloating{M}, joint.frameAfter, joint.frameBefore, q)
+    elseif isa(joint.jointType, Revolute{M})
+        return _motion_subspace(joint.jointType::Revolute{M}, joint.frameAfter, joint.frameBefore, q)
+    elseif isa(joint.jointType, Prismatic{M})
+        return _motion_subspace(joint.jointType::Prismatic{M}, joint.frameAfter, joint.frameBefore, q)
+    elseif isa(joint.jointType, Fixed{M})
+        return _motion_subspace(joint.jointType::Fixed{M}, joint.frameAfter, joint.frameBefore, q)
+    else
+        error("joint type not recognized")
+    end
 end
 
 function bias_acceleration{M, X}(joint::Joint{M}, q::AbstractVector{X}, v::AbstractVector{X})::SpatialAcceleration{promote_type(M, X)}
     @boundscheck check_num_positions(joint, q)
     @boundscheck check_num_velocities(joint, v)
-    _bias_acceleration(joint.jointType, joint.frameAfter, joint.frameBefore, q, v)
+    if isa(joint.jointType, QuaternionFloating{M})
+        return _bias_acceleration(joint.jointType::QuaternionFloating{M}, joint.frameAfter, joint.frameBefore, q, v)
+    elseif isa(joint.jointType, Revolute{M})
+        return _bias_acceleration(joint.jointType::Revolute{M}, joint.frameAfter, joint.frameBefore, q, v)
+    elseif isa(joint.jointType, Prismatic{M})
+        return _bias_acceleration(joint.jointType::Prismatic{M}, joint.frameAfter, joint.frameBefore, q, v)
+    elseif isa(joint.jointType, Fixed{M})
+        return _bias_acceleration(joint.jointType::Fixed{M}, joint.frameAfter, joint.frameBefore, q, v)
+    else
+        error("joint type not recognized")
+    end
 end
 
-function configuration_derivative_to_velocity!(joint::Joint, v::AbstractVector, q::AbstractVector, q̇::AbstractVector)::Void
+function configuration_derivative_to_velocity!{M}(joint::Joint{M}, v::AbstractVector, q::AbstractVector, q̇::AbstractVector)::Void
     @boundscheck check_num_velocities(joint, v)
     @boundscheck check_num_positions(joint, q)
     @boundscheck check_num_positions(joint, q̇)
-    _configuration_derivative_to_velocity!(joint.jointType, v, q, q̇)
+    if isa(joint.jointType, QuaternionFloating{M})
+        return _configuration_derivative_to_velocity!(joint.jointType::QuaternionFloating{M}, v, q, q̇)
+    elseif isa(joint.jointType, Revolute{M})
+        return _configuration_derivative_to_velocity!(joint.jointType::Revolute{M}, v, q, q̇)
+    elseif isa(joint.jointType, Prismatic{M})
+        return _configuration_derivative_to_velocity!(joint.jointType::Prismatic{M}, v, q, q̇)
+    elseif isa(joint.jointType, Fixed{M})
+        return _configuration_derivative_to_velocity!(joint.jointType::Fixed{M}, v, q, q̇)
+    else
+        error("joint type not recognized")
+    end
 end
 
-function velocity_to_configuration_derivative!(joint::Joint, q̇::AbstractVector, q::AbstractVector, v::AbstractVector)::Void
+function velocity_to_configuration_derivative!{M}(joint::Joint{M}, q̇::AbstractVector, q::AbstractVector, v::AbstractVector)::Void
     @boundscheck check_num_positions(joint, q̇)
     @boundscheck check_num_positions(joint, q)
     @boundscheck check_num_velocities(joint, v)
-    _velocity_to_configuration_derivative!(joint.jointType, q̇, q, v)
+    if isa(joint.jointType, QuaternionFloating{M})
+        return _velocity_to_configuration_derivative!(joint.jointType::QuaternionFloating{M}, q̇, q, v)
+    elseif isa(joint.jointType, Revolute{M})
+        return _velocity_to_configuration_derivative!(joint.jointType::Revolute{M}, q̇, q, v)
+    elseif isa(joint.jointType, Prismatic{M})
+        return _velocity_to_configuration_derivative!(joint.jointType::Prismatic{M}, q̇, q, v)
+    elseif isa(joint.jointType, Fixed{M})
+        return _velocity_to_configuration_derivative!(joint.jointType::Fixed{M}, q̇, q, v)
+    else
+        error("joint type not recognized")
+    end
 end
 
 function zero_configuration!(joint::Joint, q::AbstractVector)::Void
     @boundscheck check_num_positions(joint, q)
-    _zero_configuration!(joint.jointType, q)
+    _zero_configuration!(joint.jointType, q) # TODO
 end
 
 function rand_configuration!(joint::Joint, q::AbstractVector)::Void
     @boundscheck check_num_positions(joint, q)
-    _rand_configuration!(joint.jointType, q)
+    _rand_configuration!(joint.jointType, q) # TODO
 end
 
 function joint_twist{M, X}(joint::Joint{M}, q::AbstractVector{X}, v::AbstractVector{X})::Twist{promote_type(M, X)}
     @boundscheck check_num_positions(joint, q)
     @boundscheck check_num_velocities(joint, v)
-    _joint_twist(joint.jointType, joint.frameAfter, joint.frameBefore, q, v)
+    if isa(joint.jointType, QuaternionFloating{M})
+        return _joint_twist(joint.jointType::QuaternionFloating{M}, joint.frameAfter, joint.frameBefore, q, v)
+    elseif isa(joint.jointType, Revolute{M})
+        return _joint_twist(joint.jointType::Revolute{M}, joint.frameAfter, joint.frameBefore, q, v)
+    elseif isa(joint.jointType, Prismatic{M})
+        return _joint_twist(joint.jointType::Prismatic{M}, joint.frameAfter, joint.frameBefore, q, v)
+    elseif isa(joint.jointType, Fixed{M})
+        return _joint_twist(joint.jointType::Fixed{M}, joint.frameAfter, joint.frameBefore, q, v)
+    else
+        error("joint type not recognized")
+    end
 end
 
-function joint_torque!(joint::Joint, τ::AbstractVector, q::AbstractVector, joint_wrench::Wrench)::Void
+function joint_torque!{M}(joint::Joint{M}, τ::AbstractVector, q::AbstractVector, joint_wrench::Wrench)::Void
     @boundscheck check_num_velocities(joint, τ)
     @boundscheck check_num_positions(joint, q)
     framecheck(joint_wrench.frame, joint.frameAfter)
-    _joint_torque!(joint.jointType, τ, q, joint_wrench)
+    if isa(joint.jointType, QuaternionFloating{M})
+        return _joint_torque!(joint.jointType::QuaternionFloating{M}, τ, q, joint_wrench)
+    elseif isa(joint.jointType, Revolute{M})
+        return _joint_torque!(joint.jointType::Revolute{M}, τ, q, joint_wrench)
+    elseif isa(joint.jointType, Prismatic{M})
+        return _joint_torque!(joint.jointType::Prismatic{M}, τ, q, joint_wrench)
+    elseif isa(joint.jointType, Fixed{M})
+        return _joint_torque!(joint.jointType::Fixed{M}, τ, q, joint_wrench)
+    else
+        error("joint type not recognized")
+    end
 end
 
 immutable QuaternionFloating{T} <: JointType{T}

--- a/src/joint_types.jl
+++ b/src/joint_types.jl
@@ -1,0 +1,259 @@
+abstract JointType{T<:Real}
+flip_direction{T}(jt::JointType{T}) = deepcopy(jt) # default behavior for flipping the direction of a joint
+
+
+#=
+QuaternionFloating
+=#
+immutable QuaternionFloating{T} <: JointType{T}
+end
+
+show(io::IO, jt::QuaternionFloating) = print(io, "Quaternion floating joint")
+rand{T}(::Type{QuaternionFloating{T}}) = QuaternionFloating{T}()
+
+num_positions(::QuaternionFloating) = 7
+num_velocities(::QuaternionFloating) = 6
+
+function _joint_transform{T<:Real, X<:Real}(
+        jt::QuaternionFloating{T}, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector{X})
+    S = promote_type(T, X)
+    @inbounds rot = Quaternion(q[1], q[2], q[3], q[4])
+    Quaternions.normalize(rot)
+    @inbounds trans = SVector{3}(q[5], q[6], q[7])
+    Transform3D(frameAfter, frameBefore, convert(Quaternion{S}, rot), convert(SVector{3, S}, trans))
+end
+
+function _motion_subspace{T<:Real, X<:Real}(
+        jt::QuaternionFloating{T}, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector{X})
+    S = promote_type(T, X)
+    angular = hcat(eye(SMatrix{3, 3, S}), zeros(SMatrix{3, 3, S}))
+    linear = hcat(zeros(SMatrix{3, 3, S}), eye(SMatrix{3, 3, S}))
+    MotionSubspace(frameAfter, frameBefore, frameAfter, angular, linear)
+end
+
+function _bias_acceleration{T<:Real, X<:Real}(
+        jt::QuaternionFloating{T}, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector{X}, v::AbstractVector{X})
+    S = promote_type(T, X)
+    zero(SpatialAcceleration{S}, frameAfter, frameBefore, frameAfter)
+end
+
+function _configuration_derivative_to_velocity!(jt::QuaternionFloating, v::AbstractVector, q::AbstractVector, q̇::AbstractVector)
+    @inbounds quat = Quaternion(q[1], q[2], q[3], q[4])
+    invquat = inv(quat)
+    Quaternions.normalize(quat)
+    @inbounds quatdot = Quaternion(q̇[1], q̇[2], q̇[3], q̇[4])
+    @inbounds posdot = SVector{3}(q̇[5], q̇[6], q̇[7])
+    linear = rotate(posdot, invquat)
+    angularQuat = 2 * invquat * quatdot
+    @inbounds v[1] = angularQuat.v1
+    @inbounds v[2] = angularQuat.v2
+    @inbounds v[3] = angularQuat.v3
+    @inbounds v[4] = linear[1]
+    @inbounds v[5] = linear[2]
+    @inbounds v[6] = linear[3]
+    nothing
+end
+
+function _velocity_to_configuration_derivative!(jt::QuaternionFloating, q̇::AbstractVector, q::AbstractVector, v::AbstractVector)
+    @inbounds quat = Quaternion(q[1], q[2], q[3], q[4])
+    Quaternions.normalize(quat)
+    @inbounds ωQuat = Quaternion(0, v[1], v[2], v[3])
+    @inbounds linear = SVector{3}(v[4], v[5], v[6])
+    quatdot = 1/2 * quat * ωQuat
+    posdot = rotate(linear, quat)
+    @inbounds q̇[1] = quatdot.s
+    @inbounds q̇[2] = quatdot.v1
+    @inbounds q̇[3] = quatdot.v2
+    @inbounds q̇[4] = quatdot.v3
+    @inbounds copy!(view(q̇, 5 : 7), posdot)
+    nothing
+end
+
+function _zero_configuration!(jt::QuaternionFloating, q::AbstractVector)
+    @inbounds q[1] = 1
+    @inbounds fill!(view(q, 2 : 7), 0)
+    nothing
+end
+
+function _rand_configuration!(jt::QuaternionFloating, q::AbstractVector)
+    quat = nquatrand()
+    @inbounds q[1] = quat.s
+    @inbounds q[2] = quat.v1
+    @inbounds q[3] = quat.v2
+    @inbounds q[4] = quat.v3
+    @inbounds randn!(view(q, 5 : 7))
+    nothing
+end
+
+function _joint_twist{T<:Real, X<:Real}(
+        jt::QuaternionFloating{T}, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector{X}, v::AbstractVector{X})
+    S = promote_type(T, X)
+    @inbounds ret = Twist(frameAfter, frameBefore, frameAfter, SVector{3, S}(v[1], v[2], v[3]), SVector{3, S}(v[4], v[5], v[6]))
+    ret
+end
+
+function _joint_torque!(jt::QuaternionFloating, τ::AbstractVector, q::AbstractVector, joint_wrench::Wrench)
+    @inbounds copy!(view(τ, 1 : 3), joint_wrench.angular)
+    @inbounds copy!(view(τ, 4 : 6), joint_wrench.linear)
+    nothing
+end
+
+
+#=
+OneDegreeOfFreedomFixedAxis
+=#
+abstract OneDegreeOfFreedomFixedAxis{T<:Real} <: JointType{T}
+
+num_positions(::OneDegreeOfFreedomFixedAxis) = 1
+num_velocities(::OneDegreeOfFreedomFixedAxis) = 1
+
+function _zero_configuration!(::OneDegreeOfFreedomFixedAxis, q::AbstractVector)
+    fill!(q, zero(eltype(q)))
+    nothing
+end
+
+function _rand_configuration!(::OneDegreeOfFreedomFixedAxis, q::AbstractVector)
+    randn!(q)
+    nothing
+ end
+
+function _bias_acceleration{T<:Real, X<:Real}(
+        jt::OneDegreeOfFreedomFixedAxis{T}, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector{X}, v::AbstractVector{X})
+    zero(SpatialAcceleration{promote_type(T, X)}, frameAfter, frameBefore, frameAfter)
+end
+
+function _configuration_derivative_to_velocity!(::OneDegreeOfFreedomFixedAxis, v::AbstractVector, q::AbstractVector, q̇::AbstractVector)
+    v[:] = q̇
+    nothing
+end
+
+function _velocity_to_configuration_derivative!(::OneDegreeOfFreedomFixedAxis, q̇::AbstractVector, q::AbstractVector, v::AbstractVector)
+    q̇[:] = v
+    nothing
+end
+
+
+#=
+Prismatic
+=#
+immutable Prismatic{T<:Real} <: OneDegreeOfFreedomFixedAxis{T}
+    translation_axis::SVector{3, T}
+end
+
+show(io::IO, jt::Prismatic) = print(io, "Prismatic joint with axis $(jt.translation_axis)")
+function rand{T}(::Type{Prismatic{T}})
+    axis = rand(SVector{3, T})
+    Prismatic(axis / norm(axis))
+end
+
+flip_direction(jt::Prismatic) = Prismatic(-jt.translation_axis)
+
+function _joint_transform(
+        jt::Prismatic, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector)
+    @inbounds translation = q[1] * jt.translation_axis
+    Transform3D(frameAfter, frameBefore, translation)
+end
+
+function _joint_twist(
+        jt::Prismatic, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector, v::AbstractVector)
+    @inbounds linear = jt.translation_axis * v[1]
+    Twist(frameAfter, frameBefore, frameAfter, zeros(linear), linear)
+end
+
+function _motion_subspace{T<:Real, X<:Real}(
+        jt::Prismatic{T}, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector{X})
+    S = promote_type(T, X)
+    angular = zeros(SMatrix{3, 1, X})
+    linear = SMatrix{3, 1, X}(jt.translation_axis)
+    MotionSubspace(frameAfter, frameBefore, frameAfter, angular, linear)
+end
+
+function _joint_torque!(jt::Prismatic, τ::AbstractVector, q::AbstractVector, joint_wrench::Wrench)
+    @inbounds τ[1] = dot(joint_wrench.linear, jt.translation_axis)
+    nothing
+end
+
+
+#=
+Revolute
+=#
+immutable Revolute{T<:Real} <: OneDegreeOfFreedomFixedAxis{T}
+    rotation_axis::SVector{3, T}
+end
+
+show(io::IO, jt::Revolute) = print(io, "Revolute joint with axis $(jt.rotation_axis)")
+function rand{T}(::Type{Revolute{T}})
+    axis = rand(SVector{3, T})
+    Revolute(axis / norm(axis))
+end
+
+flip_direction(jt::Revolute) = Revolute(-jt.rotation_axis)
+
+function _joint_transform{T<:Real, X<:Real}(
+        jt::Revolute{T}, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector{X})
+    S = promote_type(T, X)
+    @inbounds arg = q[1] / X(2)
+    s = sin(arg)
+    axis = jt.rotation_axis
+    @inbounds rot = Quaternion(cos(arg), s * axis[1], s * axis[2], s * axis[3], true)
+    Transform3D(frameAfter, frameBefore, rot)
+end
+
+function _joint_twist(
+        jt::Revolute, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector, v::AbstractVector)
+    @inbounds angular_velocity = jt.rotation_axis * v[1]
+    Twist(frameAfter, frameBefore, frameAfter, angular_velocity, zeros(angular_velocity))
+end
+
+function _motion_subspace{T<:Real, X<:Real}(
+        jt::Revolute{T}, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector{X})
+    S = promote_type(T, X)
+    angular = SMatrix{3, 1, S}(jt.rotation_axis)
+    linear = zeros(SMatrix{3, 1, S})
+    MotionSubspace(frameAfter, frameBefore, frameAfter, angular, linear)
+end
+
+function _joint_torque!(jt::Revolute, τ::AbstractVector, q::AbstractVector, joint_wrench::Wrench)
+    @inbounds τ[1] = dot(joint_wrench.angular, jt.rotation_axis)
+    nothing
+end
+
+
+#=
+Fixed
+=#
+immutable Fixed{T<:Real} <: JointType{T}
+end
+show(io::IO, jt::Fixed) = print(io, "Fixed joint")
+rand{T}(::Type{Fixed{T}}) = Fixed{T}()
+
+num_positions(::Fixed) = 0
+num_velocities(::Fixed) = 0
+
+function _joint_transform{T<:Real, X<:Real}(
+        jt::Fixed{T}, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector{X})
+    Transform3D(promote_type(T, X), frameAfter, frameBefore)
+end
+
+function _joint_twist{T<:Real, X<:Real}(
+        jt::Fixed{T}, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector{X}, v::AbstractVector{X})
+    zero(Twist{promote_type(T, X)}, frameAfter, frameBefore, frameAfter)
+end
+
+function _motion_subspace{T<:Real, X<:Real}(
+        jt::Fixed{T}, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector{X})
+    S = promote_type(T, X)
+    MotionSubspace(frameAfter, frameBefore, frameAfter, zeros(SMatrix{3, 0, S}), zeros(SMatrix{3, 0, S}))
+end
+
+_zero_configuration!(::Fixed, q::AbstractVector) = nothing
+_rand_configuration!(::Fixed, q::AbstractVector) = nothing
+
+function _bias_acceleration{T<:Real, X<:Real}(
+        jt::Fixed{T}, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector{X}, v::AbstractVector{X})
+    zero(SpatialAcceleration{promote_type(T, X)}, frameAfter, frameBefore, frameAfter)
+end
+
+_configuration_derivative_to_velocity!(::Fixed, v::AbstractVector, q::AbstractVector, q̇::AbstractVector) = nothing
+_velocity_to_configuration_derivative!(::Fixed, q̇::AbstractVector, q::AbstractVector, v::AbstractVector) = nothing
+_joint_torque!(jt::Fixed, τ::AbstractVector, q::AbstractVector, joint_wrench::Wrench) = nothing

--- a/src/third_party_addendum.jl
+++ b/src/third_party_addendum.jl
@@ -42,8 +42,6 @@ end
 # TODO: make more efficient and less specific, or remove once StaticArrays does this.
 import Base: *, +, -
 
-typealias ContiguousSMatrixColumnView{S1, S2, T, L} SubArray{T,2,SMatrix{S1, S2, T, L},Tuple{Colon,UnitRange{Int64}},true}
-
 function *{S1, S2, T, L}(A::StaticMatrix, B::ContiguousSMatrixColumnView{S1, S2, T, L})
     data = A * parent(B)
     view(data, B.indexes[1], B.indexes[2])


### PR DESCRIPTION
Fixes https://github.com/tkoolen/RigidBodyDynamics.jl/issues/93 (in an unsatisfactory way).

'RTTI'-style dispatch inspired by https://groups.google.com/d/msg/julia-users/ude2-MUiFLM/z-MuQ9nhAAAJ, hopefully a short-term solution.

By specifying the exact set of types for which the Joint methods work, the compiler is able to figure out that the return type is always the same, so the type instability goes away.

Unfortunately this means that it is currently no longer possible for a user to add a new joint type, which needs to be fixed at some point.

Before (on laptop):
```
  "inverse_dynamics" => BenchmarkTools.Trial: 
  samples:          10000
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  60.86 kb
  allocs estimate:  869
  minimum time:     115.93 μs (0.00% GC)
  median time:      124.37 μs (0.00% GC)
  mean time:        137.13 μs (4.97% GC)
  maximum time:     3.22 ms (92.80% GC)
  "dynamics" => BenchmarkTools.Trial: 
  samples:          10000
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  75.22 kb
  allocs estimate:  1116
  minimum time:     214.63 μs (0.00% GC)
  median time:      221.07 μs (0.00% GC)
  mean time:        251.15 μs (3.65% GC)
  maximum time:     5.27 ms (90.13% GC)
  "mass_matrix" => BenchmarkTools.Trial: 
  samples:          10000
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  57.94 kb
  allocs estimate:  674
  minimum time:     95.19 μs (0.00% GC)
  median time:      101.76 μs (0.00% GC)
  mean time:        111.73 μs (4.83% GC)
  maximum time:     3.35 ms (94.30% GC)
```
After:
```
  "inverse_dynamics" => BenchmarkTools.Trial: 
  samples:          10000
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  35.19 kb
  allocs estimate:  466
  minimum time:     103.59 μs (0.00% GC)
  median time:      110.43 μs (0.00% GC)
  mean time:        118.68 μs (2.83% GC)
  maximum time:     3.64 ms (93.65% GC)
  "dynamics" => BenchmarkTools.Trial: 
  samples:          10000
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  49.55 kb
  allocs estimate:  713
  minimum time:     203.39 μs (0.00% GC)
  median time:      207.81 μs (0.00% GC)
  mean time:        232.11 μs (2.54% GC)
  maximum time:     3.91 ms (84.58% GC)
  "mass_matrix" => BenchmarkTools.Trial: 
  samples:          10000
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  40.98 kb
  allocs estimate:  488
  minimum time:     89.71 μs (0.00% GC)
  median time:      95.81 μs (0.00% GC)
  mean time:        103.78 μs (2.98% GC)
  maximum time:     2.38 ms (91.24% GC)
```

