### PR TITLE
Turn framecheck into a macro, base off of boundscheck.

### DIFF
--- a/src/joint.jl
+++ b/src/joint.jl
@@ -81,7 +81,7 @@ end
 function joint_torque!{M}(joint::Joint{M}, τ::AbstractVector, q::AbstractVector, joint_wrench::Wrench)::Void
     @boundscheck check_num_velocities(joint, τ)
     @boundscheck check_num_positions(joint, q)
-    framecheck(joint_wrench.frame, joint.frameAfter)
+    @framecheck(joint_wrench.frame, joint.frameAfter)
     @rtti_dispatch (QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}) _joint_torque!(joint.jointType, τ, q, joint_wrench)
 end
 

--- a/src/mechanism.jl
+++ b/src/mechanism.jl
@@ -143,14 +143,14 @@ function attach!{T}(m::Mechanism{T}, parentBody::RigidBody{T}, joint::Joint, joi
     vertex = insert!(tree(m), childBody, joint, parentBody)
 
     # define where joint is attached on parent body
-    framecheck(jointToParent.from, joint.frameBefore)
+    @framecheck(jointToParent.from, joint.frameBefore)
     add_body_fixed_frame!(m, parentBody, jointToParent)
 
     # add identity transform from frame after joint to itself
     add_body_fixed_frame!(m, childBody, Transform3D{T}(joint.frameAfter, joint.frameAfter))
 
     # define where child is attached to joint
-    framecheck(childToJoint.from, childBody.frame)
+    @framecheck(childToJoint.from, childBody.frame)
     add_body_fixed_frame!(m, childBody, childToJoint)
 
     canonicalize_frame_definitions!(m, vertex)

--- a/src/mechanism_algorithms.jl
+++ b/src/mechanism_algorithms.jl
@@ -64,7 +64,7 @@ function potential_energy{X, M, C}(state::MechanismState{X, M, C})
     m = num_cols(mat)
     @boundscheck (rowstart > 0 && rowstart + n - 1 <= size(out, 1)) || error("size mismatch")
     @boundscheck (colstart > 0 && colstart + m - 1 <= size(out, 2)) || error("size mismatch")
-    framecheck(jac.frame, mat.frame)
+    @framecheck(jac.frame, mat.frame)
 
     for col = 1 : m
         outcol = colstart + col - 1


### PR DESCRIPTION
`framecheck` was kind of broken; turning it off using RIGID_BODY_DYNAMICS_RELEASE was actually not working as expected. Now basing it off of `@boundscheck`: frame checks are turned off when Julia is run with `--check-bounds=no`. Also turned `framecheck` into a macro akin to `@assert` so that it prints a nicer error message.