### PR TITLE
Local/global coordinates functions for joints

### DIFF
--- a/src/RigidBodyDynamics.jl
+++ b/src/RigidBodyDynamics.jl
@@ -60,6 +60,8 @@ export
     newton_euler,
     joint_torque,
     joint_torque!,
+    local_coordinates!,
+    global_coordinates!,
     root_frame,
     root_vertex,
     tree,

--- a/src/joint.jl
+++ b/src/joint.jl
@@ -83,3 +83,21 @@ function joint_torque!{M}(joint::Joint{M}, τ::AbstractVector, q::AbstractVector
     framecheck(joint_wrench.frame, joint.frameAfter)
     @rtti_dispatch Union{QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}} _joint_torque!(joint.jointType, τ, q, joint_wrench)
 end
+
+function local_coordinates!{M}(joint::Joint{M},
+        ϕ::AbstractVector, ϕ̇::AbstractVector,
+        q0::AbstractVector, q::AbstractVector, v::AbstractVector)
+    @boundscheck check_num_velocities(joint, ϕ)
+    @boundscheck check_num_velocities(joint, ϕ̇)
+    @boundscheck check_num_positions(joint, q0)
+    @boundscheck check_num_positions(joint, q)
+    @boundscheck check_num_velocities(joint, v)
+    @rtti_dispatch Union{QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}} _local_coordinates!(joint.jointType, ϕ, ϕ̇, q0, q, v)
+end
+
+function global_coordinates!{M}(joint::Joint{M}, q::AbstractVector, q0::AbstractVector, ϕ::AbstractVector)
+    @boundscheck check_num_positions(joint, q)
+    @boundscheck check_num_positions(joint, q0)
+    @boundscheck check_num_velocities(joint, ϕ)
+    @rtti_dispatch Union{QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}} _global_coordinates!(joint.jointType, q, q0, ϕ)
+end

--- a/src/joint_types.jl
+++ b/src/joint_types.jl
@@ -1,9 +1,22 @@
 # TODO: put in separate module
 
 abstract JointType{T<:Real}
+
 eltype{T}(::Union{JointType{T}, Type{JointType{T}}}) = T
 
-flip_direction{T}(jt::JointType{T}) = deepcopy(jt) # default behavior for flipping the direction of a joint
+# Default implementations
+flip_direction{T}(jt::JointType{T}) = deepcopy(jt)
+
+function _local_coordinates!(jt::JointType,
+        ϕ::AbstractVector, ϕ̇::AbstractVector,
+        q0::AbstractVector, q::AbstractVector, v::AbstractVector)
+    sub!(ϕ, q, q0)
+    copy!(ϕ̇, v)
+end
+
+function _global_coordinates!(jt::JointType, q::AbstractVector, q0::AbstractVector, ϕ::AbstractVector)
+    q .= q0 .+ ϕ # TODO: allocates on 0.5
+end
 
 
 #=
@@ -112,6 +125,139 @@ function _joint_torque!(jt::QuaternionFloating, τ::AbstractVector, q::AbstractV
     linear_velocity!(jt, τ, joint_wrench.linear)
     nothing
 end
+
+function _local_coordinates!(jt::QuaternionFloating,
+        ϕ::AbstractVector, ϕ̇::AbstractVector,
+        q0::AbstractVector, q::AbstractVector, v::AbstractVector)
+    # references:
+    # Murray, Richard M., et al.
+    # A mathematical introduction to robotic manipulation.
+    # CRC press, 1994.
+
+    # Bullo, Francesco, and R. M. Murray.
+    # "Proportional derivative (PD) control on the Euclidean group."
+    # European Control Conference. Vol. 2. 1995.
+
+    # use exponential coordinates centered around q0
+    # proposition 2.9 in Murray et al.
+
+    # anonymous helper frames
+    frameBefore = CartesianFrame3D()
+    frame0 = CartesianFrame3D()
+    frameAfter = CartesianFrame3D()
+
+    # compute transform from frame at q to frame at q0
+    t0 = _joint_transform(jt, frame0, frameBefore, q0) # 0 to before
+    t = _joint_transform(jt, frameAfter, frameBefore, q) # after to before
+    relative_transform = inv(t0) * t
+    rot = relative_transform.rot
+    trans = relative_transform.trans
+
+    # rotational part of local coordinates is simply the rotation vector corresponding to orientation relative to q0 frame:
+    # not using angle_axis_proper because we want to reuse intermediate results
+    Θ_over_2 = atan2(√(rot.v1^2 + rot.v2^2 + rot.v3^2), rot.s)
+    Θ = 2 * Θ_over_2
+    sΘ_over_2 = sin(Θ_over_2)
+    cΘ_over_2 = cos(Θ_over_2)
+    axis = Θ < eps(Θ) ? SVector(one(Θ), zero(Θ), zero(Θ)) : SVector(rot.v1, rot.v2, rot.v3) * (1 / sΘ_over_2)
+    ϕrot = Θ * axis
+
+    # translational part
+    # see Bullo and Murray, (2.4) and (2.5)
+    α = Θ_over_2 * cΘ_over_2 / sΘ_over_2 # TODO: singularity
+    Θ_squared = Θ^2
+    p = trans
+    ϕtrans = p - 0.5 * ϕrot × p + (1 - α) / Θ_squared * ϕrot × (ϕrot × p) # Bullo, Murray, (2.5)
+
+    # time derivatives of exponential coordinates
+    # see Bullo and Murray, Lemma 4.
+    # this is truely magic.
+    ω = angular_velocity(jt, v)
+    ν = linear_velocity(jt, v)
+    β = Θ_over_2^2 / sΘ_over_2^2 # TODO: singularity
+    A = (2 * (1 - α) + 0.5 * (α - β)) / Θ_squared
+    B = ((1 - α) + 0.5 * (α - β)) / Θ_squared^2
+    ϕ̇rot_cross_1, ϕ̇trans_cross_1 = se3_commutator(ϕrot, ϕtrans, ω, ν)
+    ϕ̇rot_cross_2, ϕ̇trans_cross_2 = se3_commutator(ϕrot, ϕtrans, ϕ̇rot_cross_1, ϕ̇trans_cross_1)
+    ϕ̇rot_cross_3, ϕ̇trans_cross_3 = se3_commutator(ϕrot, ϕtrans, ϕ̇rot_cross_2, ϕ̇trans_cross_2)
+    ϕ̇rot_cross_4, ϕ̇trans_cross_4 = se3_commutator(ϕrot, ϕtrans, ϕ̇rot_cross_3, ϕ̇trans_cross_3)
+    ϕ̇rot = ω + 0.5 * ϕ̇rot_cross_1 + A * ϕ̇rot_cross_2 + B * ϕ̇rot_cross_4
+    ϕ̇trans = ν + 0.5 * ϕ̇trans_cross_1 + A * ϕ̇trans_cross_2 + B * ϕ̇trans_cross_4
+
+    @inbounds copy!(ϕ, 1, ϕrot, 1, 3)
+    @inbounds copy!(ϕ, 4, ϕtrans, 1, 3)
+
+    @inbounds copy!(ϕ̇, 1, ϕ̇rot, 1, 3)
+    @inbounds copy!(ϕ̇, 4, ϕ̇trans, 1, 3)
+
+    # other implementations:
+    # TODO: turn into tests
+    # ϕtrans as derived in proposition 2.9 in Murray based on rotation matrices:
+    # R = rotation_matrix(rot)
+    # A = (eye(SMatrix{3, 3, T}) - R) * hat(axis) + axis * axis' * angle # prop 2.9 in Murray
+    # ϕtrans = angle * (A \ trans)
+    #
+    # . See:
+    # # Park, Jonghoon, and Wan-Kyun Chung.
+    # # "Geometric integration on Euclidean group with application to articulated multibody systems."
+    # # IEEE Transactions on Robotics 21.5 (2005): 850-863.
+    # # Equations (23) and (24)
+    #
+    # # rotational part
+    # ω = quaternion_floating_angular_velocity(v)
+    # ϕ̇rot = rotation_vector_rate(ϕrot, ω)
+    #
+    # # translational part TODO: ugly, don't quite understand it
+    # ν = quaternion_floating_linear_velocity(v)
+    # ϕ̇trans = rotation_vector_rate(ϕrot, ν)
+    # Θ = angle
+    # Θ_2 = Θ / 2
+    # s = sin(Θ_2)
+    # c = cos(Θ_2)
+    # β = s^2
+    # γ = c / s # TODO: singularity?
+    # D = (1 - γ) / Θ^2 * hat(ν, ω) + (1 / β + γ - 2) / Θ^4 * dot(ω, v) * hat_squared(ω)
+    # ϕ̇trans += (D - 1/2 * hat(v)) * v
+
+    nothing
+end
+
+function _global_coordinates!(jt::QuaternionFloating, q::AbstractVector, q0::AbstractVector, ϕ::AbstractVector)
+    T = eltype(ϕ)
+
+    # anonymous helper frames
+    frameBefore = CartesianFrame3D()
+    frame0 = CartesianFrame3D()
+    frameAfter = CartesianFrame3D()
+
+    # compute transform from frame at q to frame at q0
+    t0 = _joint_transform(jt, frame0, frameBefore, q0)
+
+    # exponentiate ϕ
+    ϕrot = SVector{3}(view(ϕ, 1 : 3))
+    ϕtrans = SVector{3}(view(ϕ, 4 : 6))
+    Θ = norm(ϕrot)
+    if Θ < eps(Θ)
+        # 2.32 in Murray et al.
+        rot = Quaternion{T}(one(T), zero(T), zero(T), zero(T), true)
+        trans = ϕtrans
+    else
+        # 2.36 in Murray et al.
+        rot = angle_axis_to_quaternion(Θ, ϕrot / Θ)
+        # ω and v are not really velocities, but this is the notation used in 2.36
+        ω = ϕrot / Θ
+        v = ϕtrans / Θ
+        trans = ω × v
+        trans -= rotate(trans, rot)
+        trans += ω * dot(ω, v) * Θ
+    end
+    relative_transform = Transform3D(frameAfter, frame0, rot, trans)
+    t = t0 * relative_transform
+    rotation!(jt, q, t.rot)
+    translation!(jt, q, t.trans)
+    nothing
+end
+
 
 
 #=

--- a/test/test_mechanism_algorithms.jl
+++ b/test/test_mechanism_algorithms.jl
@@ -305,6 +305,39 @@
         @test isapprox(power, energy_derivative, atol = 1e-10)
     end
 
+    @testset "local / global coordinates" begin
+        mechanism = rand_tree_mechanism(Float64, [QuaternionFloating{Float64}; [Revolute{Float64} for i = 1 : 10]; [Prismatic{Float64} for i = 1 : 10]]...)
+        state = MechanismState(Float64, mechanism)
+        rand!(state)
+        for joint in joints(mechanism)
+            ϕ = Vector{Float64}(num_velocities(joint))
+            ϕ̇ = Vector{Float64}(num_velocities(joint))
+            q0 = Vector{Float64}(num_positions(joint))
+            q = configuration(state, joint)
+            v = velocity(state, joint)
+            rand_configuration!(joint, q0)
+            local_coordinates!(joint, ϕ, ϕ̇, q0, q, v)
+            q_back = Vector{Float64}(num_positions(joint))
+            global_coordinates!(joint, q_back, q0, ϕ)
+            @test isapprox(q, q_back)
+
+            # compare ϕ̇ to autodiff
+            q̇ = Vector{Float64}(num_positions(joint))
+            velocity_to_configuration_derivative!(joint, q̇, q, v)
+            v̇ = rand(num_velocities(joint))
+            q_autodiff = create_autodiff(q, q̇)
+            v_autodiff = create_autodiff(v, v̇)
+            q0_autodiff = create_autodiff(q0, zeros(length(q0)))
+            T = eltype(q_autodiff)
+            ϕ_autodiff = Vector{T}(length(ϕ))
+            ϕ̇_autodiff = Vector{T}(length(ϕ̇))
+            local_coordinates!(joint, ϕ_autodiff, ϕ̇_autodiff, q0_autodiff, q_autodiff, v_autodiff)
+            ϕ̇_from_autodiff = [ForwardDiff.partials(x)[1] for x in ϕ_autodiff]
+            @test isapprox(ϕ̇, ϕ̇_from_autodiff)
+            # TODO: should ϕ̇ just always be computed using autodiff? Should benchmark.
+        end
+    end
+
     @testset "simulate" begin
         acrobot = parse_urdf(Float64, "urdf/Acrobot.urdf")
         x = MechanismState(Float64, acrobot)


### PR DESCRIPTION
These match definition 2.9 in [Duindam's thesis](http://bibtexbib.free.fr/bibliographie_net/duindam_phdthesis.pdf), and will soon be used in a [Munthe-Kaas integrator](https://hal.archives-ouvertes.fr/hal-01328729/document) that does the right thing for quaternions (see https://github.com/tkoolen/RigidBodyDynamics.jl/issues/86).