### PR TITLE
Improve framecheck

### DIFF
--- a/src/RigidBodyDynamics.jl
+++ b/src/RigidBodyDynamics.jl
@@ -135,6 +135,8 @@ export
     inverse_dynamics,
     dynamics!,
     parse_urdf,
-    simulate
+    simulate,
+    # macros
+    @framecheck
 
 end # module

--- a/src/frames.jl
+++ b/src/frames.jl
@@ -30,10 +30,17 @@ show(io::IO, frame::CartesianFrame3D) = print(io, "CartesianFrame3D: \"$(name(fr
 
 # Check that frames match (only when bounds checks are turned on).
 macro framecheck(f1, f2)
-    failure = :($f1 != $f2)
-    msg = string(failure)
+    symname1 = string(f1)
+    symname2 = string(f2)
     ret = quote
-        @boundscheck $failure && throw(ArgumentError($msg))
+        @boundscheck begin
+            if $f1 != $f2
+                name1, name2 = name($f1), name($f2)
+                id1, id2 = ($f1).id, ($f2).id
+                msg = "$($symname1) (\"$name1\", id = $id1) ≠ $($symname2) (\"$name2\", id = $id2)"
+                throw(ArgumentError(msg))
+            end
+        end
     end
     :($(esc(ret)))
 end

--- a/test/test_frames.jl
+++ b/test/test_frames.jl
@@ -6,6 +6,12 @@
     @test name(f1) == f1name
     name(f2) # just to make sure it doesn't crash
     @test f2 != f3
+    @boundscheck begin
+        # only throws when bounds checks are enabled:
+        @test_throws ArgumentError @framecheck(f1, f2)
+        @test_throws ArgumentError @framecheck(f2, f3)
+    end
+    @framecheck(f1, f1)
 
     t1 = rand(Transform3D{Float64}, f2, f1)
     @test isapprox(t1 * inv(t1), Transform3D{Float64}(f1))


### PR DESCRIPTION
New error message shows symbol names, as well as frame names and ids for easier debugging:

```julia
julia> a = CartesianFrame3D("1");
julia> b = CartesianFrame3D("2");
julia> @framecheck a b
ERROR: ArgumentError: a ("1", id = 0) ≠ b ("2", id = 1)
```