### PR TITLE
Munthe-Kaas integrator

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,4 +3,3 @@ StaticArrays 0.1.0
 Quaternions 0.1
 DataStructures 0.4.6
 LightXML 0.4.0
-ODE 0.2.1

--- a/src/RigidBodyDynamics.jl
+++ b/src/RigidBodyDynamics.jl
@@ -28,6 +28,7 @@ include("mechanism.jl")
 include("mechanism_state.jl")
 include("mechanism_algorithms.jl")
 include("parse_urdf.jl")
+include("ode_integrators.jl")
 include("simulate.jl")
 
 export

--- a/src/RigidBodyDynamics.jl
+++ b/src/RigidBodyDynamics.jl
@@ -12,6 +12,10 @@ using Quaternions
 using DataStructures
 using LightXML
 
+if VERSION > v"0.5"
+    import Base.Iterators: filter
+end
+
 include("util.jl")
 include("third_party_addendum.jl")
 

--- a/src/RigidBodyDynamics.jl
+++ b/src/RigidBodyDynamics.jl
@@ -11,7 +11,6 @@ import StaticArrays: similar_type
 using Quaternions
 using DataStructures
 using LightXML
-import ODE: ode45
 
 include("util.jl")
 include("third_party_addendum.jl")

--- a/src/joint_types.jl
+++ b/src/joint_types.jl
@@ -14,7 +14,10 @@ function _local_coordinates!(jt::JointType,
 end
 
 function _global_coordinates!(jt::JointType, q::AbstractVector, q0::AbstractVector, ϕ::AbstractVector)
-    q .= q0 .+ ϕ # TODO: allocates on 0.5
+    @simd for i = 1 : length(q)
+        q[i] = q0[i] + ϕ[i]
+    end
+    nothing
 end
 
 

--- a/src/mechanism_algorithms.jl
+++ b/src/mechanism_algorithms.jl
@@ -238,8 +238,8 @@ type DynamicsResult{M, T}
     dynamicsBias::Vector{T}
     biasedTorques::Vector{T}
     ẋ::Vector{T}
-    q̇::AbstractVector{T}
-    v̇::AbstractVector{T}
+    q̇::VectorSegment{T}
+    v̇::VectorSegment{T}
     accelerations::Dict{RigidBody{M}, SpatialAcceleration{T}}
     jointWrenches::Dict{RigidBody{M}, Wrench{T}}
 

--- a/src/mechanism_algorithms.jl
+++ b/src/mechanism_algorithms.jl
@@ -25,7 +25,7 @@ end
 function acceleration_wrt_ancestor{X, M, C, V}(state::MechanismState{X, M, C},
         descendant::TreeVertex{RigidBody{M}, Joint{M}},
         ancestor::TreeVertex{RigidBody{M}, Joint{M}},
-        v̇::AbstractVector{V})
+        v̇::StridedVector{V})
     mechanism = state.mechanism
     T = promote_type(C, V)
     descendantFrame = default_frame(mechanism, vertex_data(descendant))
@@ -35,7 +35,7 @@ function acceleration_wrt_ancestor{X, M, C, V}(state::MechanismState{X, M, C},
     current = descendant
     while current != ancestor
         joint = edge_to_parent_data(current)
-        v̇joint = view(v̇, mechanism.vRanges[joint]) # TODO: allocates
+        v̇joint = UnsafeVectorView(v̇, mechanism.vRanges[joint])
         jointAccel = SpatialAcceleration(motion_subspace(state, joint), v̇joint)
         accel = jointAccel + accel
         current = parent(current)
@@ -133,7 +133,7 @@ function bias_accelerations!{T, X, M}(out::Associative{RigidBody{M}, SpatialAcce
     nothing
 end
 
-function spatial_accelerations!{T, X, M}(out::Associative{RigidBody{M}, SpatialAcceleration{T}}, state::MechanismState{X, M}, v̇::AbstractVector)
+function spatial_accelerations!{T, X, M}(out::Associative{RigidBody{M}, SpatialAcceleration{T}}, state::MechanismState{X, M}, v̇::StridedVector)
     mechanism = state.mechanism
 
     # TODO: consider merging back into one loop
@@ -142,7 +142,7 @@ function spatial_accelerations!{T, X, M}(out::Associative{RigidBody{M}, SpatialA
     for vertex in non_root_vertices(state)
         body = vertex_data(vertex).body
         S = motion_subspace(vertex)
-        @inbounds v̇joint = view(v̇, velocity_range(edge_to_parent_data(vertex))) # TODO: allocates
+        v̇joint = UnsafeVectorView(v̇, velocity_range(edge_to_parent_data(vertex)))
         jointAccel = SpatialAcceleration(S, v̇joint)
         out[body] = out[vertex_data(parent(vertex)).body] + jointAccel
     end
@@ -174,7 +174,7 @@ end
 Note: pass in net wrenches as wrenches argument. wrenches argument is modified to be joint wrenches
 """
 function joint_wrenches_and_torques!{T, X, M}(
-        torquesOut::AbstractVector{T},
+        torquesOut::StridedVector{T},
         netWrenchesInJointWrenchesOut::Associative{RigidBody{M}, Wrench{T}},
         state::MechanismState{X, M})
     @boundscheck length(torquesOut) == num_velocities(state) || error("torquesOut size is wrong")
@@ -189,7 +189,7 @@ function joint_wrenches_and_torques!{T, X, M}(
         end
         jointState = edge_to_parent_data(vertex)
         jointWrench = transform(jointWrench, inv(transform_to_root(vertex))) # TODO: stay in world frame?
-        @inbounds τjoint = view(torquesOut, velocity_range(jointState)) # TODO: allocates
+        @inbounds τjoint = UnsafeVectorView(torquesOut, velocity_range(jointState))
         joint_torque!(jointState.joint, τjoint, configuration(jointState), jointWrench)
     end
 end

--- a/src/mechanism_state.jl
+++ b/src/mechanism_state.jl
@@ -273,11 +273,11 @@ end
 
 function transform_to_root(state::MechanismState, frame::CartesianFrame3D)
     body = state.mechanism.bodyFixedFrameToBody[frame]
-    transform = transform_to_root(state_vertex(state, body))
-    if transform.from != frame
-        transform = transform * find_body_fixed_frame_definition(state.mechanism, body, frame) # TODO: consider caching
+    tf = transform_to_root(state_vertex(state, body))
+    if tf.from != frame
+        tf = tf * find_body_fixed_frame_definition(state.mechanism, body, frame) # TODO: consider caching
     end
-    transform
+    tf
 end
 
 motion_subspace(state::MechanismState, joint::Joint) = motion_subspace(state_vertex(state, joint))

--- a/src/mechanism_state.jl
+++ b/src/mechanism_state.jl
@@ -343,9 +343,9 @@ function local_coordinates!(state::MechanismState, ϕ::AbstractVector, ϕ̇::Abs
         jointState = edge_to_parent_data(vertex)
         qRange = configuration_range(jointState)
         vRange = velocity_range(jointState)
-        @inbounds ϕjoint = vector_view(ϕ, vRange) # TODO: allocates
-        @inbounds ϕ̇joint = vector_view(ϕ̇, vRange) # TODO: allocates
-        @inbounds q0joint = vector_view(q0, qRange) # TODO: allocates
+        @inbounds ϕjoint = view(ϕ, vRange) # TODO: allocates
+        @inbounds ϕ̇joint = view(ϕ̇, vRange) # TODO: allocates
+        @inbounds q0joint = view(q0, qRange) # TODO: allocates
         qjoint = configuration(jointState)
         vjoint = velocity(jointState)
         local_coordinates!(jointState.joint, ϕjoint, ϕ̇joint, q0joint, qjoint, vjoint)
@@ -356,8 +356,8 @@ function global_coordinates!(state::MechanismState, q0::AbstractVector, ϕ::Abst
     mechanism = state.mechanism
     for vertex in non_root_vertices(state)
         jointState = edge_to_parent_data(vertex)
-        @inbounds q0joint = vector_view(q0, configuration_range(jointState)) # TODO: allocates
-        @inbounds ϕjoint = vector_view(ϕ, velocity_range(jointState)) # TODO: allocates
+        @inbounds q0joint = view(q0, configuration_range(jointState)) # TODO: allocates
+        @inbounds ϕjoint = view(ϕ, velocity_range(jointState)) # TODO: allocates
         qjoint = configuration(jointState)
         global_coordinates!(jointState.joint, qjoint, q0joint, ϕjoint)
     end

--- a/src/mechanism_state.jl
+++ b/src/mechanism_state.jl
@@ -337,18 +337,18 @@ function transform(state::MechanismState, accel::SpatialAcceleration, to::Cartes
     transform(accel, oldToNew, twistOfOldWrtNew, twistOfBodyWrtBase)
 end
 
-function local_coordinates!(state::MechanismState, ϕ::StridedVector, ϕ̇::StridedVector, q0::StridedVector)
+function local_coordinates!(state::MechanismState, ϕ::StridedVector, ϕd::StridedVector, q0::StridedVector)
     mechanism = state.mechanism
     for vertex in non_root_vertices(state)
         jointState = edge_to_parent_data(vertex)
         qRange = configuration_range(jointState)
         vRange = velocity_range(jointState)
         ϕjoint = UnsafeVectorView(ϕ, vRange)
-        ϕ̇joint = UnsafeVectorView(ϕ̇, vRange)
+        ϕdjoint = UnsafeVectorView(ϕd, vRange)
         q0joint = UnsafeVectorView(q0, qRange)
         qjoint = configuration(jointState)
         vjoint = velocity(jointState)
-        local_coordinates!(jointState.joint, ϕjoint, ϕ̇joint, q0joint, qjoint, vjoint)
+        local_coordinates!(jointState.joint, ϕjoint, ϕdjoint, q0joint, qjoint, vjoint)
     end
 end
 

--- a/src/mechanism_state.jl
+++ b/src/mechanism_state.jl
@@ -337,27 +337,27 @@ function transform(state::MechanismState, accel::SpatialAcceleration, to::Cartes
     transform(accel, oldToNew, twistOfOldWrtNew, twistOfBodyWrtBase)
 end
 
-function local_coordinates!(state::MechanismState, ϕ::AbstractVector, ϕ̇::AbstractVector, q0::AbstractVector)
+function local_coordinates!(state::MechanismState, ϕ::StridedVector, ϕ̇::StridedVector, q0::StridedVector)
     mechanism = state.mechanism
     for vertex in non_root_vertices(state)
         jointState = edge_to_parent_data(vertex)
         qRange = configuration_range(jointState)
         vRange = velocity_range(jointState)
-        @inbounds ϕjoint = view(ϕ, vRange) # TODO: allocates
-        @inbounds ϕ̇joint = view(ϕ̇, vRange) # TODO: allocates
-        @inbounds q0joint = view(q0, qRange) # TODO: allocates
+        ϕjoint = UnsafeVectorView(ϕ, vRange)
+        ϕ̇joint = UnsafeVectorView(ϕ̇, vRange)
+        q0joint = UnsafeVectorView(q0, qRange)
         qjoint = configuration(jointState)
         vjoint = velocity(jointState)
         local_coordinates!(jointState.joint, ϕjoint, ϕ̇joint, q0joint, qjoint, vjoint)
     end
 end
 
-function global_coordinates!(state::MechanismState, q0::AbstractVector, ϕ::AbstractVector)
+function global_coordinates!(state::MechanismState, q0::StridedVector, ϕ::StridedVector)
     mechanism = state.mechanism
     for vertex in non_root_vertices(state)
         jointState = edge_to_parent_data(vertex)
-        @inbounds q0joint = view(q0, configuration_range(jointState)) # TODO: allocates
-        @inbounds ϕjoint = view(ϕ, velocity_range(jointState)) # TODO: allocates
+        q0joint = UnsafeVectorView(q0, configuration_range(jointState))
+        ϕjoint = UnsafeVectorView(ϕ, velocity_range(jointState))
         qjoint = configuration(jointState)
         global_coordinates!(jointState.joint, qjoint, q0joint, ϕjoint)
     end

--- a/src/mechanism_state.jl
+++ b/src/mechanism_state.jl
@@ -343,9 +343,9 @@ function local_coordinates!(state::MechanismState, ϕ::AbstractVector, ϕ̇::Abs
         jointState = edge_to_parent_data(vertex)
         qRange = configuration_range(jointState)
         vRange = velocity_range(jointState)
-        @inbounds ϕjoint = view(ϕ, vRange) # TODO: allocates
-        @inbounds ϕ̇joint = view(ϕ̇, vRange) # TODO: allocates
-        @inbounds q0joint = view(q0, qRange) # TODO: allocates
+        @inbounds ϕjoint = vector_view(ϕ, vRange) # TODO: allocates
+        @inbounds ϕ̇joint = vector_view(ϕ̇, vRange) # TODO: allocates
+        @inbounds q0joint = vector_view(q0, qRange) # TODO: allocates
         qjoint = configuration(jointState)
         vjoint = velocity(jointState)
         local_coordinates!(jointState.joint, ϕjoint, ϕ̇joint, q0joint, qjoint, vjoint)
@@ -356,8 +356,9 @@ function global_coordinates!(state::MechanismState, q0::AbstractVector, ϕ::Abst
     mechanism = state.mechanism
     for vertex in non_root_vertices(state)
         jointState = edge_to_parent_data(vertex)
-        @inbounds q0joint = view(q0, configuration_range(jointState)) # TODO: allocates
-        @inbounds ϕjoint = view(ϕ, velocity_range(jointState)) # TODO: allocates
-        global_coordinates!(jointState.joint, configuration(jointState), q0joint, ϕjoint)
+        @inbounds q0joint = vector_view(q0, configuration_range(jointState)) # TODO: allocates
+        @inbounds ϕjoint = vector_view(ϕ, velocity_range(jointState)) # TODO: allocates
+        qjoint = configuration(jointState)
+        global_coordinates!(jointState.joint, qjoint, q0joint, ϕjoint)
     end
 end

--- a/src/mechanism_state.jl
+++ b/src/mechanism_state.jl
@@ -336,3 +336,23 @@ function transform(state::MechanismState, accel::SpatialAcceleration, to::Cartes
     oldToNew = inv(transform_to_root(state, to)) * oldToRoot
     transform(accel, oldToNew, twistOfOldWrtNew, twistOfBodyWrtBase)
 end
+
+function local_coordinates!(state::MechanismState, ϕ::AbstractVector, ϕ̇::AbstractVector, q0::AbstractVector)
+    mechanism = state.mechanism
+    for joint in joints(mechanism)
+        vRange = mechanism.vRanges[joint]
+        @inbounds ϕjoint = view(ϕ, vRange) # TODO: allocates
+        @inbounds ϕ̇joint = view(ϕ̇, vRange) # TODO: allocates
+        @inbounds q0joint = view(q0, mechanism.qRanges[joint]) # TODO: allocates
+        local_coordinates!(joint, ϕjoint, ϕ̇joint, q0joint, configuration(state, joint), velocity(state, joint))
+    end
+end
+
+function global_coordinates!(state::MechanismState, q0::AbstractVector, ϕ::AbstractVector)
+    mechanism = state.mechanism
+    for joint in joints(mechanism)
+        @inbounds q0joint = view(q0, mechanism.qRanges[joint]) # TODO: allocates
+        @inbounds ϕjoint = view(ϕ, mechanism.vRanges[joint]) # TODO: allocates
+        global_coordinates!(joint, configuration(state, joint), q0joint, ϕjoint)
+    end
+end

--- a/src/ode_integrators.jl
+++ b/src/ode_integrators.jl
@@ -64,7 +64,7 @@ function process{T}(storage::OdeRingBufferStorage{T}, t::T, state)
     nothing
 end
 
-immutable MuntheKaasStageCache{N, T<:Real}
+type MuntheKaasStageCache{N, T<:Real}
     q0::Vector{T} # global coordinates
     vs::SVector{N, Vector{T}} # velocity vector for each stage
     vds::SVector{N, Vector{T}} # time derivatives of vs
@@ -126,7 +126,7 @@ function step(integrator::MuntheKaasIntegrator, t::Real, state, Δt::Real)
         # Update local coordinates and velocities
         ϕ = stages.ϕs[i]
         v = stages.vs[i]
-        fill!(ϕ, 0)
+        fill!(ϕ, zero(eltype(ϕ)))
         copy!(v, velocity_vector(state))
         for j = 1 : i - 1
             aij = tableau.a[i, j]

--- a/src/ode_integrators.jl
+++ b/src/ode_integrators.jl
@@ -1,10 +1,11 @@
-immutable ButcherTableau{N, T}
+immutable ButcherTableau{N, T<:Real}
     a::SMatrix{N, N, T}
     b::SVector{N, T}
     c::SVector{N, T}
     explicit::Bool
 
     function ButcherTableau(a::AbstractMatrix{T}, b::AbstractVector{T})
+        @assert N > 0
         @assert size(a, 1) == N
         @assert size(a, 2) == N
         @assert length(b) == N
@@ -13,9 +14,7 @@ immutable ButcherTableau{N, T}
         new(SMatrix{N, N}(a), SVector{N}(b), SVector{N}(c), explicit)
     end
 end
-
 ButcherTableau{T}(a::Matrix{T}, b::Vector{T}) = ButcherTableau{length(b), T}(a, b)
-
 num_stages{N, T}(::ButcherTableau{N, T}) = N
 isexplicit(tableau::ButcherTableau) = tableau.explicit
 
@@ -28,73 +27,104 @@ function runge_kutta_4{T}(::Type{T})
     ButcherTableau{4, Float64}(a, b)
 end
 
-immutable MuntheKaasIntegrator{X, M, C, N, E}
-    state::MechanismState{X, M, C}
-    effortSource::E
-    result::DynamicsResult{C}
-    tableau::ButcherTableau{N, C}
+abstract OdeResultsSink
+initialize(::OdeResultsSink, state) = error("concrete subtypes must implement")
+process(::OdeResultsSink, t, state) = error("concrete subtypes must implement")
 
-    # TODO: extract out: integrator state
-    q0::Vector{C}
-    vstage::Vector{Vector{C}}
-    v̇stage::Vector{Vector{C}}
-    ϕstage::Vector{Vector{C}}
-    ϕ̇stage::Vector{Vector{C}}
+type OdeRingBufferStorage{T} <: OdeResultsSink
+    ts::Vector{T}
+    qs::Vector{Vector{T}}
+    vs::Vector{Vector{T}}
+    nextIndex::Int64
 
-    # TODO: extract out: integrator output
-    tout::Vector{C}
-    qout::Vector{Vector{C}}
-    vout::Vector{Vector{C}}
+    function OdeRingBufferStorage(n::Int64)
+        ts = Vector{T}(n)
+        qs = [Vector{T}() for i in 1 : n]
+        vs = [Vector{T}() for i in 1 : n]
+        new(ts, qs, vs, 1)
+    end
+end
+Base.eltype{T}(storage::OdeRingBufferStorage{T}) = T
+Base.length(storage::OdeRingBufferStorage) = length(storage.ts)
+set_num_positions!(storage::OdeRingBufferStorage, n::Int64) = for q in storage.qs resize!(q, n) end
+set_num_velocities!(storage::OdeRingBufferStorage, n::Int64) = for v in storage.vs resize!(v, n) end
 
-    function MuntheKaasIntegrator(state::MechanismState{X, M, C}, effortSource::E,
-            result::DynamicsResult{C}, tableau::ButcherTableau{N, C})
-        @assert isexplicit(tableau)
-        n = num_stages(tableau)
-        @assert n > 0
+function initialize(storage::OdeRingBufferStorage, state)
+    set_num_positions!(storage, length(configuration_vector(state)))
+    set_num_velocities(storage, length(velocity_vector(state)))
+    process!(storage, zero(eltype(storage)), stage)
+end
 
-        q0 = Vector{C}(num_positions(state))
-        vstage = [Vector{C}(num_velocities(state)) for i in 1 : n]
-        v̇stage = [Vector{C}(num_velocities(state)) for i in 1 : n]
-        ϕstage = [Vector{C}(num_velocities(state)) for i in 1 : n]
-        ϕ̇stage = [Vector{C}(num_velocities(state)) for i in 1 : n]
+function process{T}(storage::OdeRingBufferStorage{T}, t::T, state)
+    index = storage.nextIndex
+    storage.ts[index] = t
+    copy!(storage.qs[index], configuration_vector(state))
+    copy!(storage.vs[index], velocity_vector(state))
+    storage.nextIndex = index % length(storage) + 1
+    nothing
+end
 
-        tout = Vector{C}()
-        qout = Vector{C}()
-        qout = Vector{Vector{C}}()
-        vout = Vector{Vector{C}}()
-        new(state, effortSource, result, tableau, q0, vstage, v̇stage, ϕstage, ϕ̇stage, tout, qout, vout)
+immutable MuntheKaasStageCache{N, T<:Real}
+    q0::Vector{T} # global coordinates
+    vs::SVector{N, Vector{T}} # velocity vector for each stage
+    vds::SVector{N, Vector{T}} # time derivatives of vs
+    ϕs::SVector{N, Vector{T}} # local coordinates around q0 for each stage
+    ϕds::SVector{N, Vector{T}} # time derivatives of ϕs
+
+    function MuntheKaasStageCache(qLength::Int64, vLength::Int64)
+        q0 = Vector{T}(qLength)
+        vs = SVector{N, Vector{T}}((Vector{T}(vLength) for i in 1 : N)...)
+        vds = SVector{N, Vector{T}}((Vector{T}(vLength) for i in 1 : N)...)
+        ϕs = SVector{N, Vector{T}}((Vector{T}(vLength) for i in 1 : N)...)
+        ϕds = SVector{N, Vector{T}}((Vector{T}(vLength) for i in 1 : N)...)
+        new(q0, vs, vds, ϕs, ϕds)
     end
 end
 
-function MuntheKaasIntegrator{X, M, C, N, E}(state::MechanismState{X, M, C}, effortSource::E, result::DynamicsResult{C}, tableau::ButcherTableau{N, C})
-    MuntheKaasIntegrator{X, M, C, N, E}(state, effortSource, result, tableau)
+immutable MuntheKaasIntegrator{N, T<:Real, F, S<:OdeResultsSink}
+    dynamics!::F # dynamics!(vd, t, state), sets vd (time derivative of v) given time t and state
+    tableau::ButcherTableau{N, T}
+    sink::S
+    stages::MuntheKaasStageCache{N, T}
+
+    function MuntheKaasIntegrator(dynamics!::F, tableau::ButcherTableau{N, T}, sink::S)
+        @assert isexplicit(tableau)
+        stages = MuntheKaasStageCache{N, T}()
+        new(dynamics!, tableau, sink, stages)
+    end
 end
 
-function step(integrator::MuntheKaasIntegrator, t::Real, Δt::Real)
+MuntheKaasIntegrator{N, T<:Real, F, S<:OdeResultsSink}(dynamics!::F, tableau::ButcherTableau{N, T}, sink::S) = MuntheKaasIntegrator{N, T, F, S}(dynamics!, tableau, sink)
+num_stages{N}(::MuntheKaasIntegrator{N}) = N
+eltype{N, T}(::MuntheKaasIntegrator{N, T}) = T
+
+# state must be a type for which the following functions are defined:
+# - configuration_vector(state), returns the configuration vector in global coordinates
+# - velocity_vector(state), returns the velocity vector
+# - global_coordinates!(state, q0, ϕ), sets global coordinates in state based on local coordinates ϕ centered around global coordinates q0
+# - set_velocity!(state, v), sets velocity vector to v
+# - local_coordinates!(state, ϕ, ϕd, q0), converts state's global configuration q and velocity v to local coordinates centered around global coordinates q0
+function step(integrator::MuntheKaasIntegrator, t::Real, state, Δt::Real)
     tableau = integrator.tableau
-    q0 = integrator.q0
-    n = num_stages(integrator.tableau)
-    state = integrator.state
-    result = integrator.result
+    stages = integrator.stages
+    n = num_stages(integrator)
 
     # Use current configuration as the configuration around which the local coordinates for this step will be centered.
-    copy!(integrator.q0, configuration_vector(state))
+    copy!(stages.q0, configuration_vector(state))
 
     # Compute integrator stages.
     for i = 1 : n
         # Update local coordinates and velocities
-        ϕ = integrator.ϕstage[i]
-        v = integrator.vstage[i]
+        ϕ = stages.ϕs[i]
+        v = stages.vs[i]
         fill!(ϕ, 0)
         copy!(v, velocity_vector(state))
         for j = 1 : i - 1
             aij = tableau.a[i, j]
             if aij != zero(aij)
-                ϕ̇ = integrator.ϕ̇stage[j]
-                v̇ = integrator.vstage[j]
                 weight = Δt * aij
-                scaleadd!(ϕ, ϕ̇, weight)
-                scaleadd!(v, v̇, weight)
+                scaleadd!(ϕ, stages.ϕd[j], weight) # TODO: use fusing broadcast in 0.6
+                scaleadd!(v, stage.vd[j], weight) # TODO: use fusing broadcast in 0.6
             end
         end
 
@@ -102,30 +132,40 @@ function step(integrator::MuntheKaasIntegrator, t::Real, Δt::Real)
         global_coordinates!(state, q0, ϕ)
         set_velocity!(state, v)
 
-        # Poll for efforts
-        torques, externalWrenches = integrator.effortSource(t + tableau.c[i] * Δt, state)
-
         # Dynamics in global coordinates
-        dynamics!(integrator.result, integrator.state, torques, externalWrenches)
+        vd = stages.vds[i]
+        integrator.dynamics!(vd, t + Δt * tableau.c[i], state)
 
-        # Convert back to local coordinates and set v̇
-        ϕ̇ = integrator.ϕ̇stage[i]
-        v̇ = integrator.v̇stage[i]
-        a = rand(length(ϕ)) # FIXME
-        local_coordinates!(state, a, ϕ̇, q0)
-        copy!(v̇, result.v̇)
+        # Convert back to local coordinates TODO: ϕ not needed, just ϕd!
+        ϕd = stages.ϕds[i]
+        local_coordinates!(state, ϕ, ϕd, q0)
     end
 
     # Combine stages (store in vector for first step)
-    ϕ = integrator.ϕstage[1]
-    v = integrator.vstage[1]
+    ϕ = stages.ϕ[1]
+    v = stages.v[1]
     scale!(ϕ, tableau.b[1] * Δt)
     scale!(v, tableau.b[1] * Δt)
     for i = 2 : n
-        scaleadd!(ϕ, integrator.ϕstage[i], tableau.b[i] * Δt)
-        scaleadd!(v, integrator.vstage[i], tableau.b[i] * Δt)
+        scaleadd!(ϕ, stages.ϕ[i], tableau.b[i] * Δt) # TODO: use fusing broadcast in 0.6
+        scaleadd!(v, stages.v[i], tableau.b[i] * Δt) # TODO: use fusing broadcast in 0.6
     end
 
     # Convert from local to global coordinates
     global_coordinates!(state, q0, ϕ)
+    set_velocity!(state, v)
+
+    nothing
+end
+
+function integrate(integrator::MuntheKaasIntegrator, state0, finalTime, Δt)
+    T = eltype(integrator)
+    t = zero(T)
+    state = state0
+    initialize(integrator.sink, state)
+    while t < finalTime
+        step(integrator, state, Δt)
+        t += Δt
+        process(integrator.sink, t, state)
+    end
 end

--- a/src/ode_integrators.jl
+++ b/src/ode_integrators.jl
@@ -1,13 +1,3 @@
-# Described in
-# Andrle, Michael S., and John L. Crassidis.
-# "Geometric integration of quaternions."
-# Journal of Guidance, Control, and Dynamics 36.6 (2013): 1762-1767.
-
-# A crucial step is ‘pulling back’ the equation from G to g using exp.
-# need function: exp!(joint, q, ϕ); rotation vector to quaternion; 'canonical coordinates of the first kind'
-# need function: log!(joint, ϕ, q); (local) quaternion to rotation vector
-# need function: dexp_inv!(joint, ϕ̇, ϕ, v); ϕ being local coordinates centred about the original configuration
-
 immutable ButcherTableau{N, T}
     a::SMatrix{N, N, T}
     b::SVector{N, T}
@@ -29,25 +19,113 @@ ButcherTableau{T}(a::Matrix{T}, b::Vector{T}) = ButcherTableau{length(b), T}(a, 
 num_stages{N, T}(::ButcherTableau{N, T}) = N
 isexplicit(tableau::ButcherTableau) = tableau.explicit
 
-function CrouchGrossman3{T}(::Type{T})
-    a = zeros(T, 3, 3)
-    a[2, 1] = 3 / 4
-    a[3, 1] = 119 / 216
-    a[3, 2] = 17 / 108
-    b = T[13 / 51, -2 / 3, 24 / 17]
-    ButcherTableau(a, b)
+function runge_kutta_4{T}(::Type{T})
+    a = zeros(T, 4, 4)
+    a[2, 1] = 1/2
+    a[3, 2] = 1/2
+    a[4, 3] = 1/2
+    b = T[1/6, 1/3, 1/3, 1/6]
+    ButcherTableau{4, Float64}(a, b)
 end
 
-type LieIntegrator{X, M, C}
+immutable MuntheKaasIntegrator{X, M, C, N, E}
     state::MechanismState{X, M, C}
-    tableau::ExplicitButcherTableau{C} #TODO: assert isexplicit
+    effortSource::E
+    result::DynamicsResult{C}
+    tableau::ButcherTableau{N, C}
+
+    # TODO: extract out: integrator state
+    q0::Vector{C}
+    vstage::Vector{Vector{C}}
+    v̇stage::Vector{Vector{C}}
+    ϕstage::Vector{Vector{C}}
+    ϕ̇stage::Vector{Vector{C}}
+
+    # TODO: extract out: integrator output
+    tout::Vector{C}
+    qout::Vector{Vector{C}}
+    vout::Vector{Vector{C}}
+
+    function MuntheKaasIntegrator(state::MechanismState{X, M, C}, effortSource::E,
+            result::DynamicsResult{C}, tableau::ButcherTableau{N, C})
+        @assert isexplicit(tableau)
+        n = num_stages(tableau)
+        @assert n > 0
+
+        q0 = Vector{C}(num_positions(state))
+        vstage = [Vector{C}(num_velocities(state)) for i in 1 : n]
+        v̇stage = [Vector{C}(num_velocities(state)) for i in 1 : n]
+        ϕstage = [Vector{C}(num_velocities(state)) for i in 1 : n]
+        ϕ̇stage = [Vector{C}(num_velocities(state)) for i in 1 : n]
+
+        tout = Vector{C}()
+        qout = Vector{C}()
+        qout = Vector{Vector{C}}()
+        vout = Vector{Vector{C}}()
+        new(state, effortSource, result, tableau, q0, vstage, v̇stage, ϕstage, ϕ̇stage, tout, qout, vout)
+    end
 end
 
-function step(integrator::LieIntegrator, Δt::Real)
+function MuntheKaasIntegrator{X, M, C, N, E}(state::MechanismState{X, M, C}, effortSource::E, result::DynamicsResult{C}, tableau::ButcherTableau{N, C})
+    MuntheKaasIntegrator{X, M, C, N, E}(state, effortSource, result, tableau)
 end
 
-function (integrator::LieCrouchGrossman3)()
+function step(integrator::MuntheKaasIntegrator, t::Real, Δt::Real)
+    tableau = integrator.tableau
+    q0 = integrator.q0
+    n = num_stages(integrator.tableau)
     state = integrator.state
-    q = configuration_vector(state)
-    v = velocity_vector(state)
+    result = integrator.result
+
+    # Use current configuration as the configuration around which the local coordinates for this step will be centered.
+    copy!(integrator.q0, configuration_vector(state))
+
+    # Compute integrator stages.
+    for i = 1 : n
+        # Update local coordinates and velocities
+        ϕ = integrator.ϕstage[i]
+        v = integrator.vstage[i]
+        fill!(ϕ, 0)
+        copy!(v, velocity_vector(state))
+        for j = 1 : i - 1
+            aij = tableau.a[i, j]
+            if aij != zero(aij)
+                ϕ̇ = integrator.ϕ̇stage[j]
+                v̇ = integrator.vstage[j]
+                weight = Δt * aij
+                scaleadd!(ϕ, ϕ̇, weight)
+                scaleadd!(v, v̇, weight)
+            end
+        end
+
+        # Convert from local to global coordinates and set state
+        global_coordinates!(state, q0, ϕ)
+        set_velocity!(state, v)
+
+        # Poll for efforts
+        torques, externalWrenches = integrator.effortSource(t + tableau.c[i] * Δt, state)
+
+        # Dynamics in global coordinates
+        dynamics!(integrator.result, integrator.state, torques, externalWrenches)
+
+        # Convert back to local coordinates and set v̇
+        ϕ̇ = integrator.ϕ̇stage[i]
+        v̇ = integrator.v̇stage[i]
+        a = rand(length(ϕ)) # FIXME
+        local_coordinates!(state, a, ϕ̇, q0)
+        copy!(v̇, result.v̇)
+    end
+
+    # Combine stages (store in vector for first step)
+    ϕ = integrator.ϕstage[1]
+    v = integrator.vstage[1]
+    scale!(ϕ, tableau.b[1] * Δt)
+    scale!(v, tableau.b[1] * Δt)
+    for i = 2 : n
+        scaleadd!(ϕ, integrator.ϕstage[i], tableau.b[i] * Δt)
+        scaleadd!(v, integrator.vstage[i], tableau.b[i] * Δt)
+    end
+
+    # Convert from local to global coordinates
+    global_coordinates!(state, q0, ϕ)
 end

--- a/src/ode_integrators.jl
+++ b/src/ode_integrators.jl
@@ -1,0 +1,53 @@
+# Described in
+# Andrle, Michael S., and John L. Crassidis.
+# "Geometric integration of quaternions."
+# Journal of Guidance, Control, and Dynamics 36.6 (2013): 1762-1767.
+
+# A crucial step is ‘pulling back’ the equation from G to g using exp.
+# need function: exp!(joint, q, ϕ); rotation vector to quaternion; 'canonical coordinates of the first kind'
+# need function: log!(joint, ϕ, q); (local) quaternion to rotation vector
+# need function: dexp_inv!(joint, ϕ̇, ϕ, v); ϕ being local coordinates centred about the original configuration
+
+immutable ButcherTableau{N, T}
+    a::SMatrix{N, N, T}
+    b::SVector{N, T}
+    c::SVector{N, T}
+    explicit::Bool
+
+    function ButcherTableau(a::AbstractMatrix{T}, b::AbstractVector{T})
+        @assert size(a, 1) == N
+        @assert size(a, 2) == N
+        @assert length(b) == N
+        c = vec(sum(a, 2))
+        explicit = all(triu(a) .== 0)
+        new(SMatrix{N, N}(a), SVector{N}(b), SVector{N}(c), explicit)
+    end
+end
+
+ButcherTableau{T}(a::Matrix{T}, b::Vector{T}) = ButcherTableau{length(b), T}(a, b)
+
+num_stages{N, T}(::ButcherTableau{N, T}) = N
+isexplicit(tableau::ButcherTableau) = tableau.explicit
+
+function CrouchGrossman3{T}(::Type{T})
+    a = zeros(T, 3, 3)
+    a[2, 1] = 3 / 4
+    a[3, 1] = 119 / 216
+    a[3, 2] = 17 / 108
+    b = T[13 / 51, -2 / 3, 24 / 17]
+    ButcherTableau(a, b)
+end
+
+type LieIntegrator{X, M, C}
+    state::MechanismState{X, M, C}
+    tableau::ExplicitButcherTableau{C} #TODO: assert isexplicit
+end
+
+function step(integrator::LieIntegrator, Δt::Real)
+end
+
+function (integrator::LieCrouchGrossman3)()
+    state = integrator.state
+    q = configuration_vector(state)
+    v = velocity_vector(state)
+end

--- a/src/parse_urdf.jl
+++ b/src/parse_urdf.jl
@@ -103,7 +103,7 @@ function parse_urdf{T}(::Type{T}, filename)
         child = nameToVertex[attribute(find_element(xmlJoint, "child"), "link")]
         insert!(parent, child, xmlJoint)
     end
-    roots = filter(isroot, vertices)
+    roots = collect(filter(isroot, vertices))
     length(roots) != 1 && error("Can only handle a single root")
     tree = roots[1]
 

--- a/src/third_party_addendum.jl
+++ b/src/third_party_addendum.jl
@@ -35,7 +35,7 @@ _mul(a, b) = a * b
 # TODO: too specific
 function _mul{S1, S2, TA, L, Tb}(
         A::ContiguousSMatrixColumnView{S1, S2, TA, L},
-        b::StridedVector{Tb})
+        b::Union{StridedVector{Tb}, UnsafeVectorView{Tb}})
     @boundscheck size(A, 2) == size(b, 1) || error("size mismatch")
     ret = zeros(SVector{S1, promote_type(TA, Tb)})
     for i = 1 : size(A, 2)

--- a/src/tree.jl
+++ b/src/tree.jl
@@ -2,6 +2,10 @@ module TreeDataStructure
 
 import Base: showcompact, show, parent, findfirst, map!, insert!, copy
 
+if VERSION > v"0.5"
+    import Base.Iterators: filter
+end
+
 export
     # types
     Tree,

--- a/src/util.jl
+++ b/src/util.jl
@@ -80,6 +80,7 @@ else
     sub!(out, a, b) = broadcast!(-, out, a, b)
 end
 
+# TODO: use fusing broadcast instead of this function in 0.6, where this doesn't allocate.
 @inline function scaleadd!(a::AbstractVector, b::AbstractVector, c::Number)
     @boundscheck length(a) == length(b) || error("size mismatch")
     @simd for i in eachindex(a)

--- a/src/util.jl
+++ b/src/util.jl
@@ -66,7 +66,7 @@ else
     sub!(out, a, b) = broadcast!(-, out, a, b)
 end
 
-function scaleadd!(a::AbstractVector, b::AbstractVector, c::Number)
+@inline function scaleadd!(a::AbstractVector, b::AbstractVector, c::Number)
     @boundscheck length(a) == length(b) || error("size mismatch")
     @simd for i in eachindex(a)
         @inbounds a[i] = a[i] + b[i] * c
@@ -212,4 +212,8 @@ end
     angular = cross(xω, yω)
     linear = cross(xω, yv) + cross(xv, yω)
     angular, linear
+end
+
+@inline function vector_view{T}(v::Vector{T}, range::UnitRange{Int64})
+    VectorSegment{T}(v, (range,), 0, 1)
 end

--- a/src/util.jl
+++ b/src/util.jl
@@ -68,19 +68,14 @@ end
 
 typealias ContiguousSMatrixColumnView{S1, S2, T, L} SubArray{T,2,SMatrix{S1, S2, T, L},Tuple{Colon,UnitRange{Int64}},true}
 
-if VERSION < v"0.6-" # TODO: get rid of sub! after moving to 0.6. broadcast! allocates in 0.5; fixed in 0.6.
-    function sub!(out, a, b)
-        @boundscheck length(out) == length(a) || error("size mismatch")
-        @boundscheck length(out) == length(b) || error("size mismatch")
-        @simd for i in eachindex(out)
-            @inbounds out[i] = a[i] - b[i]
-        end
+# TODO: use fusing broadcast instead of these functions in 0.6, where they don't allocate.
+function sub!(out, a, b)
+    @boundscheck length(out) == length(a) || error("size mismatch")
+    @boundscheck length(out) == length(b) || error("size mismatch")
+    @simd for i in eachindex(out)
+        @inbounds out[i] = a[i] - b[i]
     end
-else
-    sub!(out, a, b) = broadcast!(-, out, a, b)
 end
-
-# TODO: use fusing broadcast instead of this function in 0.6, where this doesn't allocate.
 @inline function scaleadd!(a::AbstractVector, b::AbstractVector, c::Number)
     @boundscheck length(a) == length(b) || error("size mismatch")
     @simd for i in eachindex(a)

--- a/src/util.jl
+++ b/src/util.jl
@@ -66,6 +66,13 @@ else
     sub!(out, a, b) = broadcast!(-, out, a, b)
 end
 
+function scaleadd!(a::AbstractVector, b::AbstractVector, c::Number)
+    @boundscheck length(a) == length(b) || error("size mismatch")
+    @simd for i in eachindex(a)
+        @inbounds a[i] = a[i] + b[i] * c
+    end
+end
+
 
 #=
 Geometry utilities

--- a/src/util.jl
+++ b/src/util.jl
@@ -69,7 +69,7 @@ end
 @inline function scaleadd!(a::AbstractVector, b::AbstractVector, c::Number)
     @boundscheck length(a) == length(b) || error("size mismatch")
     @simd for i in eachindex(a)
-        @inbounds a[i] = a[i] + b[i] * c
+        @inbounds a[i] += b[i] * c
     end
 end
 
@@ -212,8 +212,4 @@ end
     angular = cross(xω, yω)
     linear = cross(xω, yv) + cross(xv, yω)
     angular, linear
-end
-
-@inline function vector_view{T}(v::Vector{T}, range::UnitRange{Int64})
-    VectorSegment{T}(v, (range,), 0, 1)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,10 @@ using Quaternions
 using StaticArrays
 import ForwardDiff
 
+if VERSION > v"0.5"
+    import Base.Iterators: filter
+end
+
 # useful utility function for computing time derivatives.
 create_autodiff(x, dx) = [ForwardDiff.Dual(x[i], dx[i]) for i in 1 : length(x)]
 

--- a/test/test_mechanism_algorithms.jl
+++ b/test/test_mechanism_algorithms.jl
@@ -357,12 +357,10 @@
         x = MechanismState(Float64, acrobot)
         rand!(x)
         total_energy_before = potential_energy(x) + kinetic_energy(x)
-        tspan = linspace(0., 1., 1e4)
-        times, states = simulate(x, tspan)
-        set!(x, states[end])
+        times, qs, vs = simulate(x, 1.)
+        set_configuration!(x, qs[end])
+        set_velocity!(x, vs[end])
         total_energy_after = potential_energy(x) + kinetic_energy(x)
-
-        # fairly loose tolerance here; should use geometric integrator:
-        @test isapprox(total_energy_after, total_energy_before, atol = 1e-1)
+        @test isapprox(total_energy_after, total_energy_before, atol = 1e-3)
     end
 end

--- a/test/test_mechanism_manipulation.jl
+++ b/test/test_mechanism_manipulation.jl
@@ -9,8 +9,8 @@
         for body in bodies(mechanism2)
             for i = 1 : 5
                 frame = CartesianFrame3D("frame_$i")
-                transform = rand(Transform3D{Float64}, frame, body.frame)
-                add_body_fixed_frame!(mechanism2, body, transform)
+                tf = rand(Transform3D{Float64}, frame, body.frame)
+                add_body_fixed_frame!(mechanism2, body, tf)
                 additionalFrames[frame] = body
             end
         end
@@ -64,7 +64,7 @@
         rand!(state)
         q = configuration_vector(state)
         M = mass_matrix(state)
-        nonFixedJointVertices = filter(v -> !isa(edge_to_parent_data(v).jointType, Fixed), non_root_vertices(mechanism))
+        nonFixedJointVertices = collect(filter(v -> !isa(edge_to_parent_data(v).jointType, Fixed), non_root_vertices(mechanism)))
 
         remove_fixed_joints!(mechanism)
         @test non_root_vertices(mechanism) == nonFixedJointVertices


### PR DESCRIPTION
Implements a fixed-step Munthe-Kaas integrator that is able to properly handle e.g. the parameterization of orientation using a unit quaternion with the `QuaternionFloating` joint type. Fixes https://github.com/tkoolen/RigidBodyDynamics.jl/issues/86.

Also introduces and uses `UnsafeVectorView`, a lightweight view that doesn't allocate but also isn't GC-safe (used only where it is safe to do so). Reduces allocations for `inverse_dynamics!` to zero.