### PR TITLE
More performance tweaks

### DIFF
--- a/src/cache_element.jl
+++ b/src/cache_element.jl
@@ -20,7 +20,7 @@ end
 
 @inline isdirty(element::CacheElement) = element.dirty
 
-# The reason to do this using a macro instead of using something like get!(element::CacheElement, callable)
+# The reason for doing this using a macro instead of using something like get!(element::CacheElement, callable)
 # is that in all use cases so far, the callable would be a closure over some non-isbits types, meaning that
 # creating the closure allocates.
 # Example showing this allocation behavior: @benchmark (fun = () -> a.x) setup = a = Ref(rand(Int64))

--- a/src/joint.jl
+++ b/src/joint.jl
@@ -29,60 +29,60 @@ end
 # 'RTTI'-style dispatch inspired by https://groups.google.com/d/msg/julia-users/ude2-MUiFLM/z-MuQ9nhAAAJ, hopefully a short-term solution.
 # See https://github.com/tkoolen/RigidBodyDynamics.jl/issues/93.
 
-num_positions{M}(joint::Joint{M})::Int64 = @rtti_dispatch Union{QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}} num_positions(joint.jointType)
-num_velocities{M}(joint::Joint{M})::Int64 = @rtti_dispatch Union{QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}} num_velocities(joint.jointType)
+num_positions{M}(joint::Joint{M})::Int64 = @rtti_dispatch (QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}) num_positions(joint.jointType)
+num_velocities{M}(joint::Joint{M})::Int64 = @rtti_dispatch (QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}) num_velocities(joint.jointType)
 
 function joint_transform{M, X}(joint::Joint{M}, q::AbstractVector{X})::Transform3D{promote_type(M, X)}
     @boundscheck check_num_positions(joint, q)
-    @rtti_dispatch Union{QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}} _joint_transform(joint.jointType, joint.frameAfter, joint.frameBefore, q)
+    @rtti_dispatch (QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}) _joint_transform(joint.jointType, joint.frameAfter, joint.frameBefore, q)
 end
 
 function motion_subspace{M, X}(joint::Joint{M}, q::AbstractVector{X})::MotionSubspace{promote_type(M, X)}
     @boundscheck check_num_positions(joint, q)
-    @rtti_dispatch Union{QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}} _motion_subspace(joint.jointType, joint.frameAfter, joint.frameBefore, q)
+    @rtti_dispatch (QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}) _motion_subspace(joint.jointType, joint.frameAfter, joint.frameBefore, q)
 end
 
 function bias_acceleration{M, X}(joint::Joint{M}, q::AbstractVector{X}, v::AbstractVector{X})::SpatialAcceleration{promote_type(M, X)}
     @boundscheck check_num_positions(joint, q)
     @boundscheck check_num_velocities(joint, v)
-    @rtti_dispatch Union{QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}} _bias_acceleration(joint.jointType, joint.frameAfter, joint.frameBefore, q, v)
+    @rtti_dispatch (QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}) _bias_acceleration(joint.jointType, joint.frameAfter, joint.frameBefore, q, v)
 end
 
 function configuration_derivative_to_velocity!{M}(joint::Joint{M}, v::AbstractVector, q::AbstractVector, q̇::AbstractVector)::Void
     @boundscheck check_num_velocities(joint, v)
     @boundscheck check_num_positions(joint, q)
     @boundscheck check_num_positions(joint, q̇)
-    @rtti_dispatch Union{QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}} _configuration_derivative_to_velocity!(joint.jointType, v, q, q̇)
+    @rtti_dispatch (QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}) _configuration_derivative_to_velocity!(joint.jointType, v, q, q̇)
 end
 
 function velocity_to_configuration_derivative!{M}(joint::Joint{M}, q̇::AbstractVector, q::AbstractVector, v::AbstractVector)::Void
     @boundscheck check_num_positions(joint, q̇)
     @boundscheck check_num_positions(joint, q)
     @boundscheck check_num_velocities(joint, v)
-    @rtti_dispatch Union{QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}} _velocity_to_configuration_derivative!(joint.jointType, q̇, q, v)
+    @rtti_dispatch (QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}) _velocity_to_configuration_derivative!(joint.jointType, q̇, q, v)
 end
 
 function zero_configuration!{M}(joint::Joint{M}, q::AbstractVector)::Void
     @boundscheck check_num_positions(joint, q)
-    @rtti_dispatch Union{QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}} _zero_configuration!(joint.jointType, q)
+    @rtti_dispatch (QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}) _zero_configuration!(joint.jointType, q)
 end
 
 function rand_configuration!{M}(joint::Joint{M}, q::AbstractVector)::Void
     @boundscheck check_num_positions(joint, q)
-    @rtti_dispatch Union{QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}} _rand_configuration!(joint.jointType, q)
+    @rtti_dispatch (QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}) _rand_configuration!(joint.jointType, q)
 end
 
 function joint_twist{M, X}(joint::Joint{M}, q::AbstractVector{X}, v::AbstractVector{X})::Twist{promote_type(M, X)}
     @boundscheck check_num_positions(joint, q)
     @boundscheck check_num_velocities(joint, v)
-    @rtti_dispatch Union{QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}} _joint_twist(joint.jointType, joint.frameAfter, joint.frameBefore, q, v)
+    @rtti_dispatch (QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}) _joint_twist(joint.jointType, joint.frameAfter, joint.frameBefore, q, v)
 end
 
 function joint_torque!{M}(joint::Joint{M}, τ::AbstractVector, q::AbstractVector, joint_wrench::Wrench)::Void
     @boundscheck check_num_velocities(joint, τ)
     @boundscheck check_num_positions(joint, q)
     framecheck(joint_wrench.frame, joint.frameAfter)
-    @rtti_dispatch Union{QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}} _joint_torque!(joint.jointType, τ, q, joint_wrench)
+    @rtti_dispatch (QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}) _joint_torque!(joint.jointType, τ, q, joint_wrench)
 end
 
 function local_coordinates!{M}(joint::Joint{M},
@@ -93,12 +93,12 @@ function local_coordinates!{M}(joint::Joint{M},
     @boundscheck check_num_positions(joint, q0)
     @boundscheck check_num_positions(joint, q)
     @boundscheck check_num_velocities(joint, v)
-    @rtti_dispatch Union{QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}} _local_coordinates!(joint.jointType, ϕ, ϕ̇, q0, q, v)
+    @rtti_dispatch (QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}) _local_coordinates!(joint.jointType, ϕ, ϕ̇, q0, q, v)
 end
 
 function global_coordinates!{M}(joint::Joint{M}, q::AbstractVector, q0::AbstractVector, ϕ::AbstractVector)
     @boundscheck check_num_positions(joint, q)
     @boundscheck check_num_positions(joint, q0)
     @boundscheck check_num_velocities(joint, ϕ)
-    @rtti_dispatch Union{QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}} _global_coordinates!(joint.jointType, q, q0, ϕ)
+    @rtti_dispatch (QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}) _global_coordinates!(joint.jointType, q, q0, ϕ)
 end

--- a/src/mechanism_algorithms.jl
+++ b/src/mechanism_algorithms.jl
@@ -75,7 +75,7 @@ function potential_energy{X, M, C}(state::MechanismState{X, M, C})
         for row = 1 : n
             outrow = rowstart + row - 1
             @inbounds out.data[outrow, outcol] = zero(eltype(out))
-            @simd for i = 1 : 3
+            for i = 1 : 3
                 @inbounds out.data[outrow, outcol] += jac.angular[i, row] * mat.angular[i, col]
                 @inbounds out.data[outrow, outcol] += jac.linear[i, row] * mat.linear[i, col]
             end

--- a/src/mechanism_state.jl
+++ b/src/mechanism_state.jl
@@ -129,14 +129,14 @@ velocity(state::MechanismState, joint::Joint) = edge_to_parent_data(state_vertex
 non_root_vertices(state::MechanismState) = state.nonRootTopoSortedStateVertices
 
 function setdirty!(state::MechanismState)
-    for vertex in filter(x -> !isroot(x), state.toposortedStateVertices)
+    for vertex in state.nonRootTopoSortedStateVertices
         setdirty!(vertex_data(vertex))
         setdirty!(edge_to_parent_data(vertex))
     end
 end
 
 function zero_configuration!(state::MechanismState)
-    for vertex in filter(x -> !isroot(x), state.toposortedStateVertices)
+    for vertex in state.nonRootTopoSortedStateVertices
         zero_configuration!(edge_to_parent_data(vertex))
     end
     setdirty!(state)
@@ -151,7 +151,7 @@ end
 zero!(state::MechanismState) = begin zero_configuration!(state); zero_velocity!(state) end
 
 function rand_configuration!(state::MechanismState)
-    for vertex in filter(x -> !isroot(x), state.toposortedStateVertices)
+    for vertex in state.nonRootTopoSortedStateVertices
         rand_configuration!(edge_to_parent_data(vertex))
     end
     setdirty!(state)
@@ -257,7 +257,7 @@ momentum{X, M, C}(vertex::TreeVertex{RigidBodyState{M, C}, JointState{X, M, C}})
 momentum_rate_bias{X, M, C}(vertex::TreeVertex{RigidBodyState{M, C}, JointState{X, M, C}}) = newton_euler(vertex, bias_acceleration(vertex))
 
 function configuration_derivative!{X}(out::AbstractVector{X}, state::MechanismState{X})
-    for vertex in filter(x -> !isroot(x), state.toposortedStateVertices)
+    for vertex in state.nonRootTopoSortedStateVertices
         jointState = edge_to_parent_data(vertex)
         q = configuration(jointState)
         v = velocity(jointState)

--- a/src/mechanism_state.jl
+++ b/src/mechanism_state.jl
@@ -130,14 +130,14 @@ velocity(state::MechanismState, joint::Joint) = edge_to_parent_data(state_vertex
 non_root_vertices(state::MechanismState) = state.nonRootTopoSortedStateVertices
 
 function setdirty!(state::MechanismState)
-    for vertex in state.nonRootTopoSortedStateVertices
+    for vertex in non_root_vertices(state)
         setdirty!(vertex_data(vertex))
         setdirty!(edge_to_parent_data(vertex))
     end
 end
 
 function zero_configuration!(state::MechanismState)
-    for vertex in state.nonRootTopoSortedStateVertices
+    for vertex in non_root_vertices(state)
         zero_configuration!(edge_to_parent_data(vertex))
     end
     setdirty!(state)
@@ -152,7 +152,7 @@ end
 zero!(state::MechanismState) = begin zero_configuration!(state); zero_velocity!(state) end
 
 function rand_configuration!(state::MechanismState)
-    for vertex in state.nonRootTopoSortedStateVertices
+    for vertex in non_root_vertices(state)
         rand_configuration!(edge_to_parent_data(vertex))
     end
     setdirty!(state)
@@ -256,7 +256,7 @@ momentum{X, M, C}(vertex::TreeVertex{RigidBodyState{M, C}, JointState{X, M, C}})
 momentum_rate_bias{X, M, C}(vertex::TreeVertex{RigidBodyState{M, C}, JointState{X, M, C}}) = newton_euler(vertex, bias_acceleration(vertex))
 
 function configuration_derivative!{X}(out::AbstractVector{X}, state::MechanismState{X})
-    for vertex in state.nonRootTopoSortedStateVertices
+    for vertex in non_root_vertices(state)
         jointState = edge_to_parent_data(vertex)
         q = configuration(jointState)
         v = velocity(jointState)

--- a/src/mechanism_state.jl
+++ b/src/mechanism_state.jl
@@ -28,10 +28,11 @@ velocity(state::JointState) = state.v
 configuration_range(state::JointState) = first(parentindexes(state.q))
 velocity_range(state::JointState) = first(parentindexes(state.v))
 parent_frame(state::JointState) = state.beforeJointToParent.to
-transform(state::JointState) = get!(state.afterJointToParent, () -> state.beforeJointToParent * joint_transform(state.joint, state.q))
-twist(state::JointState) = get!(state.twist, () -> change_base(joint_twist(state.joint, state.q, state.v), parent_frame(state)))
-bias_acceleration(state::JointState) = get!(state.biasAcceleration, () -> change_base(bias_acceleration(state.joint, state.q, state.v), parent_frame(state)))
-motion_subspace(state::JointState) = get!(state.motionSubspace, () -> change_base(motion_subspace(state.joint, state.q), parent_frame(state)))
+transform(state::JointState) = @cache_element_get!(state.afterJointToParent, state.beforeJointToParent * joint_transform(state.joint, state.q))
+twist(state::JointState) = @cache_element_get!(state.twist, change_base(joint_twist(state.joint, state.q, state.v), parent_frame(state)))
+bias_acceleration(state::JointState) = @cache_element_get!(state.biasAcceleration, change_base(bias_acceleration(state.joint, state.q, state.v), parent_frame(state)))
+motion_subspace(state::JointState) = @cache_element_get!(state.motionSubspace, change_base(motion_subspace(state.joint, state.q), parent_frame(state)))
+
 zero_configuration!(state::JointState) = (zero_configuration!(state.joint, state.q))
 rand_configuration!(state::JointState) = (rand_configuration!(state.joint, state.q))
 
@@ -202,17 +203,17 @@ end
 
 # the following functions return quantities expressed in world frame and w.r.t. world frame (where applicable)
 function transform_to_root{X, M, C}(vertex::TreeVertex{RigidBodyState{M, C}, JointState{X, M, C}})
-    update = () -> transform_to_root(parent(vertex)) * transform(edge_to_parent_data(vertex))
-    get!(vertex_data(vertex).transformToWorld, update)
+    @cache_element_get!(vertex_data(vertex).transformToWorld,
+        transform_to_root(parent(vertex)) * transform(edge_to_parent_data(vertex)))
 end
 
 function twist_wrt_world{X, M, C}(vertex::TreeVertex{RigidBodyState{M, C}, JointState{X, M, C}})
-    update = () -> twist_wrt_world(parent(vertex)) + transform(twist(edge_to_parent_data(vertex)), transform_to_root(vertex))
-    get!(vertex_data(vertex).twist, update)
+    @cache_element_get!(vertex_data(vertex).twist,
+        twist_wrt_world(parent(vertex)) + transform(twist(edge_to_parent_data(vertex)), transform_to_root(vertex)))
 end
 
 function bias_acceleration{X, M, C}(vertex::TreeVertex{RigidBodyState{M, C}, JointState{X, M, C}})
-    update = () -> begin
+    @cache_element_get!(vertex_data(vertex).biasAcceleration, begin
         parentVertex = parent(vertex)
         parentBias = bias_acceleration(parentVertex)
         toRoot = transform_to_root(vertex)
@@ -221,29 +222,27 @@ function bias_acceleration{X, M, C}(vertex::TreeVertex{RigidBodyState{M, C}, Joi
         jointTwist = twist(edge_to_parent_data(vertex))
         jointBias = transform(jointBias, toRoot, twistWrtWorld, jointTwist)
         parentBias + jointBias
-    end
-    get!(vertex_data(vertex).biasAcceleration, update)
+    end)
 end
 
 function motion_subspace{X, M, C}(vertex::TreeVertex{RigidBodyState{M, C}, JointState{X, M, C}})
-    update = () -> transform(motion_subspace(edge_to_parent_data(vertex)), transform_to_root(vertex))
-    get!(vertex_data(vertex).motionSubspace, update)
+    @cache_element_get!(vertex_data(vertex).motionSubspace,
+        transform(motion_subspace(edge_to_parent_data(vertex)), transform_to_root(vertex)))
 end
 
 function spatial_inertia{X, M, C}(vertex::TreeVertex{RigidBodyState{M, C}, JointState{X, M, C}})
-    update = () -> transform(spatial_inertia(vertex_data(vertex).body), transform_to_root(vertex))
-    get!(vertex_data(vertex).inertia, update)
+    @cache_element_get!(vertex_data(vertex).inertia,
+        transform(spatial_inertia(vertex_data(vertex).body), transform_to_root(vertex)))
 end
 
 function crb_inertia{X, M, C}(vertex::TreeVertex{RigidBodyState{M, C}, JointState{X, M, C}})
-    update = () -> begin
+    @cache_element_get!(vertex_data(vertex).crbInertia, begin
         ret = spatial_inertia(vertex)
         for child in children(vertex)
             ret += crb_inertia(child)
         end
         ret
-    end
-    get!(vertex_data(vertex).crbInertia, update)
+    end)
 end
 
 function newton_euler{X, M, C}(vertex::TreeVertex{RigidBodyState{M, C}, JointState{X, M, C}}, accel::SpatialAcceleration)

--- a/src/spatial.jl
+++ b/src/spatial.jl
@@ -385,27 +385,37 @@ end
 # GeometricJacobian with a view of a 3×6 SMatrix as the underlying data type gets around type
 # instabilities in motion_subspace while still using an isbits type.
 # See https://github.com/tkoolen/RigidBodyDynamics.jl/issues/84.
-typealias MotionSubspace{T} GeometricJacobian{ContiguousSMatrixColumnView{3, 6, T, 18}}
+typealias MotionSubspaceArrayType{T} ContiguousSMatrixColumnView{3, 6, T, 18}
+typealias MotionSubspace{T} GeometricJacobian{MotionSubspaceArrayType{T}}
+@inline function fast_view_for_motion_subspace{T}(data::SMatrix{3, 6, T, 18}, colrange::UnitRange{Int64})
+    MotionSubspaceArrayType{T}(data, (:, colrange), 0, 1)
+end
 
 @generated function MotionSubspace{N, T}(body::CartesianFrame3D, base::CartesianFrame3D, frame::CartesianFrame3D, angular::SMatrix{3, N, T}, linear::SMatrix{3, N, T})
-    fillerSize = 6 - N
-    return quote
-        $(Expr(:meta, :inline))
-        filler = fill(NaN, SMatrix{3, $fillerSize, T})
-        angularData = hcat(angular, filler)::SMatrix{3, 6, T, 18}
-        linearData = hcat(linear, filler)::SMatrix{3, 6, T, 18}
-        MotionSubspace{T}(body, base, frame, view(angularData, :, 1 : N), view(linearData, :, 1 : N))
+    colrange = 1 : N
+    if N == 0
+        return quote
+            $(Expr(:meta, :inline))
+            angularData = fill(NaN, SMatrix{3, 6, T, 18})
+            linearData = fill(NaN, SMatrix{3, 6, T, 18})
+            MotionSubspace{T}(body, base, frame, fast_view_for_motion_subspace(angularData, $colrange), fast_view_for_motion_subspace(linearData, $colrange))
+        end
+    elseif N == 6
+        return quote
+            $(Expr(:meta, :inline))
+            MotionSubspace{T}(body, base, frame, fast_view_for_motion_subspace(angular, $colrange), fast_view_for_motion_subspace(linear, $colrange))
+        end
+    else
+        fillerSize = 6 - N
+        L = 3 * fillerSize
+        return quote
+            $(Expr(:meta, :inline))
+            filler = fill(NaN, SMatrix{3, $fillerSize, T, $L})
+            angularData = hcat(angular, filler)::SMatrix{3, 6, T, 18}
+            linearData = hcat(linear, filler)::SMatrix{3, 6, T, 18}
+            MotionSubspace{T}(body, base, frame, fast_view_for_motion_subspace(angularData, $colrange), fast_view_for_motion_subspace(linearData, $colrange))
+        end
     end
-end
-
-function MotionSubspace{T}(body::CartesianFrame3D, base::CartesianFrame3D, frame::CartesianFrame3D, angular::SMatrix{3, 0, T}, linear::SMatrix{3, 0, T})
-    angularData = fill(NaN, SMatrix{3, 6, T})
-    linearData = fill(NaN, SMatrix{3, 6, T})
-    MotionSubspace{T}(body, base, frame, view(angularData, :, 1 : 0), view(linearData, :, 1 : 0))
-end
-
-function MotionSubspace{T}(body::CartesianFrame3D, base::CartesianFrame3D, frame::CartesianFrame3D, angular::SMatrix{3, 6, T}, linear::SMatrix{3, 6, T})
-    MotionSubspace{T}(body, base, frame, view(angular, :, 1 : 6), view(linear, :, 1 : 6))
 end
 
 convert{A}(::Type{GeometricJacobian{A}}, jac::GeometricJacobian{A}) = jac

--- a/src/third_party_addendum.jl
+++ b/src/third_party_addendum.jl
@@ -4,29 +4,29 @@ import Base: *, +, -
 
 function *{S1, S2, T, L}(A::StaticMatrix, B::ContiguousSMatrixColumnView{S1, S2, T, L})
     data = A * parent(B)
-    view(data, B.indexes[1], B.indexes[2])
+    typeof(B)(data, (:, B.indexes[2]), B.offset1, B.stride1)
 end
 
 function +{S1, S2, T, L}(A::ContiguousSMatrixColumnView{S1, S2, T, L}, B::ContiguousSMatrixColumnView{S1, S2, T, L})
     @boundscheck size(A) == size(B)
     data = parent(A) + parent(B)
-    view(data, A.indexes[1], A.indexes[2])
+    typeof(A)(data, A.indexes, A.offset1, A.stride1)
 end
 
 function -{S1, S2, T, L}(A::ContiguousSMatrixColumnView{S1, S2, T, L}, B::ContiguousSMatrixColumnView{S1, S2, T, L})
     @boundscheck size(A) == size(B)
     data = parent(A) - parent(B)
-    view(data, A.indexes[1], A.indexes[2])
+    typeof(A)(data, A.indexes, A.offset1, A.stride1)
 end
 
 function -{S1, S2, T, L}(A::ContiguousSMatrixColumnView{S1, S2, T, L})
     data = -parent(A)
-    view(data, A.indexes[1], A.indexes[2])
+    typeof(A)(data, A.indexes, A.offset1, A.stride1)
 end
 
 function *{S1, S2, T, L}(s::Number, A::ContiguousSMatrixColumnView{S1, S2, T, L})
     data = s * parent(A)
-    view(data, A.indexes[1], A.indexes[2])
+    typeof(A)(data, A.indexes, A.offset1, A.stride1)
 end
 
 # FIXME: hack to get around ambiguities

--- a/src/util.jl
+++ b/src/util.jl
@@ -34,17 +34,16 @@ function cached_download(url::String, localFileName::String, cacheDir::String = 
     fullCachePath
 end
 
-macro rtti_dispatch(typeUnion, signature)
+macro rtti_dispatch(typeTuple, signature)
     @assert signature.head == :call
     @assert length(signature.args) > 1
-    @assert typeUnion.head == :curly
-    @assert typeUnion.args[1] == :Union
+    @assert typeTuple.head == :tuple
 
     f = signature.args[1]
     args = signature.args[2 : end]
     dispatchArg = args[1]
     otherArgs = args[2 : end]
-    types = typeUnion.args[2 : end]
+    types = typeTuple.args
 
     ret = :(error("type not recognized"))
     for T in reverse(types)

--- a/test/test_mechanism_algorithms.jl
+++ b/test/test_mechanism_algorithms.jl
@@ -151,11 +151,12 @@
         @test isapprox(M2, M; atol = 1e-12)
     end
 
-    @testset "mass matrix allocation" begin
-        M = Symmetric(Matrix{Float64}(num_velocities(x), num_velocities(x)))
-        mass_matrix!(M, x) # JIT compile
-        @test @allocated(mass_matrix!(M, x)) == 0
-    end
+    # TODO: enable once StaticArrays tag with #82 is released
+    # @testset "mass matrix allocation" begin
+    #     M = Symmetric(Matrix{Float64}(num_velocities(x), num_velocities(x)))
+    #     mass_matrix!(M, x) # JIT compile
+    #     @test @allocated(mass_matrix!(M, x)) == 0
+    # end
 
     @testset "inverse dynamics / acceleration term" begin
         M = mass_matrix(x)

--- a/test/test_mechanism_algorithms.jl
+++ b/test/test_mechanism_algorithms.jl
@@ -151,6 +151,12 @@
         @test isapprox(M2, M; atol = 1e-12)
     end
 
+    @testset "mass matrix allocation" begin
+        M = Symmetric(Matrix{Float64}(num_velocities(x), num_velocities(x)))
+        mass_matrix!(M, x) # JIT compile
+        @test @allocated(mass_matrix!(M, x)) == 0
+    end
+
     @testset "inverse dynamics / acceleration term" begin
         M = mass_matrix(x)
 


### PR DESCRIPTION
* finally got rid of all allocations in `mass_matrix!` (with https://github.com/JuliaArrays/StaticArrays.jl/pull/82, which helped a great deal).
* allocations in `dynamics!` and `inverse_dynamics!` are close to zero as well now; almost there.
* fixes https://github.com/tkoolen/RigidBodyDynamics.jl/issues/109
* some other minor performance improvements.
* simplified rtti macro a bit; it now expects a tuple.

Before (with https://github.com/JuliaArrays/StaticArrays.jl/pull/82):
```
inverse_dynamics:
BenchmarkTools.Trial: 
  memory estimate:  11.63 kb
  allocs estimate:  620
  --------------
  minimum time:     50.290 μs (0.00% GC)
  median time:      51.143 μs (0.00% GC)
  mean time:        52.789 μs (1.77% GC)
  maximum time:     1.985 ms (95.97% GC)

dynamics:
BenchmarkTools.Trial: 
  memory estimate:  16.13 kb
  allocs estimate:  869
  --------------
  minimum time:     91.392 μs (0.00% GC)
  median time:      141.795 μs (0.00% GC)
  mean time:        139.169 μs (1.19% GC)
  maximum time:     2.702 ms (93.11% GC)

mass_matrix:
BenchmarkTools.Trial: 
  memory estimate:  6.69 kb
  allocs estimate:  428
  --------------
  minimum time:     44.550 μs (0.00% GC)
  median time:      45.467 μs (0.00% GC)
  mean time:        46.422 μs (0.46% GC)
  maximum time:     1.123 ms (94.81% GC)
```

After:
```
inverse_dynamics:
BenchmarkTools.Trial: 
  memory estimate:  2.91 kb
  allocs estimate:  62
  --------------
  minimum time:     42.761 μs (0.00% GC)
  median time:      43.366 μs (0.00% GC)
  mean time:        44.233 μs (0.46% GC)
  maximum time:     2.090 ms (96.62% GC)

dynamics:
BenchmarkTools.Trial: 
  memory estimate:  2.95 kb
  allocs estimate:  64
  --------------
  minimum time:     73.487 μs (0.00% GC)
  median time:      74.677 μs (0.00% GC)
  mean time:        74.885 μs (0.00% GC)
  maximum time:     261.432 μs (0.00% GC)
 
mass_matrix:
BenchmarkTools.Trial: 
  memory estimate:  0.00 bytes
  allocs estimate:  0
  --------------
  minimum time:     34.701 μs (0.00% GC)
  median time:      34.974 μs (0.00% GC)
  mean time:        35.353 μs (0.00% GC)
  maximum time:     72.627 μs (0.00% GC)
```