### PR TITLE
Add time derivative of log on SE(3)

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,9 @@ import ForwardDiff
 # useful utility function for computing time derivatives.
 create_autodiff(x, dx) = [ForwardDiff.Dual(x[i], dx[i]) for i in 1 : length(x)]
 
+# TODO: open a PR with ForwardDiff:
+Base.mod{T<:ForwardDiff.Dual}(x::T, y::T) = ForwardDiff.Dual(mod(ForwardDiff.value(x), ForwardDiff.value(y)), ForwardDiff.partials(x))
+
 include("test_util.jl")
 include("test_tree.jl")
 include("test_frames.jl")


### PR DESCRIPTION
Mainly because ForwardDiff won't work at the singularity of log.
It is also ~50% faster than ForwardDiff in this case.