### PR TITLE
Basic documentation using Documenter.jl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@
 *.jl.mem
 deps/deps.jl
 *.ipynb_checkpoints
+docs/build/
+docs/site/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,5 @@ script:
   # Note: PYTHON env is to ensure that PyCall uses the Conda.jl package's Miniconda distribution within Julia. Otherwise the sympy Python module won't be installed/imported properly.
 after_success:
   - julia -e 'cd(Pkg.dir("RigidBodyDynamics")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+  - julia -e 'Pkg.add("Documenter")'
+  - julia -e 'cd(Pkg.dir("RigidBodyDynamics")); include(joinpath("docs", "make.jl"))'

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ os:
   - linux
 #  - osx
 julia:
-  - 0.5
+  - release
   - nightly
 matrix:
   allow_failures:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.org/tkoolen/RigidBodyDynamics.jl.svg?branch=master)](https://travis-ci.org/tkoolen/RigidBodyDynamics.jl)
 [![codecov.io](https://codecov.io/github/tkoolen/RigidBodyDynamics.jl/coverage.svg?branch=master)](https://codecov.io/github/tkoolen/RigidBodyDynamics.jl?branch=master)
+[![](https://img.shields.io/badge/docs-latest-blue.svg)](https://USER_NAME.github.io/PACKAGE_NAME.jl/latest)
 
 RigidBodyDynamics.jl is a small rigid body dynamics library for Julia. It was inspired by the [IHMCRoboticsToolkit](https://bitbucket.org/ihmcrobotics/ihmc-open-robotics-software) from the Institute for Human and Machine Cognition, and by [Drake](http://drake.mit.edu).
 
@@ -10,111 +11,3 @@ RigidBodyDynamics.jl is a small rigid body dynamics library for Julia. It was in
 * December 6, 2016: [tagged version 0.0.3](https://github.com/JuliaLang/METADATA.jl/pull/7183).
 * October 28, 2016: [tagged version 0.0.2](https://github.com/JuliaLang/METADATA.jl/pull/6896).
 * October 24, 2016: [tagged version 0.0.1](https://github.com/JuliaLang/METADATA.jl/pull/6831).
-
-## Key features
-* easy creation of general rigid body mechanisms (including basic [URDF](http://wiki.ros.org/urdf) parsing)
-* extensive checks that verify that coordinate systems match before computation: the goal is to make reference frame mistakes impossible
-* support for automatic differentiation using e.g. [ForwardDiff.jl](https://github.com/JuliaDiff/ForwardDiff.jl)
-* flexible caching of intermediate results to prevent doing double work
-* fairly small codebase and few dependencies
-
-## Current functionality
-* kinematics/transforming points and free vectors from one coordinate system to another
-* transforming wrenches, momenta (spatial force vectors) and twists and their derivatives (spatial motion vectors) from one coordinate system to another
-* relative twists/spatial accelerations between bodies
-* kinetic/potential energy
-* center of mass
-* geometric/basic/spatial Jacobians
-* momentum
-* momentum matrix
-* momentum rate bias (= momentum matrix time derivative multiplied by joint velocity vector)
-* mass matrix (composite rigid body algorithm)
-* inverse dynamics (recursive Newton-Euler)
-* dynamics
-
-The (forward) dynamics algorithm is currently rudimentary; it just computes the mass matrix and the bias term (using the inverse dynamics algorithm), and then solves for joint accelerations without exploiting sparsity.
-
-Closed loop systems and contact are not yet supported.
-
-## Benchmarks
-Run `perf/runbenchmarks.jl` (`-O3` and `--check-bounds=no` flags recommended) to see benchmark results for the Atlas robot (v5) in the following scenarios:
-
-1. Compute the joint-space mass matrix.
-1. Do inverse dynamics.
-1. Do forward dynamics.
-
-Note that results on Travis builds are **not at all** representative because of code coverage. Results on a recent, fast machine with version 0.0.4:
-
-Output of `versioninfo()`:
-```
-Julia Version 0.5.0
-Commit 3c9d753 (2016-09-19 18:14 UTC)
-Platform Info:
-  System: Linux (x86_64-pc-linux-gnu)
-  CPU: Intel(R) Core(TM) i7-6950X CPU @ 3.00GHz
-  WORD_SIZE: 64
-  BLAS: libopenblas (USE64BITINT DYNAMIC_ARCH NO_AFFINITY Haswell)
-  LAPACK: libopenblas64_
-  LIBM: libopenlibm
-  LLVM: libLLVM-3.7.1 (ORCJIT, broadwell)
-```
-Mass matrix:
-```
-  memory estimate:  0.00 bytes
-  allocs estimate:  0
-  --------------
-  minimum time:     23.034 μs (0.00% GC)
-  median time:      23.364 μs (0.00% GC)
-  mean time:        23.546 μs (0.00% GC)
-  maximum time:     52.605 μs (0.00% GC)
-  --------------
-  samples:          10000
-  evals/sample:     1
-  time tolerance:   5.00%
-  memory tolerance: 1.00%
-```
-
-Inverse dynamics:
-```
-  memory estimate:  0.00 bytes
-  allocs estimate:  0
-  --------------
-  minimum time:     29.178 μs (0.00% GC)
-  median time:      29.704 μs (0.00% GC)
-  mean time:        30.276 μs (0.00% GC)
-  maximum time:     65.232 μs (0.00% GC)
-  --------------
-  samples:          10000
-  evals/sample:     1
-  time tolerance:   5.00%
-  memory tolerance: 1.00%
-```
-
-Forward dynamics:
-```
-  memory estimate:  48.00 bytes
-  allocs estimate:  2
-  --------------
-  minimum time:     53.336 μs (0.00% GC)
-  median time:      82.928 μs (0.00% GC)
-  mean time:        83.334 μs (0.00% GC)
-  maximum time:     208.453 μs (0.00% GC)
-  --------------
-  samples:          10000
-  evals/sample:     1
-  time tolerance:   5.00%
-  memory tolerance: 1.00%
-```
-
-## Related packages
-* [RigidBodyTreeInspector.jl](https://github.com/rdeits/RigidBodyTreeInspector.jl) - 3D visualization of RigidBodyDynamics.jl `Mechanism`s using [Director](https://github.com/RobotLocomotion/director).
-
-## Citing this library
-```
-@misc{rigidbodydynamicsjl,
- author = "Twan Koolen and contributors",
- title = "RigidBodyDynamics.jl",
- year = 2016,
- url = "https://github.com/tkoolen/RigidBodyDynamics.jl"
-}
-```

--- a/REQUIRE
+++ b/REQUIRE
@@ -3,3 +3,4 @@ StaticArrays 0.1.0
 Rotations 0.3.3
 DataStructures 0.4.6
 LightXML 0.4.0
+DocStringExtensions 0.3.1

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -11,3 +11,7 @@ deploydocs(
     julia  = "release",
     osname = "linux"
 )
+
+deploydocs(
+    repo = "github.com/tkoolen/RigidBodyDynamics.jl.git"
+)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,6 +8,6 @@ makedocs(
 deploydocs(
     deps   = Deps.pip("pygments", "mkdocs", "python-markdown-math"),
     repo = "github.com/tkoolen/RigidBodyDynamics.jl.git",
-    julia  = "0.5",
+    julia  = "release",
     osname = "linux"
 )

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,10 +8,6 @@ makedocs(
 deploydocs(
     deps   = Deps.pip("pygments", "mkdocs", "python-markdown-math"),
     repo = "github.com/tkoolen/RigidBodyDynamics.jl.git",
-    julia  = "release",
+    julia  = "0.5",
     osname = "linux"
-)
-
-deploydocs(
-    repo = "github.com/tkoolen/RigidBodyDynamics.jl.git"
 )

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,13 @@
+using Documenter, RigidBodyDynamics
+
+makedocs(
+    # options
+    modules = [RigidBodyDynamics]
+)
+
+deploydocs(
+    deps   = Deps.pip("pygments", "mkdocs", "python-markdown-math"),
+    repo = "github.com/tkoolen/RigidBodyDynamics.jl.git",
+    julia  = "release",
+    osname = "linux"
+)

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,0 +1,24 @@
+site_name:        RigidBodyDynamics.jl
+repo_url:         https://github.com/tkoolen/RigidBodyDynamics.jl
+site_description: RigidBodyDynamics.jl Documentation
+site_author:      tkoolen
+
+theme: readthedocs
+
+extra_css:
+  - assets/Documenter.css
+
+extra_javascript:
+  - https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML
+  - assets/mathjaxhelper.js
+
+markdown_extensions:
+  - extra
+  - tables
+  - fenced_code
+  - mdx_math
+
+docs_dir: 'build'
+
+pages:
+  - Home: index.md

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -29,3 +29,4 @@ pages:
   - 'Mechanism': 'mechanism.md'
   - 'MechanismState': mechanismstate.md
   - 'Kinematics/dynamics algorithms': 'algorithms.md'
+  - 'Simulation': 'simulation.md'

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -30,3 +30,4 @@ pages:
   - 'MechanismState': mechanismstate.md
   - 'Kinematics/dynamics algorithms': 'algorithms.md'
   - 'Simulation': 'simulation.md'
+  - 'Benchmarks': 'benchmarks.md'

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -23,8 +23,9 @@ docs_dir: 'build'
 pages:
   - 'Home': 'index.md'
   - 'Quick start guide': 'quickstart.md'
-  - 'Mechanism': 'mechanism.md'
-  - 'Algorithms': 'algorithms.md'
+  - 'Spatial vector algebra': 'spatial.md'
   - 'Joints': 'joints.md'
   - 'Rigid bodies': 'rigidbody.md'
-  - 'Spatial vector algebra': 'spatial.md'
+  - 'Mechanism': 'mechanism.md'
+  - 'MechanismState': mechanismstate.md
+  - 'Kinematics/dynamics algorithms': 'algorithms.md'

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -22,5 +22,9 @@ docs_dir: 'build'
 
 pages:
   - 'Home': 'index.md'
+  - 'Quick start guide': 'quickstart.md'
+  - 'Mechanism': 'mechanism.md'
+  - 'Algorithms': 'algorithms.md'
   - 'Joints': 'joints.md'
-  - 'Rigid Bodies': 'rigidbody.md'
+  - 'Rigid bodies': 'rigidbody.md'
+  - 'Spatial vector algebra': 'spatial.md'

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name:        RigidBodyDynamics.jl
-repo_url:         https://github.com/tkoolen/RigidBodyDynamics.jl
+repo_url:         https://github.com/tkoolen/RigidBodyDynamics.jl/
 site_description: RigidBodyDynamics.jl Documentation
-site_author:      tkoolen
+site_author:      Twan Koolen
 
 theme: readthedocs
 
@@ -21,4 +21,6 @@ markdown_extensions:
 docs_dir: 'build'
 
 pages:
-  - Home: index.md
+  - 'Home': 'index.md'
+  - 'Joints': 'joints.md'
+  - 'Rigid Bodies': 'rigidbody.md'

--- a/docs/src/algorithms.md
+++ b/docs/src/algorithms.md
@@ -1,3 +1,9 @@
+# Index
+```@index
+Pages   = ["algorithms.md"]
+Order   = [:type, :function]
+```
+
 # `DynamicsResult`
 ```@docs
 DynamicsResult

--- a/docs/src/algorithms.md
+++ b/docs/src/algorithms.md
@@ -1,5 +1,6 @@
 # Algorithms
 
+## Index
 ```@index
 Pages   = ["algorithms.md"]
 Order   = [:type, :function]

--- a/docs/src/algorithms.md
+++ b/docs/src/algorithms.md
@@ -1,3 +1,9 @@
+# `DynamicsResult`
+```@docs
+DynamicsResult
+```
+
+# Functions
 ```@autodocs
 Modules = [RigidBodyDynamics]
 Order   = [:function]

--- a/docs/src/algorithms.md
+++ b/docs/src/algorithms.md
@@ -1,0 +1,5 @@
+```@autodocs
+Modules = [RigidBodyDynamics]
+Order   = [:function]
+Pages   = ["mechanism_algorithms.jl"]
+```

--- a/docs/src/algorithms.md
+++ b/docs/src/algorithms.md
@@ -1,15 +1,16 @@
-# Index
+# Algorithms
+
 ```@index
 Pages   = ["algorithms.md"]
 Order   = [:type, :function]
 ```
 
-# `DynamicsResult`
+## `DynamicsResult`
 ```@docs
 DynamicsResult
 ```
 
-# Functions
+## Functions
 ```@autodocs
 Modules = [RigidBodyDynamics]
 Order   = [:function]

--- a/docs/src/benchmarks.md
+++ b/docs/src/benchmarks.md
@@ -1,0 +1,70 @@
+
+# Benchmarks
+Run `perf/runbenchmarks.jl` (`-O3` and `--check-bounds=no` flags recommended) to see benchmark results for the Atlas robot (v5) in the following scenarios:
+
+1. Compute the joint-space mass matrix.
+1. Do inverse dynamics.
+1. Do forward dynamics.
+
+Note that results on Travis builds are **not at all** representative because of code coverage. Results on a recent, fast machine with version 0.0.4:
+
+Output of `versioninfo()`:
+```
+Julia Version 0.5.0
+Commit 3c9d753 (2016-09-19 18:14 UTC)
+Platform Info:
+  System: Linux (x86_64-pc-linux-gnu)
+  CPU: Intel(R) Core(TM) i7-6950X CPU @ 3.00GHz
+  WORD_SIZE: 64
+  BLAS: libopenblas (USE64BITINT DYNAMIC_ARCH NO_AFFINITY Haswell)
+  LAPACK: libopenblas64_
+  LIBM: libopenlibm
+  LLVM: libLLVM-3.7.1 (ORCJIT, broadwell)
+```
+Mass matrix:
+```
+  memory estimate:  0.00 bytes
+  allocs estimate:  0
+  --------------
+  minimum time:     23.034 μs (0.00% GC)
+  median time:      23.364 μs (0.00% GC)
+  mean time:        23.546 μs (0.00% GC)
+  maximum time:     52.605 μs (0.00% GC)
+  --------------
+  samples:          10000
+  evals/sample:     1
+  time tolerance:   5.00%
+  memory tolerance: 1.00%
+```
+
+Inverse dynamics:
+```
+  memory estimate:  0.00 bytes
+  allocs estimate:  0
+  --------------
+  minimum time:     29.178 μs (0.00% GC)
+  median time:      29.704 μs (0.00% GC)
+  mean time:        30.276 μs (0.00% GC)
+  maximum time:     65.232 μs (0.00% GC)
+  --------------
+  samples:          10000
+  evals/sample:     1
+  time tolerance:   5.00%
+  memory tolerance: 1.00%
+```
+
+Forward dynamics:
+```
+  memory estimate:  48.00 bytes
+  allocs estimate:  2
+  --------------
+  minimum time:     53.336 μs (0.00% GC)
+  median time:      82.928 μs (0.00% GC)
+  mean time:        83.334 μs (0.00% GC)
+  maximum time:     208.453 μs (0.00% GC)
+  --------------
+  samples:          10000
+  evals/sample:     1
+  time tolerance:   5.00%
+  memory tolerance: 1.00%
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,18 +1,44 @@
-RigidBodyDynamics provides pure Julia implementations of various rigid body
-dynamics and kinematics algorithms.
+# RigidBodyDynamics
+RigidBodyDynamics implements various rigid body dynamics and kinematics algorithms.
 
-# About
-TODO:
-* Murray
-* Featherstone
-* Duindam
+## Design features
+Some of the key design features of this package are:
+* pure Julia implementation, enabling seamless support for e.g. automatic differentiation using e.g. [ForwardDiff.jl](https://github.com/JuliaDiff/ForwardDiff.jl) and symbolic dynamics using [SymPy.jl](https://github.com/JuliaPy/SymPy.jl).
+* easy creation and modification of general rigid body mechanisms (including basic [URDF](http://wiki.ros.org/urdf) parsing).
+* extensive checks that verify that coordinate systems match before computation, with the goal of making reference frame mistakes impossible
+* flexible caching of intermediate results to prevent doing double work
+* fairly small codebase and few dependencies
+* singularity-free rotation parameterizations
 
-# Installation
+## Functionality
+Current functionality of RigidBodyDynamics includes:
+* kinematics/transforming points and free vectors from one coordinate system to another
+* transforming wrenches, momenta (spatial force vectors) and twists and their derivatives (spatial motion vectors) from one coordinate system to another
+* relative twists/spatial accelerations between bodies
+* kinetic/potential energy
+* center of mass
+* geometric/basic/spatial Jacobians
+* momentum
+* momentum matrix
+* momentum rate bias (= momentum matrix time derivative multiplied by joint velocity vector)
+* mass matrix (composite rigid body algorithm)
+* inverse dynamics (recursive Newton-Euler)
+* dynamics
+* simulation, either using an off-the-shelf ODE integrator or using an included custom Munthe-Kaas integrator that properly handles second-order ODEs defined on a manifold.
 
-To install the latest release of RigidBodyDynamics, simply run
+There is currently partial support for closed-loop systems (parallel mechanisms); more features will be added soon in this area.
+Contact is not yet supported.
+
+## Installation
+
+### Installing Julia
+Download links and more detailed instructions are available on the [Julia](http://julialang.org/) website.
+
+### Installing RigidBodyDynamics
+To install the latest tagged release of RigidBodyDynamics, simply run
 
 ```julia
-Pkg.add("RigidBodyDynamics")
+Pkg.add("RigidBodyDynamics") 
 ```
 
 To check out the master branch and work on the bleeding edge, additionally run
@@ -23,5 +49,28 @@ Pkg.checkout("RigidBodyDynamics")
 
 RigidBodyDynamics currently only supports version 0.5 of Julia.
 
-# Example IJulia notebooks
-TODO
+## References
+Most of the nomenclature used and algorithms implemented by this package stem
+from the following resources:
+
+* Murray, Richard M., et al. A mathematical introduction to robotic manipulation. CRC press, 1994.
+* Featherstone, Roy. Rigid body dynamics algorithms. Springer, 2008.
+* Duindam, Vincent. Port-based modeling and control for efficient bipedal walking robots. Diss. University of Twente, 2006.
+
+## Related packages
+* [RigidBodyTreeInspector.jl](https://github.com/rdeits/RigidBodyTreeInspector.jl) - 3D visualization of RigidBodyDynamics.jl `Mechanism`s using [Director](https://github.com/RobotLocomotion/director).
+
+## Contents
+```@contents
+Depth = 2
+```
+
+## Citing this library
+```bibtex
+@misc{rigidbodydynamicsjl,
+ author = "Twan Koolen and contributors",
+ title = "RigidBodyDynamics.jl",
+ year = 2016,
+ url = "https://github.com/tkoolen/RigidBodyDynamics.jl"
+}
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -2,11 +2,26 @@
 
 RigidBodyDynamics provides pure Julia implementations of various rigid body dynamics and kinematics algorithms.
 
-```@contents
+## About
+TODO:
+* Featherstone
+* Duindam
+
+## Installation
+
+To install the latest release of RigidBodyDynamics, simply run
+
+```julia
+Pkg.add("RigidBodyDynamics")
 ```
 
+To check out the master branch and work on the bleeding edge, additionally run
 
-## Index
-
-```@index
+```julia
+Pkg.checkout("RigidBodyDynamics")
 ```
+
+RigidBodyDynamics currently only supports version 0.5 of Julia.
+
+## Example IJulia notebooks
+TODO

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,14 +1,12 @@
-# RigidBodyDynamics
-
 RigidBodyDynamics provides pure Julia implementations of various rigid body dynamics and kinematics algorithms.
 
-## About
+# About
 TODO:
 * Murray
 * Featherstone
 * Duindam
 
-## Installation
+# Installation
 
 To install the latest release of RigidBodyDynamics, simply run
 
@@ -24,5 +22,5 @@ Pkg.checkout("RigidBodyDynamics")
 
 RigidBodyDynamics currently only supports version 0.5 of Julia.
 
-## Example IJulia notebooks
+# Example IJulia notebooks
 TODO

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,12 @@
+# RigidBodyDynamics
+
+RigidBodyDynamics provides pure Julia implementations of various rigid body dynamics and kinematics algorithms.
+
+```@contents
+```
+
+
+## Index
+
+```@index
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,6 +4,7 @@ RigidBodyDynamics provides pure Julia implementations of various rigid body dyna
 
 ## About
 TODO:
+* Murray
 * Featherstone
 * Duindam
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,4 +1,5 @@
-RigidBodyDynamics provides pure Julia implementations of various rigid body dynamics and kinematics algorithms.
+RigidBodyDynamics provides pure Julia implementations of various rigid body
+dynamics and kinematics algorithms.
 
 # About
 TODO:

--- a/docs/src/joints.md
+++ b/docs/src/joints.md
@@ -1,5 +1,3 @@
-# Joints
-
 ## The `Joint` type
 
 ```@docs
@@ -14,7 +12,7 @@ Order   = [:function]
 Pages   = ["joint.jl"]
 ```
 
-## Types
+## `JointType`s
 
 ```@autodocs
 Modules = [RigidBodyDynamics]

--- a/docs/src/joints.md
+++ b/docs/src/joints.md
@@ -4,7 +4,7 @@
 Joint
 ```
 
-# Functionality
+# Functions
 
 ```@autodocs
 Modules = [RigidBodyDynamics]

--- a/docs/src/joints.md
+++ b/docs/src/joints.md
@@ -1,16 +1,18 @@
-# Index
+# Joints
+
+## Index
 ```@index
 Pages   = ["joints.md"]
 Order   = [:type, :function]
 ```
 
-# The `Joint` type
+## The `Joint` type
 
 ```@docs
 Joint
 ```
 
-# Functions
+## Functions
 
 ```@autodocs
 Modules = [RigidBodyDynamics]
@@ -18,7 +20,7 @@ Order   = [:function]
 Pages   = ["joint.jl"]
 ```
 
-# `JointType`s
+## `JointType`s
 
 ```@autodocs
 Modules = [RigidBodyDynamics]

--- a/docs/src/joints.md
+++ b/docs/src/joints.md
@@ -1,3 +1,9 @@
+# Index
+```@index
+Pages   = ["joints.md"]
+Order   = [:type, :function]
+```
+
 # The `Joint` type
 
 ```@docs

--- a/docs/src/joints.md
+++ b/docs/src/joints.md
@@ -1,0 +1,23 @@
+# Joints
+
+## The `Joint` type
+
+```@docs
+Joint
+```
+
+## Functionality
+
+```@autodocs
+Modules = [RigidBodyDynamics]
+Order   = [:function]
+Pages   = ["joint.jl"]
+```
+
+## Types
+
+```@autodocs
+Modules = [RigidBodyDynamics]
+Order   = [:type, :function]
+Pages   = ["joint_types.jl"]
+```

--- a/docs/src/joints.md
+++ b/docs/src/joints.md
@@ -1,10 +1,10 @@
-## The `Joint` type
+# The `Joint` type
 
 ```@docs
 Joint
 ```
 
-## Functionality
+# Functionality
 
 ```@autodocs
 Modules = [RigidBodyDynamics]
@@ -12,7 +12,7 @@ Order   = [:function]
 Pages   = ["joint.jl"]
 ```
 
-## `JointType`s
+# `JointType`s
 
 ```@autodocs
 Modules = [RigidBodyDynamics]

--- a/docs/src/mechanism.md
+++ b/docs/src/mechanism.md
@@ -1,22 +1,27 @@
-# Index
+# Mechanisms
+
+```@contents
+Pages   = ["mechanism.md"]
+```
+
 ```@index
 Pages   = ["mechanism.md"]
 Order   = [:type, :function]
 ```
 
-# The `Mechanism` type
+## The `Mechanism` type
 ```@docs
 Mechanism
 ```
 
-# Basic functionality
+## Basic functionality
 ```@autodocs
 Modules = [RigidBodyDynamics]
 Order   = [:function]
 Pages   = ["mechanism.jl"]
 ```
 
-# Creating and modifying `Mechanism`s
+## [Creating and modifying `Mechanism`s](@id mechanism_create)
 ```@docs
 parse_urdf
 ```

--- a/docs/src/mechanism.md
+++ b/docs/src/mechanism.md
@@ -11,7 +11,11 @@ Order   = [:function]
 Pages   = ["mechanism.jl"]
 ```
 
-# Creating and Manipulating `Mechanism`s
+# Creating and modifying `Mechanism`s
+```@docs
+parse_urdf
+```
+
 ```@autodocs
 Modules = [RigidBodyDynamics]
 Order   = [:function]

--- a/docs/src/mechanism.md
+++ b/docs/src/mechanism.md
@@ -1,9 +1,6 @@
 # Mechanisms
 
-```@contents
-Pages   = ["mechanism.md"]
-```
-
+## Index
 ```@index
 Pages   = ["mechanism.md"]
 Order   = [:type, :function]

--- a/docs/src/mechanism.md
+++ b/docs/src/mechanism.md
@@ -1,0 +1,19 @@
+# The `Mechanism` type
+
+```@docs
+Mechanism
+```
+
+# Basic functionality
+```@autodocs
+Modules = [RigidBodyDynamics]
+Order   = [:function]
+Pages   = ["mechanism.jl"]
+```
+
+# Creating and Manipulating `Mechanism`s
+```@autodocs
+Modules = [RigidBodyDynamics]
+Order   = [:function]
+Pages   = ["mechanism_manipulation.jl"]
+```

--- a/docs/src/mechanism.md
+++ b/docs/src/mechanism.md
@@ -1,5 +1,10 @@
-# The `Mechanism` type
+# Index
+```@index
+Pages   = ["mechanism.md"]
+Order   = [:type, :function]
+```
 
+# The `Mechanism` type
 ```@docs
 Mechanism
 ```

--- a/docs/src/mechanismstate.md
+++ b/docs/src/mechanismstate.md
@@ -1,3 +1,9 @@
+# Index
+```@index
+Pages   = ["mechanismstate.md"]
+Order   = [:type, :function]
+```
+
 # The `MechanismState` type
 ```@docs
 MechanismState

--- a/docs/src/mechanismstate.md
+++ b/docs/src/mechanismstate.md
@@ -1,9 +1,6 @@
 # MechanismState
 
-```@contents
-Pages   = ["mechanismstate.md"]
-```
-
+## Index
 ```@index
 Pages   = ["mechanismstate.md"]
 Order   = [:type, :function]

--- a/docs/src/mechanismstate.md
+++ b/docs/src/mechanismstate.md
@@ -1,11 +1,11 @@
-# The `RigidBody` type
+# The `MechanismState` type
 ```@docs
-RigidBody
+MechanismState
 ```
 
 # Functions
 ```@autodocs
 Modules = [RigidBodyDynamics]
 Order   = [:function]
-Pages   = ["rigid_body.jl"]
+Pages   = ["mechanism_state.jl"]
 ```

--- a/docs/src/mechanismstate.md
+++ b/docs/src/mechanismstate.md
@@ -1,15 +1,20 @@
-# Index
+# MechanismState
+
+```@contents
+Pages   = ["mechanismstate.md"]
+```
+
 ```@index
 Pages   = ["mechanismstate.md"]
 Order   = [:type, :function]
 ```
 
-# The `MechanismState` type
+## The `MechanismState` type
 ```@docs
 MechanismState
 ```
 
-# Functions
+## Functions
 ```@autodocs
 Modules = [RigidBodyDynamics]
 Order   = [:function]

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -1,0 +1,28 @@
+# Quick start guide
+TODO: See notebook.
+
+<!-- # Creating a double pendulum `Mechanism`
+We're going to create a simple `Mechanism` that represents a
+[double pendulum](https://en.wikipedia.org/wiki/Double_pendulum).
+The `Mechanism` type can be thought of as an interconnection of rigid bodies and joints.
+
+We'll start by creating a new `Mechanism`:
+```@example
+
+```
+
+
+
+`Mechanism`s can also be loaded from an XML file called a URDF, merged, split
+apart, etc. See [here](@ref mechanism_create) for more information.
+
+# Creating a `MechanismState`
+`Mechanism`s store the joint layout and inertia parameters, but no
+state-dependent information. State-dependent information is instead stored in
+a separate object called a `MechanismState`.
+
+# Computing the mass matrix of the double pendulum
+
+# Simulation
+
+# Visualization -->

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -1,28 +1,2 @@
 # Quick start guide
-TODO: See notebook.
-
-<!-- # Creating a double pendulum `Mechanism`
-We're going to create a simple `Mechanism` that represents a
-[double pendulum](https://en.wikipedia.org/wiki/Double_pendulum).
-The `Mechanism` type can be thought of as an interconnection of rigid bodies and joints.
-
-We'll start by creating a new `Mechanism`:
-```@example
-
-```
-
-
-
-`Mechanism`s can also be loaded from an XML file called a URDF, merged, split
-apart, etc. See [here](@ref mechanism_create) for more information.
-
-# Creating a `MechanismState`
-`Mechanism`s store the joint layout and inertia parameters, but no
-state-dependent information. State-dependent information is instead stored in
-a separate object called a `MechanismState`.
-
-# Computing the mass matrix of the double pendulum
-
-# Simulation
-
-# Visualization -->
+TODO: create notebook and point to it.

--- a/docs/src/rigidbody.md
+++ b/docs/src/rigidbody.md
@@ -1,9 +1,6 @@
 # Rigid bodies
 
-```@contents
-Pages   = ["rigidbody.md"]
-```
-
+## Index
 ```@index
 Pages   = ["rigidbody.md"]
 Order   = [:type, :function]

--- a/docs/src/rigidbody.md
+++ b/docs/src/rigidbody.md
@@ -1,0 +1,14 @@
+# Rigid Bodies
+
+## The `RigidBody` type
+```@docs
+RigidBody
+```
+
+## Functionality
+
+```@autodocs
+Modules = [RigidBodyDynamics]
+Order   = [:function]
+Pages   = ["rigid_body.jl"]
+```

--- a/docs/src/rigidbody.md
+++ b/docs/src/rigidbody.md
@@ -1,5 +1,3 @@
-# Rigid Bodies
-
 ## The `RigidBody` type
 ```@docs
 RigidBody

--- a/docs/src/rigidbody.md
+++ b/docs/src/rigidbody.md
@@ -1,9 +1,9 @@
-## The `RigidBody` type
+# The `RigidBody` type
 ```@docs
 RigidBody
 ```
 
-## Functionality
+# Functionality
 
 ```@autodocs
 Modules = [RigidBodyDynamics]

--- a/docs/src/rigidbody.md
+++ b/docs/src/rigidbody.md
@@ -1,15 +1,20 @@
-# Index
+# Rigid bodies
+
+```@contents
+Pages   = ["rigidbody.md"]
+```
+
 ```@index
 Pages   = ["rigidbody.md"]
 Order   = [:type, :function]
 ```
 
-# The `RigidBody` type
+## The `RigidBody` type
 ```@docs
 RigidBody
 ```
 
-# Functions
+## Functions
 ```@autodocs
 Modules = [RigidBodyDynamics]
 Order   = [:function]

--- a/docs/src/rigidbody.md
+++ b/docs/src/rigidbody.md
@@ -1,3 +1,9 @@
+# Index
+```@index
+Pages   = ["rigidbody.md"]
+Order   = [:type, :function]
+```
+
 # The `RigidBody` type
 ```@docs
 RigidBody

--- a/docs/src/simulation.md
+++ b/docs/src/simulation.md
@@ -1,9 +1,6 @@
 # Simulation
 
-```@contents
-Pages   = ["simulation.md"]
-```
-
+## Index
 ```@index
 Pages   = ["simulation.md"]
 Order   = [:type, :function]

--- a/docs/src/simulation.md
+++ b/docs/src/simulation.md
@@ -1,0 +1,17 @@
+# Index
+```@index
+Pages   = ["simulation.md"]
+Order   = [:type, :function]
+```
+
+# Basic simulation
+```@docs
+simulate
+```
+
+# Lower level ODE integration interface
+```@autodocs
+Modules = [RigidBodyDynamics.OdeIntegrators]
+Order   = [:type, :function]
+Pages   = ["ode_integrators.jl"]
+```

--- a/docs/src/simulation.md
+++ b/docs/src/simulation.md
@@ -1,15 +1,20 @@
-# Index
+# Simulation
+
+```@contents
+Pages   = ["simulation.md"]
+```
+
 ```@index
 Pages   = ["simulation.md"]
 Order   = [:type, :function]
 ```
 
-# Basic simulation
+## Basic simulation
 ```@docs
 simulate
 ```
 
-# Lower level ODE integration interface
+## Lower level ODE integration interface
 ```@autodocs
 Modules = [RigidBodyDynamics.OdeIntegrators]
 Order   = [:type, :function]

--- a/docs/src/spatial.md
+++ b/docs/src/spatial.md
@@ -1,3 +1,9 @@
+# Index
+```@index
+Pages   = ["spatial.md"]
+Order   = [:type, :function, :macro]
+```
+
 # Types
 
 ## Coordinate frames

--- a/docs/src/spatial.md
+++ b/docs/src/spatial.md
@@ -1,0 +1,25 @@
+## Coordinate frames
+```@docs
+CartesianFrame3D
+```
+
+## Transforms
+```@docs
+Transform3D
+```
+
+## Points, free vectors
+```@docs
+Point3D
+FreeVector3D
+```
+
+## Inertias
+
+## Twists, spatial accelerations
+
+## Momenta, wrenches
+
+## Geometric Jacobians
+
+## Momentum matrices

--- a/docs/src/spatial.md
+++ b/docs/src/spatial.md
@@ -43,9 +43,14 @@ GeometricJacobian
 MomentumMatrix
 ```
 
+# The `@framecheck` macro
+```@docs
+@framecheck
+```
+
 # Functions
 ```@autodocs
 Modules = [RigidBodyDynamics]
-Order   = [:function, :macro]
-Pages   = ["spatial.jl"]
+Order   = [:function]
+Pages   = ["spatial.jl", "frames.jl"]
 ```

--- a/docs/src/spatial.md
+++ b/docs/src/spatial.md
@@ -1,3 +1,5 @@
+# Types
+
 ## Coordinate frames
 ```@docs
 CartesianFrame3D
@@ -15,11 +17,35 @@ FreeVector3D
 ```
 
 ## Inertias
+```@docs
+SpatialInertia
+```
 
 ## Twists, spatial accelerations
+```@docs
+Twist
+SpatialAcceleration
+```
 
 ## Momenta, wrenches
+```@docs
+Momentum
+Wrench
+```
 
 ## Geometric Jacobians
+```@docs
+GeometricJacobian
+```
 
 ## Momentum matrices
+```@docs
+MomentumMatrix
+```
+
+# Functions
+```@autodocs
+Modules = [RigidBodyDynamics]
+Order   = [:function, :macro]
+Pages   = ["spatial.jl"]
+```

--- a/docs/src/spatial.md
+++ b/docs/src/spatial.md
@@ -1,60 +1,62 @@
-# Index
+# Spatial vector algebra
+
+## Index
 ```@index
 Pages   = ["spatial.md"]
 Order   = [:type, :function, :macro]
 ```
 
-# Types
+## Types
 
-## Coordinate frames
+### Coordinate frames
 ```@docs
 CartesianFrame3D
 ```
 
-## Transforms
+### Transforms
 ```@docs
 Transform3D
 ```
 
-## Points, free vectors
+### Points, free vectors
 ```@docs
 Point3D
 FreeVector3D
 ```
 
-## Inertias
+### Inertias
 ```@docs
 SpatialInertia
 ```
 
-## Twists, spatial accelerations
+### Twists, spatial accelerations
 ```@docs
 Twist
 SpatialAcceleration
 ```
 
-## Momenta, wrenches
+### Momenta, wrenches
 ```@docs
 Momentum
 Wrench
 ```
 
-## Geometric Jacobians
+### Geometric Jacobians
 ```@docs
 GeometricJacobian
 ```
 
-## Momentum matrices
+### Momentum matrices
 ```@docs
 MomentumMatrix
 ```
 
-# The `@framecheck` macro
+## The `@framecheck` macro
 ```@docs
 @framecheck
 ```
 
-# Functions
+## Functions
 ```@autodocs
 Modules = [RigidBodyDynamics]
 Order   = [:function]

--- a/src/RigidBodyDynamics.jl
+++ b/src/RigidBodyDynamics.jl
@@ -11,6 +11,9 @@ import StaticArrays: similar_type
 using Rotations
 using DataStructures
 using LightXML
+using DocStringExtensions
+
+const noalloc_doc = """This method does its computation in place, performing no dynamic memory allocation."""
 
 if isdefined(Base, :Iterators)
     import Base.Iterators: filter

--- a/src/RigidBodyDynamics.jl
+++ b/src/RigidBodyDynamics.jl
@@ -31,6 +31,7 @@ include("cache_element.jl")
 
 importall .TreeDataStructure
 include("mechanism.jl")
+include("mechanism_manipulation.jl")
 include("mechanism_state.jl")
 include("dynamics_result.jl")
 include("mechanism_algorithms.jl")

--- a/src/dynamics_result.jl
+++ b/src/dynamics_result.jl
@@ -1,3 +1,9 @@
+"""
+    DynamicsResult
+
+Stores variables related to the dynamics of a `Mechanism`, e.g. the
+`Mechanism`'s mass matrix and joint acceleration vector.
+"""
 type DynamicsResult{M, T}
     massMatrix::Symmetric{T, Matrix{T}}
     dynamicsBias::Vector{T}

--- a/src/dynamics_result.jl
+++ b/src/dynamics_result.jl
@@ -1,5 +1,5 @@
 """
-    DynamicsResult
+$(TYPEDEF)
 
 Stores variables related to the dynamics of a `Mechanism`, e.g. the
 `Mechanism`'s mass matrix and joint acceleration vector.

--- a/src/frames.jl
+++ b/src/frames.jl
@@ -10,7 +10,7 @@ const next_frame_id = Ref(0)
 const frame_names = Dict{Int64, String}()
 
 """
-    CartesianFrame3D
+$(TYPEDEF)
 
 A `CartesianFrame3D` identifies a three-dimensional Cartesian coordinate system.
 
@@ -35,7 +35,7 @@ immutable CartesianFrame3D
 end
 
 """
-    name(frame)
+$(SIGNATURES)
 
 Return the name of `frame`.
 """
@@ -43,7 +43,7 @@ name(frame::CartesianFrame3D) = get(frame_names, frame.id, "anonymous")
 show(io::IO, frame::CartesianFrame3D) = print(io, "CartesianFrame3D: \"$(name(frame))\" (id = $(frame.id))")
 
 """
-    @framecheck(f1, f2)
+$(SIGNATURES)
 
 Check that `f1` and `f2` are identical (when bounds checks are enabled).
 
@@ -69,7 +69,7 @@ end
 
 # Transform between frames
 """
-    Transform3D
+$(TYPEDEF)
 
 A homogeneous transformation matrix representing the transformation from one
 three-dimensional Cartesian coordinate system to another.
@@ -147,7 +147,7 @@ for VectorType in (:FreeVector3D, :Point3D)
         # copy(p::$VectorType) = $VectorType(p.frame, copy(p.v))
 
         """
-            transform(x, t)
+        $(SIGNATURES)
 
         Returns `x` transformed to `CartesianFrame3D` `t.from`.
         """
@@ -158,7 +158,7 @@ for VectorType in (:FreeVector3D, :Point3D)
 end
 
 """
-    Point3D
+$(TYPEDEF)
 
 A `Point3D` represents a position in a given coordinate system.
 
@@ -169,7 +169,7 @@ Applying a `Transform3D` to a `Point3D` both rotates and translates the
 Point3D
 
 """
-   FreeVector3D
+$(TYPEDEF)
 
 A `FreeVector3D` represents a [free vector](https://en.wikipedia.org/wiki/Euclidean_vector#Overview).
 

--- a/src/frames.jl
+++ b/src/frames.jl
@@ -34,11 +34,6 @@ immutable CartesianFrame3D
     end
 end
 
-"""
-$(SIGNATURES)
-
-Return the name of `frame`.
-"""
 name(frame::CartesianFrame3D) = get(frame_names, frame.id, "anonymous")
 show(io::IO, frame::CartesianFrame3D) = print(io, "CartesianFrame3D: \"$(name(frame))\" (id = $(frame.id))")
 

--- a/src/joint.jl
+++ b/src/joint.jl
@@ -1,4 +1,6 @@
 """
+$(TYPEDEF)
+
 A joint represents a kinematic restriction of the relative twist between two
 rigid bodies to a linear subspace of dimension ``k``.
 The state related to the joint is parameterized by two sets of variables, namely
@@ -53,28 +55,28 @@ end
 # See https://github.com/tkoolen/RigidBodyDynamics.jl/issues/93.
 
 """
-    num_positions(joint)
+$(SIGNATURES)
 
 Return the length of the configuration vector of `joint`.
 """
 num_positions{M}(joint::Joint{M})::Int64 = @rtti_dispatch (QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}) num_positions(joint.jointType)
 
 """
-    num_velocities(joint)
+$(SIGNATURES)
 
 Return the length of the velocity vector of `joint`.
 """
 num_velocities{M}(joint::Joint{M})::Int64 = @rtti_dispatch (QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}) num_velocities(joint.jointType)
 
 """
-    num_constraints(joint::Joint)
+$(SIGNATURES)
 
 Return the number of constraints imposed on the relative twist between the joint's predecessor and successor
 """
 num_constraints(joint::Joint) = 6 - num_velocities(joint)
 
 """
-    joint_transform(joint, q)
+$(SIGNATURES)
 
 Return a `Transform3D` representing the homogeneous transform from the frame
 after the joint to the frame before the joint for joint configuration vector ``q``.
@@ -85,7 +87,7 @@ function joint_transform{M, X}(joint::Joint{M}, q::AbstractVector{X})::Transform
 end
 
 """
-    motion_subspace(joint, q)
+$(SIGNATURES)
 
 Return a basis for the motion subspace of the joint in configuration ``q``.
 
@@ -100,7 +102,7 @@ function motion_subspace{M, X}(joint::Joint{M}, q::AbstractVector{X})::MotionSub
 end
 
 """
-    constraint_wrench_subspace(joint, transform)
+$(SIGNATURES)
 
 Return a basis for the constraint wrench subspace of the joint in configuration
 ``q``.
@@ -119,7 +121,7 @@ function constraint_wrench_subspace{M, X}(joint::Joint{M}, jointTransform::Trans
 end
 
 """
-    bias_acceleration(joint, q, v)
+$(SIGNATURES)
 
 Return the acceleration of the joint's successor with respect to its predecessor
 in configuration ``q`` and at velocity ``v``, when the joint acceleration
@@ -132,7 +134,7 @@ function bias_acceleration{M, X}(joint::Joint{M}, q::AbstractVector{X}, v::Abstr
 end
 
 """
-    has_fixed_subspaces(joint)
+$(SIGNATURES)
 
 Whether the joint's motion subspace and constraint wrench subspace depend on
 ``q``.
@@ -142,7 +144,7 @@ function has_fixed_subspaces{M}(joint::Joint{M})
 end
 
 """
-    configuration_derivative_to_velocity!(joint, v, q, q̇)
+$(SIGNATURES)
 
 Compute joint velocity vector ``v`` given the joint configuration vector ``q``
 and its time derivative ``\\dot{q}`` (in place).
@@ -159,7 +161,7 @@ function configuration_derivative_to_velocity!{M}(joint::Joint{M}, v::AbstractVe
 end
 
 """
-    velocity_to_configuration_derivative!(joint, v, q, q̇)
+$(SIGNATURES)
 
 Compute the time derivative ``\\dot{q}`` of the joint configuration vector ``q``
 given ``q`` and the joint velocity vector ``v`` (in place).
@@ -176,7 +178,7 @@ function velocity_to_configuration_derivative!{M}(joint::Joint{M}, q̇::Abstract
 end
 
 """
-    zero_configuration!(joint, q)
+$(SIGNATURES)
 
 Set ``q`` to the 'zero' configuration, corresponding to an identity joint
 transform.
@@ -187,7 +189,7 @@ function zero_configuration!{M}(joint::Joint{M}, q::AbstractVector)::Void
 end
 
 """
-    rand_configuration!(joint, q)
+$(SIGNATURES)
 
 Set ``q`` to a random configuration. The distribution used depends on the
 joint type.
@@ -198,7 +200,7 @@ function rand_configuration!{M}(joint::Joint{M}, q::AbstractVector)::Void
 end
 
 """
-    joint_twist(joint, q, v)
+$(SIGNATURES)
 
 Return the twist of `joint`'s  successor with respect to its predecessor,
 expressed in the frame after the joint.
@@ -212,7 +214,7 @@ function joint_twist{M, X}(joint::Joint{M}, q::AbstractVector{X}, v::AbstractVec
 end
 
 """
-    joint_torque!(joint, τ, q, joint_wrench)
+$(SIGNATURES)
 
 Given the wrench exerted across the joint on the joint's successor, compute the
 vector of joint torques ``\\tau`` (in place), in configuration `q`.
@@ -225,7 +227,7 @@ function joint_torque!{M}(joint::Joint{M}, τ::AbstractVector, q::AbstractVector
 end
 
 """
-    local_coordinates!(joint, ϕ, ϕ̇, q0, q, v)
+$(SIGNATURES)
 
 Compute a vector of local coordinates ``\\phi`` around configuration ``q_0``
 corresponding to configuration ``q`` (in place). Also compute the time
@@ -253,7 +255,7 @@ function local_coordinates!{M}(joint::Joint{M},
 end
 
 """
-    global_coordinates!(joint, q, q0, ϕ)
+$(SIGNATURES)
 
 Compute the global parameterization of the joint's configuration, ``q``, given
 a 'base' orientation ``q_0`` and a vector of local coordinates relative to

--- a/src/joint.jl
+++ b/src/joint.jl
@@ -1,3 +1,27 @@
+"""
+A joint represents a kinematic restriction of the relative twist between two
+rigid bodies to a linear subspace of dimension ``k``.
+The state related to the joint is parameterized by two sets of variables, namely
+
+* a vector ``q \\in  \\mathcal{Q}``, parameterizing the relative homogeneous transform.
+* a vector ``v \\in \\mathbb{R}^k``, parameterizing the relative twist.
+
+A joint has a direction. The rigid body before the joint is called the
+joint's predecessor, and the rigid body after the joint is its successor.
+
+The twist of the successor with respect to the predecessor is a linear function
+of ``v``.
+
+For some joint types (notably those using a redundant representation of relative
+orientation, such as a unit quaternion), ``\\dot{q}``, the time derivative of
+``q``, may not be the same as ``v``.
+However, an invertible linear transformation exists between
+``\\dot{q}`` and ``v``.
+
+See also:
+* Definition 2.9 in Duindam, "Port-Based Modeling and Control for Efficient Bipedal Walking Robots", 2006.
+* Section 4.4 of Featherstone, "Rigid Body Dynamics Algorithms", 2008.
+"""
 type Joint{T<:Number}
     name::String
     frameBefore::CartesianFrame3D
@@ -10,6 +34,7 @@ Joint(name::String, jointType::JointType) = Joint(name, CartesianFrame3D(string(
 show(io::IO, joint::Joint) = print(io, "Joint \"$(joint.name)\": $(joint.jointType)")
 showcompact(io::IO, joint::Joint) = print(io, "$(joint.name)")
 
+# TODO: deprecate in favor of sum(num_positions, ...)
 num_positions(itr) = reduce((val, joint) -> val + num_positions(joint), 0, itr)
 num_velocities(itr) = reduce((val, joint) -> val + num_velocities(joint), 0, itr)
 
@@ -27,36 +52,105 @@ end
 # 'RTTI'-style dispatch inspired by https://groups.google.com/d/msg/julia-users/ude2-MUiFLM/z-MuQ9nhAAAJ, hopefully a short-term solution.
 # See https://github.com/tkoolen/RigidBodyDynamics.jl/issues/93.
 
+"""
+    num_positions(joint)
+
+Return the length of the configuration vector of `joint`.
+"""
 num_positions{M}(joint::Joint{M})::Int64 = @rtti_dispatch (QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}) num_positions(joint.jointType)
+
+"""
+    num_velocities(joint)
+
+Return the length of the velocity vector of `joint`.
+"""
 num_velocities{M}(joint::Joint{M})::Int64 = @rtti_dispatch (QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}) num_velocities(joint.jointType)
+
+"""
+    num_constraints(joint::Joint)
+
+Return the number of constraints imposed on the relative twist between the joint's predecessor and successor
+"""
 num_constraints(joint::Joint) = 6 - num_velocities(joint)
 
+"""
+    joint_transform(joint, q)
+
+Return a `Transform3D` representing the homogeneous transform from the frame
+after the joint to the frame before the joint for joint configuration vector ``q``.
+"""
 function joint_transform{M, X}(joint::Joint{M}, q::AbstractVector{X})::Transform3D{promote_type(M, X)}
     @boundscheck check_num_positions(joint, q)
     @rtti_dispatch (QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}) _joint_transform(joint.jointType, joint.frameAfter, joint.frameBefore, q)
 end
 
+"""
+    motion_subspace(joint, q)
+
+Return a basis for the motion subspace of the joint in configuration ``q``.
+
+The motion subspace basis is a ``6 \\times  k`` matrix, where ``k`` is the dimension of
+the velocity vector ``v``, that maps ``v`` to the twist of the joint's successor
+with respect to its predecessor. The returned motion subspace is expressed in
+the frame after the joint, which is attached to the joint's successor.
+"""
 function motion_subspace{M, X}(joint::Joint{M}, q::AbstractVector{X})::MotionSubspace{promote_type(M, X)}
     @boundscheck check_num_positions(joint, q)
     @rtti_dispatch (QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}) _motion_subspace(joint.jointType, joint.frameAfter, joint.frameBefore, q)
 end
 
+"""
+    constraint_wrench_subspace(joint, transform)
+
+Return a basis for the constraint wrench subspace of the joint in configuration
+``q``.
+
+The constraint wrench subspace is a ``6 \\times (6 - k)`` matrix, where ``k``
+is the dimension of the velocity vector ``v``, that maps a vector of Lagrange
+multipliers ``\\lambda`` to the constraint wrench exerted across the joint onto
+its successor.
+
+The constraint wrench subspace is orthogonal to the motion subspace.
+"""
 function constraint_wrench_subspace{M, X}(joint::Joint{M}, jointTransform::Transform3D{X})#::WrenchSubspace{promote_type(M, X)} # FIXME: type assertion causes segfault! see https://github.com/JuliaLang/julia/issues/20034. should be fixed in 0.6
     @framecheck jointTransform.from joint.frameAfter
     @framecheck jointTransform.to joint.frameBefore
     @rtti_dispatch (QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}) _constraint_wrench_subspace(joint.jointType, jointTransform)
 end
 
+"""
+    bias_acceleration(joint, q, v)
+
+Return the acceleration of the joint's successor with respect to its predecessor
+in configuration ``q`` and at velocity ``v``, when the joint acceleration
+``\\dot{v}`` is zero.
+"""
 function bias_acceleration{M, X}(joint::Joint{M}, q::AbstractVector{X}, v::AbstractVector{X})::SpatialAcceleration{promote_type(M, X)}
     @boundscheck check_num_positions(joint, q)
     @boundscheck check_num_velocities(joint, v)
     @rtti_dispatch (QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}) _bias_acceleration(joint.jointType, joint.frameAfter, joint.frameBefore, q, v)
 end
 
+"""
+    has_fixed_subspaces(joint)
+
+Whether the joint's motion subspace and constraint wrench subspace depend on
+``q``.
+"""
 function has_fixed_subspaces{M}(joint::Joint{M})
     @rtti_dispatch (QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}) _has_fixed_subspaces(joint.jointType)
 end
 
+"""
+    configuration_derivative_to_velocity!(joint, v, q, q̇)
+
+Compute joint velocity vector ``v`` given the joint configuration vector ``q``
+and its time derivative ``\\dot{q}`` (in place).
+
+Note that this mapping is linear.
+
+See also [`velocity_to_configuration_derivative!`](@ref), the inverse mapping.
+"""
 function configuration_derivative_to_velocity!{M}(joint::Joint{M}, v::AbstractVector, q::AbstractVector, q̇::AbstractVector)::Void
     @boundscheck check_num_velocities(joint, v)
     @boundscheck check_num_positions(joint, q)
@@ -64,6 +158,16 @@ function configuration_derivative_to_velocity!{M}(joint::Joint{M}, v::AbstractVe
     @rtti_dispatch (QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}) _configuration_derivative_to_velocity!(joint.jointType, v, q, q̇)
 end
 
+"""
+    velocity_to_configuration_derivative!(joint, v, q, q̇)
+
+Compute the time derivative ``\\dot{q}`` of the joint configuration vector ``q``
+given ``q`` and the joint velocity vector ``v`` (in place).
+
+Note that this mapping is linear.
+
+See also [`configuration_derivative_to_velocity!`](@ref), the inverse mapping.
+"""
 function velocity_to_configuration_derivative!{M}(joint::Joint{M}, q̇::AbstractVector, q::AbstractVector, v::AbstractVector)::Void
     @boundscheck check_num_positions(joint, q̇)
     @boundscheck check_num_positions(joint, q)
@@ -71,22 +175,48 @@ function velocity_to_configuration_derivative!{M}(joint::Joint{M}, q̇::Abstract
     @rtti_dispatch (QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}) _velocity_to_configuration_derivative!(joint.jointType, q̇, q, v)
 end
 
+"""
+    zero_configuration!(joint, q)
+
+Set ``q`` to the 'zero' configuration, corresponding to an identity joint
+transform.
+"""
 function zero_configuration!{M}(joint::Joint{M}, q::AbstractVector)::Void
     @boundscheck check_num_positions(joint, q)
     @rtti_dispatch (QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}) _zero_configuration!(joint.jointType, q)
 end
 
+"""
+    rand_configuration!(joint, q)
+
+Set ``q`` to a random configuration. The distribution used depends on the
+joint type.
+"""
 function rand_configuration!{M}(joint::Joint{M}, q::AbstractVector)::Void
     @boundscheck check_num_positions(joint, q)
     @rtti_dispatch (QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}) _rand_configuration!(joint.jointType, q)
 end
 
+"""
+    joint_twist(joint, q, v)
+
+Return the twist of `joint`'s  successor with respect to its predecessor,
+expressed in the frame after the joint.
+
+Note that this is the same as `Twist([`motion_subspace`](@ref)(joint, q), v)`.
+"""
 function joint_twist{M, X}(joint::Joint{M}, q::AbstractVector{X}, v::AbstractVector{X})::Twist{promote_type(M, X)}
     @boundscheck check_num_positions(joint, q)
     @boundscheck check_num_velocities(joint, v)
     @rtti_dispatch (QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}) _joint_twist(joint.jointType, joint.frameAfter, joint.frameBefore, q, v)
 end
 
+"""
+    joint_torque!(joint, τ, q, joint_wrench)
+
+Given the wrench exerted across the joint on the joint's successor, compute the
+vector of joint torques ``\\tau`` (in place), in configuration `q`.
+"""
 function joint_torque!{M}(joint::Joint{M}, τ::AbstractVector, q::AbstractVector, joint_wrench::Wrench)::Void
     @boundscheck check_num_velocities(joint, τ)
     @boundscheck check_num_positions(joint, q)
@@ -94,6 +224,23 @@ function joint_torque!{M}(joint::Joint{M}, τ::AbstractVector, q::AbstractVector
     @rtti_dispatch (QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}) _joint_torque!(joint.jointType, τ, q, joint_wrench)
 end
 
+"""
+    local_coordinates!(joint, ϕ, ϕ̇, q0, q, v)
+
+Compute a vector of local coordinates ``\\phi`` around configuration ``q_0``
+corresponding to configuration ``q`` (in place). Also compute the time
+derivative ``\\dot{\\phi}`` of ``\\phi`` given the joint velocity vector ``v``.
+
+The local coordinate vector ``\\phi`` must be zero if and only if ``q = q_0``.
+
+For revolute or prismatic joint types, the local coordinates can just be
+``\\phi = q - q_0``, but for joint types with configuration vectors that are
+restricted to a manifold (e.g. when unit quaternions are used to represent
+orientation), elementwise subtraction may not make sense. For such joints,
+exponential coordinates could be used as the local coordinate vector ``\\phi``.
+
+See also [`global_coordinates!`](@ref).
+"""
 function local_coordinates!{M}(joint::Joint{M},
         ϕ::AbstractVector, ϕ̇::AbstractVector,
         q0::AbstractVector, q::AbstractVector, v::AbstractVector)
@@ -105,6 +252,15 @@ function local_coordinates!{M}(joint::Joint{M},
     @rtti_dispatch (QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}) _local_coordinates!(joint.jointType, ϕ, ϕ̇, q0, q, v)
 end
 
+"""
+    global_coordinates!(joint, q, q0, ϕ)
+
+Compute the global parameterization of the joint's configuration, ``q``, given
+a 'base' orientation ``q_0`` and a vector of local coordinates relative to
+``q_0``, ``ϕ``.
+
+See also [`local_coordinates!`](@ref).
+"""
 function global_coordinates!{M}(joint::Joint{M}, q::AbstractVector, q0::AbstractVector, ϕ::AbstractVector)
     @boundscheck check_num_positions(joint, q)
     @boundscheck check_num_positions(joint, q0)

--- a/src/joint.jl
+++ b/src/joint.jl
@@ -205,7 +205,7 @@ $(SIGNATURES)
 Return the twist of `joint`'s  successor with respect to its predecessor,
 expressed in the frame after the joint.
 
-Note that this is the same as `Twist([`motion_subspace`](@ref)(joint, q), v)`.
+Note that this is the same as `Twist(motion_subspace(joint, q), v)`.
 """
 function joint_twist{M, X}(joint::Joint{M}, q::AbstractVector{X}, v::AbstractVector{X})::Twist{promote_type(M, X)}
     @boundscheck check_num_positions(joint, q)

--- a/src/joint_types.jl
+++ b/src/joint_types.jl
@@ -22,7 +22,7 @@ end
 
 
 """
-    QuaternionFloating
+$(TYPEDEF)
 
 A floating joint type that uses a unit quaternion representation for orientation.
 
@@ -232,7 +232,7 @@ end
 
 
 """
-    Prismatic
+$(TYPEDEF)
 
 A `Prismatic` joint type allows translation along a fixed axis.
 """
@@ -244,7 +244,7 @@ immutable Prismatic{T<:Number} <: OneDegreeOfFreedomFixedAxis{T}
 end
 
 """
-    Prismatic(axis)
+$(SIGNATURES)
 
 Construct a new `Prismatic` joint type, allowing translation along `axis`
 (expressed in the frame before the joint).
@@ -294,7 +294,7 @@ end
 
 
 """
-    Revolute
+$(TYPEDEF)
 
 A `Revolute` joint type allows rotation about a fixed axis.
 """
@@ -306,7 +306,7 @@ immutable Revolute{T<:Number} <: OneDegreeOfFreedomFixedAxis{T}
 end
 
 """
-    Revolute(axis)
+$(SIGNATURES)
 
 Construct a new `Revolute` joint type, allowing rotation about `axis`
 (expressed in the frame before the joint).
@@ -354,7 +354,7 @@ end
 
 
 """
-    Fixed
+$(TYPEDEF)
 
 The `Fixed` joint type is a degenerate joint type, in the sense that it allows
 no motion between its predecessor and successor rigid bodies.

--- a/src/joint_types.jl
+++ b/src/joint_types.jl
@@ -21,9 +21,24 @@ function _global_coordinates!(jt::JointType, q::AbstractVector, q0::AbstractVect
 end
 
 
-#=
-QuaternionFloating
-=#
+"""
+    QuaternionFloating
+
+A floating joint type that uses a unit quaternion representation for orientation.
+
+Floating joints are 6-degree-of-freedom joints that are in a sense degenerate,
+as they impose no constraints on the relative motion between two bodies.
+
+The full, 7-dimensional configuration vector of a `QuaternionFloating` joint
+type consists of a unit quaternion representing the orientation that rotates
+vectors from the frame 'directly after' the joint to the frame 'directly before'
+it, and a 3D position vector representing the origin of the frame after the
+joint in the frame before the joint.
+
+The 6-dimensional velocity vector of a `QuaternionFloating` joint is the twist
+of the frame after the joint with respect to the frame before it, expressed in
+the frame after the joint.
+"""
 immutable QuaternionFloating{T} <: JointType{T}
 end
 
@@ -216,15 +231,24 @@ function _velocity_to_configuration_derivative!(::OneDegreeOfFreedomFixedAxis, q
 end
 
 
-#=
-Prismatic
-=#
+"""
+    Prismatic
+
+A `Prismatic` joint type allows translation along a fixed axis.
+"""
 immutable Prismatic{T<:Number} <: OneDegreeOfFreedomFixedAxis{T}
     axis::SVector{3, T}
     rotationFromZAligned::RotMatrix{3, T}
 
     Prismatic(axis::SVector{3, T}) = new(axis, rotation_between(SVector(zero(T), zero(T), one(T)), axis))
 end
+
+"""
+    Prismatic(axis)
+
+Construct a new `Prismatic` joint type, allowing translation along `axis`
+(expressed in the frame before the joint).
+"""
 Prismatic{T}(axis::SVector{3, T}) = Prismatic{T}(axis)
 
 show(io::IO, jt::Prismatic) = print(io, "Prismatic joint with axis $(jt.axis)")
@@ -269,15 +293,24 @@ function _joint_torque!(jt::Prismatic, τ::AbstractVector, q::AbstractVector, jo
 end
 
 
-#=
-Revolute
-=#
+"""
+    Revolute
+
+A `Revolute` joint type allows rotation about a fixed axis.
+"""
 immutable Revolute{T<:Number} <: OneDegreeOfFreedomFixedAxis{T}
     axis::SVector{3, T}
     rotationFromZAligned::RotMatrix{3, T}
 
     Revolute(axis::SVector{3, T}) = new(axis, rotation_between(SVector(zero(T), zero(T), one(T)), axis))
 end
+
+"""
+    Revolute(axis)
+
+Construct a new `Revolute` joint type, allowing rotation about `axis`
+(expressed in the frame before the joint).
+"""
 Revolute{T}(axis::SVector{3, T}) = Revolute{T}(axis)
 
 show(io::IO, jt::Revolute) = print(io, "Revolute joint with axis $(jt.axis)")
@@ -320,9 +353,12 @@ function _joint_torque!(jt::Revolute, τ::AbstractVector, q::AbstractVector, joi
 end
 
 
-#=
-Fixed
-=#
+"""
+    Fixed
+
+The `Fixed` joint type is a degenerate joint type, in the sense that it allows
+no motion between its predecessor and successor rigid bodies.
+"""
 immutable Fixed{T<:Number} <: JointType{T}
 end
 show(io::IO, jt::Fixed) = print(io, "Fixed joint")

--- a/src/mechanism.jl
+++ b/src/mechanism.jl
@@ -32,43 +32,50 @@ be attached with joints.
 """
 Mechanism{T}(rootBody::RigidBody{T}; kwargs...) = Mechanism{T}(rootBody; kwargs...)
 eltype{T}(::Mechanism{T}) = T
-root_vertex(m::Mechanism) = m.toposortedTree[1]
-non_root_vertices(m::Mechanism) = view(m.toposortedTree, 2 : length(m.toposortedTree)) # TODO: allocates
-tree(m::Mechanism) = m.toposortedTree[1]
+root_vertex(mechanism::Mechanism) = mechanism.toposortedTree[1]
+non_root_vertices(mechanism::Mechanism) = view(mechanism.toposortedTree, 2 : length(mechanism.toposortedTree)) # TODO: allocates
+tree(mechanism::Mechanism) = mechanism.toposortedTree[1]
 
 """
 $(SIGNATURES)
 
 Return the root (stationary 'world') body of the `Mechanism`.
 """
-root_body(m::Mechanism) = vertex_data(root_vertex(m))
+root_body(mechanism::Mechanism) = vertex_data(root_vertex(mechanism))
 
 """
 $(SIGNATURES)
 
 Return the default frame of the root body.
 """
-root_frame(m::Mechanism) = default_frame(root_body(m))
-path(m::Mechanism, from::RigidBody, to::RigidBody) = path(findfirst(tree(m), from), findfirst(tree(m), to))
-show(io::IO, m::Mechanism) = print(io, m.toposortedTree[1])
-isinertial(m::Mechanism, frame::CartesianFrame3D) = is_fixed_to_body(frame, root_body(m))
-isroot{T}(m::Mechanism{T}, b::RigidBody{T}) = b == root_body(m)
-non_root_bodies{T}(m::Mechanism{T}) = (vertex_data(vertex) for vertex in non_root_vertices(m))
-num_bodies(m::Mechanism) = length(m.toposortedTree)
+root_frame(mechanism::Mechanism) = default_frame(root_body(mechanism))
+
+"""
+$(SIGNATURES)
+
+Return the path from rigid body `from` to `to` along edges of the `Mechanism`'s
+kinematic tree.
+"""
+path(mechanism::Mechanism, from::RigidBody, to::RigidBody) = path(findfirst(tree(mechanism), from), findfirst(tree(mechanism), to))
+show(io::IO, mechanism::Mechanism) = print(io, mechanism.toposortedTree[1])
+isinertial(mechanism::Mechanism, frame::CartesianFrame3D) = is_fixed_to_body(frame, root_body(mechanism))
+isroot{T}(mechanism::Mechanism{T}, b::RigidBody{T}) = b == root_body(mechanism)
+non_root_bodies{T}(mechanism::Mechanism{T}) = (vertex_data(vertex) for vertex in non_root_vertices(mechanism))
+num_bodies(mechanism::Mechanism) = length(mechanism.toposortedTree)
 
 """
 $(SIGNATURES)
 
 Return the `Joint`s that are part of the `Mechanism` as an iterable collection.
 """
-joints(m::Mechanism) = (edge_to_parent_data(vertex) for vertex in non_root_vertices(m))
+joints(mechanism::Mechanism) = (edge_to_parent_data(vertex) for vertex in non_root_vertices(mechanism))
 
 """
 $(SIGNATURES)
 
 Return the `RigidBody`s that are part of the `Mechanism` as an iterable collection.
 """
-bodies{T}(m::Mechanism{T}) = (vertex_data(vertex) for vertex in m.toposortedTree)
+bodies{T}(mechanism::Mechanism{T}) = (vertex_data(vertex) for vertex in mechanism.toposortedTree)
 
 
 """
@@ -76,23 +83,23 @@ $(SIGNATURES)
 
 Return the dimension of the joint configuration vector ``q``.
 """
-num_positions(m::Mechanism) = num_positions(joints(m))
+num_positions(mechanism::Mechanism) = num_positions(joints(mechanism))
 
 """
 $(SIGNATURES)
 
 Return the dimension of the joint velocity vector ``v``.
 """
-num_velocities(m::Mechanism) = num_velocities(joints(m))
+num_velocities(mechanism::Mechanism) = num_velocities(joints(mechanism))
 
 """
 $(SIGNATURES)
 
 Return the `RigidBody` to which `frame` is attached.
 """
-function body_fixed_frame_to_body(m::Mechanism, frame::CartesianFrame3D)
+function body_fixed_frame_to_body(mechanism::Mechanism, frame::CartesianFrame3D)
     # linear in number of bodies and number of frames; not meant to be super fast
-    for vertex in m.toposortedTree
+    for vertex in mechanism.toposortedTree
         body = vertex_data(vertex)
         if is_fixed_to_body(body, frame)
             return body
@@ -107,10 +114,10 @@ $(SIGNATURES)
 Return the definition of body-fixed frame `frame`, i.e., the `Transform3D` from
 `frame` to the default frame of the body to which it is attached.
 
-See also [default_frame](@ref), [frame_definition](@ref).
+See also [`default_frame`](@ref), [`frame_definition`](@ref).
 """
-function body_fixed_frame_definition(m::Mechanism, frame::CartesianFrame3D)
-    frame_definition(body_fixed_frame_to_body(m, frame), frame)
+function body_fixed_frame_definition(mechanism::Mechanism, frame::CartesianFrame3D)
+    frame_definition(body_fixed_frame_to_body(mechanism, frame), frame)
 end
 
 """
@@ -119,16 +126,16 @@ $(SIGNATURES)
 Return the transform from `CartesianFrame3D` `from` to `to`, both of which are
 rigidly attached to the same `RigidBody`.
 """
-function fixed_transform(m::Mechanism, from::CartesianFrame3D, to::CartesianFrame3D)
-    fixed_transform(body_fixed_frame_to_body(m, from), from, to)
+function fixed_transform(mechanism::Mechanism, from::CartesianFrame3D, to::CartesianFrame3D)
+    fixed_transform(body_fixed_frame_to_body(mechanism, from), from, to)
 end
 
-Base.@deprecate add_body_fixed_frame!{T}(m::Mechanism{T}, body::RigidBody{T}, transform::Transform3D{T}) add_frame!(body, transform)
-function add_body_fixed_frame!{T}(m::Mechanism{T}, transform::Transform3D{T})
-    add_frame!(body_fixed_frame_to_body(m, transform.to), transform)
+Base.@deprecate add_body_fixed_frame!{T}(mechanism::Mechanism{T}, body::RigidBody{T}, transform::Transform3D{T}) add_frame!(body, transform)
+function add_body_fixed_frame!{T}(mechanism::Mechanism{T}, transform::Transform3D{T})
+    add_frame!(body_fixed_frame_to_body(mechanism, transform.to), transform)
 end
 
-function canonicalize_frame_definitions!{T}(m::Mechanism{T}, vertex::TreeVertex{RigidBody{T}, Joint{T}})
+function canonicalize_frame_definitions!{T}(mechanism::Mechanism{T}, vertex::TreeVertex{RigidBody{T}, Joint{T}})
     if !isroot(vertex)
         body = vertex_data(vertex)
         joint = edge_to_parent_data(vertex)
@@ -138,15 +145,15 @@ function canonicalize_frame_definitions!{T}(m::Mechanism{T}, vertex::TreeVertex{
     end
 end
 
-function canonicalize_frame_definitions!(m::Mechanism)
-    for vertex in non_root_vertices(m)
-        canonicalize_frame_definitions!(m, vertex)
+function canonicalize_frame_definitions!(mechanism::Mechanism)
+    for vertex in non_root_vertices(mechanism)
+        canonicalize_frame_definitions!(mechanism, vertex)
     end
 end
 
-function gravitational_spatial_acceleration{M}(m::Mechanism{M})
-    frame = m.gravitationalAcceleration.frame
-    SpatialAcceleration(frame, frame, frame, zeros(SVector{3, M}), m.gravitationalAcceleration.v)
+function gravitational_spatial_acceleration{M}(mechanism::Mechanism{M})
+    frame = mechanism.gravitationalAcceleration.frame
+    SpatialAcceleration(frame, frame, frame, zeros(SVector{3, mechanism}), mechanism.gravitationalAcceleration.v)
 end
 
 function constraint_jacobian_structure(mechanism::Mechanism)

--- a/src/mechanism.jl
+++ b/src/mechanism.jl
@@ -24,6 +24,12 @@ type Mechanism{T<:Number}
     end
 end
 
+"""
+$(SIGNATURES)
+
+Create a new `Mechanism` containing only a root body, to which other bodies can
+be attached with joints.
+"""
 Mechanism{T}(rootBody::RigidBody{T}; kwargs...) = Mechanism{T}(rootBody; kwargs...)
 eltype{T}(::Mechanism{T}) = T
 root_vertex(m::Mechanism) = m.toposortedTree[1]

--- a/src/mechanism.jl
+++ b/src/mechanism.jl
@@ -5,7 +5,7 @@ type NonTreeEdge{T}
 end
 
 """
-    Mechanism
+$(TYPEDEF)
 
 A `Mechanism` represents an interconnection of rigid bodies and joints.
 `Mechanism`s store the joint layout and inertia parameters, but no
@@ -29,19 +29,61 @@ eltype{T}(::Mechanism{T}) = T
 root_vertex(m::Mechanism) = m.toposortedTree[1]
 non_root_vertices(m::Mechanism) = view(m.toposortedTree, 2 : length(m.toposortedTree)) # TODO: allocates
 tree(m::Mechanism) = m.toposortedTree[1]
+
+"""
+$(SIGNATURES)
+
+Return the root (stationary 'world') body of the `Mechanism`.
+"""
 root_body(m::Mechanism) = vertex_data(root_vertex(m))
+
+"""
+$(SIGNATURES)
+
+Return the default frame of the root body.
+"""
 root_frame(m::Mechanism) = default_frame(root_body(m))
 path(m::Mechanism, from::RigidBody, to::RigidBody) = path(findfirst(tree(m), from), findfirst(tree(m), to))
 show(io::IO, m::Mechanism) = print(io, m.toposortedTree[1])
 isinertial(m::Mechanism, frame::CartesianFrame3D) = is_fixed_to_body(frame, root_body(m))
 isroot{T}(m::Mechanism{T}, b::RigidBody{T}) = b == root_body(m)
-joints(m::Mechanism) = (edge_to_parent_data(vertex) for vertex in non_root_vertices(m))
-bodies{T}(m::Mechanism{T}) = (vertex_data(vertex) for vertex in m.toposortedTree)
 non_root_bodies{T}(m::Mechanism{T}) = (vertex_data(vertex) for vertex in non_root_vertices(m))
-num_positions(m::Mechanism) = num_positions(joints(m))
-num_velocities(m::Mechanism) = num_velocities(joints(m))
 num_bodies(m::Mechanism) = length(m.toposortedTree)
 
+"""
+$(SIGNATURES)
+
+Return the `Joint`s that are part of the `Mechanism` as an iterable collection.
+"""
+joints(m::Mechanism) = (edge_to_parent_data(vertex) for vertex in non_root_vertices(m))
+
+"""
+$(SIGNATURES)
+
+Return the `RigidBody`s that are part of the `Mechanism` as an iterable collection.
+"""
+bodies{T}(m::Mechanism{T}) = (vertex_data(vertex) for vertex in m.toposortedTree)
+
+
+"""
+$(SIGNATURES)
+
+Return the dimension of the joint configuration vector ``q``.
+"""
+num_positions(m::Mechanism) = num_positions(joints(m))
+
+"""
+$(SIGNATURES)
+
+Return the dimension of the joint velocity vector ``v``.
+"""
+num_velocities(m::Mechanism) = num_velocities(joints(m))
+
+"""
+$(SIGNATURES)
+
+Return the `RigidBody` to which `frame` is attached.
+"""
 function body_fixed_frame_to_body(m::Mechanism, frame::CartesianFrame3D)
     # linear in number of bodies and number of frames; not meant to be super fast
     for vertex in m.toposortedTree
@@ -53,16 +95,29 @@ function body_fixed_frame_to_body(m::Mechanism, frame::CartesianFrame3D)
     error("Unable to determine to what body $(frame) is attached")
 end
 
+"""
+$(SIGNATURES)
+
+Return the definition of body-fixed frame `frame`, i.e., the `Transform3D` from
+`frame` to the default frame of the body to which it is attached.
+
+See also [default_frame](@ref), [frame_definition](@ref).
+"""
 function body_fixed_frame_definition(m::Mechanism, frame::CartesianFrame3D)
     frame_definition(body_fixed_frame_to_body(m, frame), frame)
 end
 
+"""
+$(SIGNATURES)
+
+Return the transform from `CartesianFrame3D` `from` to `to`, both of which are
+rigidly attached to the same `RigidBody`.
+"""
 function fixed_transform(m::Mechanism, from::CartesianFrame3D, to::CartesianFrame3D)
     fixed_transform(body_fixed_frame_to_body(m, from), from, to)
 end
 
 Base.@deprecate add_body_fixed_frame!{T}(m::Mechanism{T}, body::RigidBody{T}, transform::Transform3D{T}) add_frame!(body, transform)
-
 function add_body_fixed_frame!{T}(m::Mechanism{T}, transform::Transform3D{T})
     add_frame!(body_fixed_frame_to_body(m, transform.to), transform)
 end
@@ -83,252 +138,10 @@ function canonicalize_frame_definitions!(m::Mechanism)
     end
 end
 
-"""
-    attach!(mechanism, predecessor, joint, jointToPredecessor, successor, successorToJoint)
-
-Attach `successor` to `predecessor` via `joint`.
-
-See [`Joint`](@ref) for definitions of the terms successor and predecessor.
-
-The `Transform3D`s `jointToPredecessor` and `successorToJoint` define where
-`joint` is attached to each body. `jointToPredecessor` should define
-`joint.frameBefore` with respect to any frame fixed to `predecessor`, and likewise
-`successorToJoint` should define any frame fixed to `successor` with respect to
-`joint.frameAfter`.
-
-`predecessor` is required to already be among the bodies of the `Mechanism`.
-
-If `successor` is not yet a part of the `Mechanism`, it will be added.
-Otherwise, the `joint` will be treated as a non-tree edge in the `Mechanism`
-(effectively creating a loop).
-"""
-function attach!{T}(m::Mechanism{T}, predecessor::RigidBody{T}, joint::Joint, jointToPredecessor::Transform3D{T},
-        successor::RigidBody{T}, successorToJoint::Transform3D{T} = Transform3D{T}(default_frame(successor), joint.frameAfter))
-    # TODO: check that jointToPredecessor.from and successorToJoint.to match joint.
-
-    # define where joint is attached on predecessor
-    add_frame!(predecessor, jointToPredecessor)
-
-    # define where child is attached to joint
-    add_frame!(successor, inv(successorToJoint))
-
-    if successor ∈ bodies(m)
-        push!(m.nonTreeEdges, NonTreeEdge(joint, predecessor, successor))
-    else
-        vertex = insert!(tree(m), successor, joint, predecessor)
-        m.toposortedTree = toposort(tree(m))
-        canonicalize_frame_definitions!(m, vertex)
-    end
-    m
-end
-
-check_no_cycles(m::Mechanism) = (length(m.nonTreeEdges) == 0 || error("Mechanisms with cycles not yet supported."))
-
-# Essentially replaces the root body of childMechanism with parentBody (which belongs to m)
-function attach!{T}(m::Mechanism{T}, parentBody::RigidBody{T}, childMechanism::Mechanism{T})
-    check_no_cycles(m)
-    check_no_cycles(childMechanism)
-
-    # note: gravitational acceleration for childMechanism is ignored.
-    parentVertex = findfirst(tree(m), parentBody)
-    childRootVertex = root_vertex(childMechanism)
-    childRootBody = vertex_data(childRootVertex)
-
-    # define where child root body is located w.r.t parent body
-    # and add frames that were attached to childRootBody to parentBody
-    add_frame!(parentBody, Transform3D{T}(default_frame(childRootBody), default_frame(parentBody))) # TODO: add optional function argument
-    for transform in frame_definitions(childRootBody)
-        add_frame!(parentBody, transform)
-    end
-    canonicalize_frame_definitions!(m, parentVertex)
-
-    # merge trees
-    for child in children(childRootVertex)
-        vertex = insert_subtree!(parentVertex, child)
-        canonicalize_frame_definitions!(m, vertex)
-    end
-
-    m.toposortedTree = toposort(tree(m))
-
-    m
-end
-
-function submechanism{T}(m::Mechanism{T}, submechanismRootBody::RigidBody{T})
-    check_no_cycles(m)
-
-    # Create mechanism and set up tree
-    ret = Mechanism{T}(submechanismRootBody; gravity = m.gravitationalAcceleration.v)
-    for child in children(findfirst(tree(m), submechanismRootBody))
-        insert_subtree!(root_vertex(ret), child)
-    end
-    ret.toposortedTree = toposort(tree(ret))
-    canonicalize_frame_definitions!(ret)
-    ret
-end
-
-#=
-Detaches the subtree rooted at oldSubtreeRootBody, reroots it so that newSubtreeRootBody is the new root, and then attaches
-newSubtreeRootBody to parentBody using the specified joint.
-=#
-function reattach!{T}(mechanism::Mechanism{T}, oldSubtreeRootBody::RigidBody{T},
-        parentBody::RigidBody{T}, joint::Joint, jointToParent::Transform3D{T},
-        newSubtreeRootBody::RigidBody{T}, newSubTreeRootBodyToJoint::Transform3D{T} = Transform3D{T}(default_frame(newSubtreeRootBody), joint.frameAfter))
-    # TODO: add option to prune frames related to old joints
-    check_no_cycles(mechanism)
-
-    newSubtreeRoot = findfirst(tree(mechanism), newSubtreeRootBody)
-    oldSubtreeRoot = findfirst(tree(mechanism), oldSubtreeRootBody)
-    parentVertex = findfirst(tree(mechanism), parentBody)
-    @assert newSubtreeRoot ∈ toposort(oldSubtreeRoot)
-    @assert parentVertex ∉ toposort(oldSubtreeRoot)
-
-    # detach oldSubtreeRoot
-    detach!(oldSubtreeRoot)
-
-    # reroot
-    flippedJoints = Dict{Joint{T}, Joint{T}}()
-    flipDirectionFunction = joint -> begin
-        flipped = Joint(joint.name * "_flipped", flip_direction(joint.jointType))
-        flippedJoints[joint] = flipped
-        flipped
-    end
-    subtreeRerooted = reroot(newSubtreeRoot, flipDirectionFunction)
-
-    # attach newSubtreeRoot using joint
-    insert!(parentVertex, subtreeRerooted, joint)
-    mechanism.toposortedTree = toposort(tree(mechanism))
-
-    # define frames related to new joint
-    add_frame!(parentBody, jointToParent)
-    add_frame!(newSubtreeRootBody, inv(newSubTreeRootBodyToJoint))
-
-    # define identities between new frames and old frames and recanonicalize frame definitions
-    for (oldJoint, newJoint) in flippedJoints
-        add_body_fixed_frame!(mechanism, Transform3D{T}(newJoint.frameBefore, oldJoint.frameAfter))
-        add_body_fixed_frame!(mechanism, Transform3D{T}(newJoint.frameAfter, oldJoint.frameBefore))
-    end
-    canonicalize_frame_definitions!(mechanism)
-
-    flippedJoints
-end
-
-function remove_fixed_joints!(m::Mechanism)
-    check_no_cycles(m)
-    T = eltype(m)
-    for vertex in copy(m.toposortedTree)
-        if !isroot(vertex)
-            body = vertex_data(vertex)
-            joint = edge_to_parent_data(vertex)
-            parentVertex = parent(vertex)
-            parentBody = vertex_data(parentVertex)
-            if isa(joint.jointType, Fixed)
-                # add identity joint transform as a body-fixed frame definition
-                jointTransform = Transform3D{T}(joint.frameAfter, joint.frameBefore)
-                add_frame!(parentBody, jointTransform)
-
-                # migrate body fixed frames to parent body
-                for tf in frame_definitions(body)
-                    add_frame!(parentBody, tf)
-                end
-
-                # add inertia to parent body
-                if has_defined_inertia(parentBody)
-                    inertia = spatial_inertia(body)
-                    parentInertia = spatial_inertia(parentBody)
-                    toParent = fixed_transform(parentBody, inertia.frame, parentInertia.frame)
-                    parentBody.inertia = parentInertia + transform(inertia, toParent)
-                end
-
-                # merge vertex into parent
-                formerChildren = children(vertex)
-                merge_into_parent!(vertex)
-
-                # recanonicalize children since their new parent's default frame may be different
-                for child in formerChildren
-                    canonicalize_frame_definitions!(m, child)
-                end
-            end
-        end
-    end
-    m.toposortedTree = toposort(tree(m))
-    m
-end
-
-function maximal_coordinates(mechanism::Mechanism)
-    T = eltype(mechanism)
-    bodymap = Dict{RigidBody{T}, RigidBody{T}}()
-    jointmap = Dict{Joint{T}, Joint{T}}()
-    newfloatingjoints = Dict{RigidBody{T}, Joint{T}}()
-    oldroot = root_body(mechanism)
-    newroot = bodymap[oldroot] = deepcopy(oldroot)
-    ret = Mechanism(newroot, gravity = mechanism.gravitationalAcceleration.v)
-
-    # Copy bodies and attach them to the root with a floating joint.
-    for oldbody in non_root_bodies(mechanism)
-        newbody = bodymap[oldbody] = deepcopy(oldbody)
-        frameBefore = default_frame(newroot)
-        frameAfter = default_frame(newbody)
-        floatingjoint = newfloatingjoints[newbody] = Joint(name(newbody), frameBefore, frameAfter, QuaternionFloating{T}())
-        attach!(ret, newroot, floatingjoint, Transform3D(T, frameBefore), newbody, Transform3D(T, frameAfter))
-    end
-
-    # Copy input Mechanism's joints.
-    function copy_edge(oldpredecessor::RigidBody, oldjoint::Joint, oldsuccessor::RigidBody)
-        newjoint = jointmap[oldjoint] = deepcopy(oldjoint)
-        jointToPredecessor = fixed_transform(mechanism, newjoint.frameBefore, default_frame(oldpredecessor))
-        successorToJoint = fixed_transform(mechanism, default_frame(oldsuccessor), newjoint.frameAfter)
-        attach!(ret, bodymap[oldpredecessor], newjoint, jointToPredecessor, bodymap[oldsuccessor], successorToJoint)
-    end
-
-    for vertex in non_root_vertices(mechanism)
-        copy_edge(vertex_data(parent(vertex)), edge_to_parent_data(vertex), vertex_data(vertex))
-    end
-
-    for nonTreeEdge in mechanism.nonTreeEdges
-        copy_edge(nonTreeEdge.predecessor, nonTreeEdge.successor, nonTreeEdge.joint)
-    end
-
-    ret, newfloatingjoints, bodymap, jointmap
-end
-
-function rand_mechanism{T}(::Type{T}, parentSelector::Function, jointTypes...)
-    parentBody = RigidBody{T}("world")
-    m = Mechanism(parentBody)
-    for i = 1 : length(jointTypes)
-        @assert jointTypes[i] <: JointType{T}
-        joint = Joint("joint$i", rand(jointTypes[i]))
-        jointToParentBody = rand(Transform3D{T}, joint.frameBefore, default_frame(parentBody))
-        body = RigidBody(rand(SpatialInertia{T}, CartesianFrame3D("body$i")))
-        bodyToJoint = Transform3D{T}(default_frame(body), joint.frameAfter)
-        attach!(m, parentBody, joint, jointToParentBody, body, bodyToJoint)
-        parentBody = parentSelector(m)
-    end
-    return m
-end
-
-rand_chain_mechanism{T}(t::Type{T}, jointTypes...) = rand_mechanism(t, m::Mechanism -> vertex_data(m.toposortedTree[end]), jointTypes...)
-rand_tree_mechanism{T}(t::Type{T}, jointTypes...) = rand_mechanism(t, m::Mechanism -> rand(collect(bodies(m))), jointTypes...)
-function rand_floating_tree_mechanism{T}(t::Type{T}, nonFloatingJointTypes...)
-    parentSelector = (m::Mechanism) -> begin
-        only_root = length(bodies(m)) == 1
-        only_root ? root_body(m) : rand(collect(non_root_bodies(m)))
-    end
-    rand_mechanism(t, parentSelector, [QuaternionFloating{T}; nonFloatingJointTypes...]...)
-end
-
 function gravitational_spatial_acceleration{M}(m::Mechanism{M})
     frame = m.gravitationalAcceleration.frame
     SpatialAcceleration(frame, frame, frame, zeros(SVector{3, M}), m.gravitationalAcceleration.v)
 end
-
-function subtree_mass{T}(base::Tree{RigidBody{T}, Joint{T}})
-    result = isroot(base) ? zero(T) : spatial_inertia(vertex_data(base)).mass
-    for child in children(base)
-        result += subtree_mass(child)
-    end
-    result
-end
-mass(m::Mechanism) = subtree_mass(tree(m))
 
 function constraint_jacobian_structure(mechanism::Mechanism)
     # columns correspond to non-tree edges, rows correspond to tree joints

--- a/src/mechanism.jl
+++ b/src/mechanism.jl
@@ -151,9 +151,9 @@ function canonicalize_frame_definitions!(mechanism::Mechanism)
     end
 end
 
-function gravitational_spatial_acceleration{M}(mechanism::Mechanism{M})
+function gravitational_spatial_acceleration(mechanism::Mechanism)
     frame = mechanism.gravitationalAcceleration.frame
-    SpatialAcceleration(frame, frame, frame, zeros(SVector{3, mechanism}), mechanism.gravitationalAcceleration.v)
+    SpatialAcceleration(frame, frame, frame, zeros(SVector{3, eltype(mechanism)}), mechanism.gravitationalAcceleration.v)
 end
 
 function constraint_jacobian_structure(mechanism::Mechanism)

--- a/src/mechanism_algorithms.jl
+++ b/src/mechanism_algorithms.jl
@@ -55,7 +55,7 @@ Compute a geometric Jacobian (also known as a basic, or spatial Jacobian)
 for a path in the graph of joints and bodies of a `Mechanism`,
 in the given state.
 
-See also [path](@ref), [GeometricJacobian](@ref).
+See also [`path`](@ref), [`GeometricJacobian`](@ref).
 """
 function geometric_jacobian{X, M, C}(state::MechanismState{X, M, C}, path::Path{RigidBody{M}, Joint{M}})
     copysign = (motionSubspace::GeometricJacobian, sign::Int64) -> sign < 0 ? -motionSubspace : motionSubspace

--- a/src/mechanism_algorithms.jl
+++ b/src/mechanism_algorithms.jl
@@ -1,6 +1,27 @@
 """
 $(SIGNATURES)
 
+Return the mass of a subtree of a `Mechanism`, rooted at `base` (including
+the mass of `base`).
+"""
+function subtree_mass{T}(base::Tree{RigidBody{T}, Joint{T}})
+    result = isroot(base) ? zero(T) : spatial_inertia(vertex_data(base)).mass
+    for child in children(base)
+        result += subtree_mass(child)
+    end
+    result
+end
+
+"""
+$(SIGNATURES)
+
+Return the total mass of the `Mechanism`.
+"""
+mass(m::Mechanism) = subtree_mass(tree(m))
+
+"""
+$(SIGNATURES)
+
 Compute the center of mass of an iterable subset of a `Mechanism`'s bodies in
 the given state.
 """

--- a/src/mechanism_algorithms.jl
+++ b/src/mechanism_algorithms.jl
@@ -1,3 +1,9 @@
+"""
+$(SIGNATURES)
+
+Compute the center of mass of an iterable subset of a `Mechanism`'s bodies in
+the given state.
+"""
 function center_of_mass{X, M, C}(state::MechanismState{X, M, C}, itr)
     frame = root_frame(state.mechanism)
     com = Point3D(frame, zeros(SVector{3, C}))
@@ -14,8 +20,22 @@ function center_of_mass{X, M, C}(state::MechanismState{X, M, C}, itr)
     com
 end
 
+"""
+$(SIGNATURES)
+
+Compute the center of mass of the whole `Mechanism` in the given state.
+"""
 center_of_mass(state::MechanismState) = center_of_mass(state, non_root_bodies(state.mechanism))
 
+"""
+$(SIGNATURES)
+
+Compute a geometric Jacobian (also known as a basic, or spatial Jacobian)
+for a path in the graph of joints and bodies of a `Mechanism`,
+in the given state.
+
+See also [RigidBodyDynamics.path](@ref).
+"""
 function geometric_jacobian{X, M, C}(state::MechanismState{X, M, C}, path::Path{RigidBody{M}, Joint{M}})
     copysign = (motionSubspace::GeometricJacobian, sign::Int64) -> sign < 0 ? -motionSubspace : motionSubspace
     motionSubspaces = [copysign(motion_subspace(state, joint), sign)::GeometricJacobian for (joint, sign) in zip(path.edgeData, path.directions)]
@@ -43,6 +63,12 @@ function acceleration_wrt_ancestor{X, M, C, V}(state::MechanismState{X, M, C},
     -bias_acceleration(state, vertex_data(ancestor)) + bias_acceleration(state, vertex_data(descendant)) + accel
 end
 
+"""
+$(SIGNATURES)
+
+Compute the spatial acceleration of `body` with respect to `base` for
+the given state and joint acceleration vector ``\\dot{v}``.
+"""
 function relative_acceleration(state::MechanismState, body::RigidBody, base::RigidBody, v̇::AbstractVector)
     bodyVertex = findfirst(tree(state.mechanism), body)
     baseVertex = findfirst(tree(state.mechanism), base)
@@ -50,6 +76,13 @@ function relative_acceleration(state::MechanismState, body::RigidBody, base::Rig
     -acceleration_wrt_ancestor(state, baseVertex, lca, v̇) + acceleration_wrt_ancestor(state, bodyVertex, lca, v̇)
 end
 
+"""
+$(SIGNATURES)
+
+Compute the gravitational potential energy in the given state, computed as the
+negation of the dot product of the gravitational force and the center
+of mass expressed in the `Mechanism`'s root frame.
+"""
 function gravitational_potential_energy{X, M, C}(state::MechanismState{X, M, C})
     m = mass(state.mechanism)
     gravitationalForce = m * state.mechanism.gravitationalAcceleration
@@ -83,6 +116,27 @@ function gravitational_potential_energy{X, M, C}(state::MechanismState{X, M, C})
      end
  end
 
+const mass_matrix_doc = """Compute the joint-space mass matrix
+(also known as the inertia matrix) of the `Mechanism` in the given state, i.e.,
+the matrix ``M(q)`` in the unconstrained joint-space equations of motion
+```math
+M(q) \\dot{v} + c(q, v, w_\\text{ext}) = \\tau
+```
+
+This method implements the composite rigid body algorithm.
+"""
+
+"""
+$(SIGNATURES)
+
+$mass_matrix_doc
+
+$noalloc_doc
+
+The `out` argument must be an ``n_v \\times n_v`` lower triangular
+`Symmetric` matrix, where ``n_v`` is the dimension of the `Mechanism`'s joint
+velocity vector ``v``.
+"""
 function mass_matrix!{X, M, C}(out::Symmetric{C, Matrix{C}}, state::MechanismState{X, M, C})
     @boundscheck size(out, 1) == num_velocities(state) || error("mass matrix has wrong size")
     @boundscheck out.uplo == 'L' || error("expected a lower triangular symmetric matrix type as the mass matrix")
@@ -116,6 +170,11 @@ function mass_matrix!{X, M, C}(out::Symmetric{C, Matrix{C}}, state::MechanismSta
     end
 end
 
+"""
+$(SIGNATURES)
+
+$mass_matrix_doc
+"""
 function mass_matrix{X, M, C}(state::MechanismState{X, M, C})
     nv = num_velocities(state)
     ret = Symmetric(Matrix{C}(nv, nv), :L)
@@ -123,6 +182,28 @@ function mass_matrix{X, M, C}(state::MechanismState{X, M, C})
     ret
 end
 
+const momentum_matrix_doc = """Compute the momentum matrix ``A(q)`` of the
+`Mechanism` in the given state.
+
+The momentum matrix maps the `Mechanism`'s joint velocity vectory ``v`` to
+its total momentum.
+
+This is a slight generalization of the centroidal momentum matrix
+(Orin, Goswami, "Centroidal momentum matrix of a humanoid robot: Structure and properties.")
+in that the matrix (and hence the corresponding total momentum) need not be
+expressed in a centroidal frame.
+"""
+
+"""
+$(SIGNATURES)
+
+$momentum_matrix_doc
+
+$noalloc_doc
+
+The `out` argument must be a mutable `MomentumMatrix` with as many columns as
+the dimension of the `Mechanism`'s joint velocity vector ``v``.
+"""
 function momentum_matrix!(out::MomentumMatrix, state::MechanismState)
     @boundscheck num_velocities(state) == num_cols(out) || error("size mismatch")
     pos = 1
@@ -136,6 +217,11 @@ function momentum_matrix!(out::MomentumMatrix, state::MechanismState)
     end
 end
 
+"""
+$(SIGNATURES)
+
+$momentum_matrix_doc
+"""
 function momentum_matrix(state::MechanismState)
     ncols = num_velocities(state)
     T = cache_eltype(state)
@@ -192,13 +278,12 @@ function newton_euler!{T, X, M, W}(
     end
 end
 
-"""
-Note: pass in net wrenches as wrenches argument. wrenches argument is modified to be joint wrenches
-"""
+
 function joint_wrenches_and_torques!{T, X, M}(
         torquesOut::StridedVector{T},
         netWrenchesInJointWrenchesOut::Associative{RigidBody{M}, Wrench{T}},
         state::MechanismState{X, M})
+    # Note: pass in net wrenches as wrenches argument. wrenches argument is modified to be joint wrenches
     @boundscheck length(torquesOut) == num_velocities(state) || error("torquesOut size is wrong")
     vertices = state.toposortedStateVertices
     for i = length(vertices) : -1 : 2
@@ -216,6 +301,20 @@ function joint_wrenches_and_torques!{T, X, M}(
     end
 end
 
+"""
+$(SIGNATURES)
+
+Compute the 'dynamics bias term', i.e. the term
+```math
+c(q, v, w_\\text{ext})
+```
+in the unconstrained joint-space equations of motion
+```math
+M(q) \\dot{v} + c(q, v, w_\\text{ext}) = \\tau
+```
+
+$noalloc_doc
+"""
 function dynamics_bias!{T, X, M, W}(
         torques::AbstractVector{T},
         biasAccelerations::Associative{RigidBody{M}, SpatialAcceleration{T}},
@@ -228,6 +327,25 @@ function dynamics_bias!{T, X, M, W}(
     joint_wrenches_and_torques!(torques, wrenches, state)
 end
 
+const inverse_dynamics_doc = """Do inverse dynamics, i.e. compute ``\\tau``
+in the unconstrained joint-space equations of motion
+```math
+M(q) \\dot{v} + c(q, v, w_\\text{ext}) = \\tau
+```
+given joint configuration vectory ``q``, joint velocity vector ``v``,
+joint acceleration vector ``\\dot{v}`` and (optionally) external
+wrenches ``w_\\text{ext}``.
+
+This method implements the recursive Newton-Euler algorithm.
+"""
+
+"""
+$(SIGNATURES)
+
+$inverse_dynamics_doc
+
+$noalloc_doc
+"""
 function inverse_dynamics!{T, X, M, V, W}(
         torquesOut::AbstractVector{T},
         jointWrenchesOut::Associative{RigidBody{M}, Wrench{T}},
@@ -240,7 +358,11 @@ function inverse_dynamics!{T, X, M, V, W}(
     joint_wrenches_and_torques!(torquesOut, jointWrenchesOut, state)
 end
 
-# note: lots of allocations, preallocate stuff and use inverse_dynamics! for performance
+"""
+$(SIGNATURES)
+
+$inverse_dynamics_doc
+"""
 function inverse_dynamics{X, M, V, W}(
         state::MechanismState{X, M},
         v̇::AbstractVector{V},
@@ -391,18 +513,45 @@ function dynamics_solve!{S, T<:LinAlg.BlasReal}(result::DynamicsResult{S, T}, τ
     nothing
 end
 
-function dynamics!{T, X, M, Tau, W}(out::DynamicsResult{T}, state::MechanismState{X, M},
+"""
+$(SIGNATURES)
+
+Compute the joint acceleration vector ``\\dot{v}`` and Lagrange multipliers
+``\\lambda`` that satisfy the joint-space equations of motion
+```math
+M(q) \\dot{v} + c(q, v, w_\\text{ext}) = \\tau - K(q)^{T} \\lambda
+```
+and the constraint equations
+```math
+K(q) \\dot{v} = -k
+```
+given joint configuration vectory ``q``, joint velocity vector ``v``, and
+(optionally) joint torques ``\\tau`` and external wrenches ``w_\\text{ext}``.
+"""
+function dynamics!{T, X, M, Tau, W}(result::DynamicsResult{T}, state::MechanismState{X, M},
         torques::AbstractVector{Tau} = NullVector{T}(num_velocities(state)),
         externalWrenches::Associative{RigidBody{M}, Wrench{W}} = NullDict{RigidBody{M}, Wrench{T}}())
-    dynamics_bias!(out.dynamicsBias, out.accelerations, out.jointWrenches, state, externalWrenches)
-    mass_matrix!(out.massMatrix, state)
-    constraint_jacobian_and_bias!(state, out.constraintJacobian, out.constraintBias)
-    dynamics_solve!(out, torques)
+    dynamics_bias!(result.dynamicsBias, result.accelerations, result.jointWrenches, state, externalWrenches)
+    mass_matrix!(result.massMatrix, state)
+    constraint_jacobian_and_bias!(state, result.constraintJacobian, result.constraintBias)
+    dynamics_solve!(result, torques)
     nothing
 end
 
-# Convenience function that takes a Vector argument for the state stacked as [q; v]
-# and returns a Vector, for use with standard ODE integrators.
+
+"""
+$(SIGNATURES)
+
+Convenience function for use with standard ODE integrators that takes a
+`Vector` argument
+```math
+x = \\left(\\begin{array}{c}
+q\\\\
+v
+\\end{array}\\right)
+```
+and returns a `Vector` ``\\dot{x}``.
+"""
 function dynamics!{T, X, M, Tau, W}(ẋ::StridedVector{X},
         result::DynamicsResult{T}, state::MechanismState{X, M}, stateVec::AbstractVector{X},
         torques::AbstractVector{Tau} = NullVector{T}(num_velocities(state)),

--- a/src/mechanism_algorithms.jl
+++ b/src/mechanism_algorithms.jl
@@ -55,7 +55,7 @@ Compute a geometric Jacobian (also known as a basic, or spatial Jacobian)
 for a path in the graph of joints and bodies of a `Mechanism`,
 in the given state.
 
-See also [RigidBodyDynamics.path](@ref).
+See also [path](@ref), [GeometricJacobian](@ref).
 """
 function geometric_jacobian{X, M, C}(state::MechanismState{X, M, C}, path::Path{RigidBody{M}, Joint{M}})
     copysign = (motionSubspace::GeometricJacobian, sign::Int64) -> sign < 0 ? -motionSubspace : motionSubspace

--- a/src/mechanism_manipulation.jl
+++ b/src/mechanism_manipulation.jl
@@ -1,0 +1,233 @@
+"""
+    attach!(mechanism, predecessor, joint, jointToPredecessor, successor, successorToJoint)
+
+Attach `successor` to `predecessor` via `joint`.
+
+See [`Joint`](@ref) for definitions of the terms successor and predecessor.
+
+The `Transform3D`s `jointToPredecessor` and `successorToJoint` define where
+`joint` is attached to each body. `jointToPredecessor` should define
+`joint.frameBefore` with respect to any frame fixed to `predecessor`, and likewise
+`successorToJoint` should define any frame fixed to `successor` with respect to
+`joint.frameAfter`.
+
+`predecessor` is required to already be among the bodies of the `Mechanism`.
+
+If `successor` is not yet a part of the `Mechanism`, it will be added to the
+`Mechanism`. Otherwise, the `joint` will be treated as a non-tree edge in the
+`Mechanism`, effectively creating a loop constraint that will be enforced
+using Lagrange multipliers (as opposed to using recursive algorithms).
+"""
+function attach!{T}(m::Mechanism{T}, predecessor::RigidBody{T}, joint::Joint, jointToPredecessor::Transform3D{T},
+        successor::RigidBody{T}, successorToJoint::Transform3D{T} = Transform3D{T}(default_frame(successor), joint.frameAfter))
+    # TODO: check that jointToPredecessor.from and successorToJoint.to match joint.
+
+    # define where joint is attached on predecessor
+    add_frame!(predecessor, jointToPredecessor)
+
+    # define where child is attached to joint
+    add_frame!(successor, inv(successorToJoint))
+
+    if successor ∈ bodies(m)
+        push!(m.nonTreeEdges, NonTreeEdge(joint, predecessor, successor))
+    else
+        vertex = insert!(tree(m), successor, joint, predecessor)
+        m.toposortedTree = toposort(tree(m))
+        canonicalize_frame_definitions!(m, vertex)
+    end
+    m
+end
+
+check_no_cycles(m::Mechanism) = (length(m.nonTreeEdges) == 0 || error("Mechanisms with cycles not yet supported."))
+
+# Essentially replaces the root body of childMechanism with parentBody (which belongs to m)
+function attach!{T}(m::Mechanism{T}, parentBody::RigidBody{T}, childMechanism::Mechanism{T})
+    check_no_cycles(m)
+    check_no_cycles(childMechanism)
+
+    # note: gravitational acceleration for childMechanism is ignored.
+    parentVertex = findfirst(tree(m), parentBody)
+    childRootVertex = root_vertex(childMechanism)
+    childRootBody = vertex_data(childRootVertex)
+
+    # define where child root body is located w.r.t parent body
+    # and add frames that were attached to childRootBody to parentBody
+    add_frame!(parentBody, Transform3D{T}(default_frame(childRootBody), default_frame(parentBody))) # TODO: add optional function argument
+    for transform in frame_definitions(childRootBody)
+        add_frame!(parentBody, transform)
+    end
+    canonicalize_frame_definitions!(m, parentVertex)
+
+    # merge trees
+    for child in children(childRootVertex)
+        vertex = insert_subtree!(parentVertex, child)
+        canonicalize_frame_definitions!(m, vertex)
+    end
+
+    m.toposortedTree = toposort(tree(m))
+
+    m
+end
+
+function submechanism{T}(m::Mechanism{T}, submechanismRootBody::RigidBody{T})
+    check_no_cycles(m)
+
+    # Create mechanism and set up tree
+    ret = Mechanism{T}(submechanismRootBody; gravity = m.gravitationalAcceleration.v)
+    for child in children(findfirst(tree(m), submechanismRootBody))
+        insert_subtree!(root_vertex(ret), child)
+    end
+    ret.toposortedTree = toposort(tree(ret))
+    canonicalize_frame_definitions!(ret)
+    ret
+end
+
+#=
+Detaches the subtree rooted at oldSubtreeRootBody, reroots it so that newSubtreeRootBody is the new root, and then attaches
+newSubtreeRootBody to parentBody using the specified joint.
+=#
+function reattach!{T}(mechanism::Mechanism{T}, oldSubtreeRootBody::RigidBody{T},
+        parentBody::RigidBody{T}, joint::Joint, jointToParent::Transform3D{T},
+        newSubtreeRootBody::RigidBody{T}, newSubTreeRootBodyToJoint::Transform3D{T} = Transform3D{T}(default_frame(newSubtreeRootBody), joint.frameAfter))
+    # TODO: add option to prune frames related to old joints
+    check_no_cycles(mechanism)
+
+    newSubtreeRoot = findfirst(tree(mechanism), newSubtreeRootBody)
+    oldSubtreeRoot = findfirst(tree(mechanism), oldSubtreeRootBody)
+    parentVertex = findfirst(tree(mechanism), parentBody)
+    @assert newSubtreeRoot ∈ toposort(oldSubtreeRoot)
+    @assert parentVertex ∉ toposort(oldSubtreeRoot)
+
+    # detach oldSubtreeRoot
+    detach!(oldSubtreeRoot)
+
+    # reroot
+    flippedJoints = Dict{Joint{T}, Joint{T}}()
+    flipDirectionFunction = joint -> begin
+        flipped = Joint(joint.name * "_flipped", flip_direction(joint.jointType))
+        flippedJoints[joint] = flipped
+        flipped
+    end
+    subtreeRerooted = reroot(newSubtreeRoot, flipDirectionFunction)
+
+    # attach newSubtreeRoot using joint
+    insert!(parentVertex, subtreeRerooted, joint)
+    mechanism.toposortedTree = toposort(tree(mechanism))
+
+    # define frames related to new joint
+    add_frame!(parentBody, jointToParent)
+    add_frame!(newSubtreeRootBody, inv(newSubTreeRootBodyToJoint))
+
+    # define identities between new frames and old frames and recanonicalize frame definitions
+    for (oldJoint, newJoint) in flippedJoints
+        add_body_fixed_frame!(mechanism, Transform3D{T}(newJoint.frameBefore, oldJoint.frameAfter))
+        add_body_fixed_frame!(mechanism, Transform3D{T}(newJoint.frameAfter, oldJoint.frameBefore))
+    end
+    canonicalize_frame_definitions!(mechanism)
+
+    flippedJoints
+end
+
+function remove_fixed_joints!(m::Mechanism)
+    check_no_cycles(m)
+    T = eltype(m)
+    for vertex in copy(m.toposortedTree)
+        if !isroot(vertex)
+            body = vertex_data(vertex)
+            joint = edge_to_parent_data(vertex)
+            parentVertex = parent(vertex)
+            parentBody = vertex_data(parentVertex)
+            if isa(joint.jointType, Fixed)
+                # add identity joint transform as a body-fixed frame definition
+                jointTransform = Transform3D{T}(joint.frameAfter, joint.frameBefore)
+                add_frame!(parentBody, jointTransform)
+
+                # migrate body fixed frames to parent body
+                for tf in frame_definitions(body)
+                    add_frame!(parentBody, tf)
+                end
+
+                # add inertia to parent body
+                if has_defined_inertia(parentBody)
+                    inertia = spatial_inertia(body)
+                    parentInertia = spatial_inertia(parentBody)
+                    toParent = fixed_transform(parentBody, inertia.frame, parentInertia.frame)
+                    parentBody.inertia = parentInertia + transform(inertia, toParent)
+                end
+
+                # merge vertex into parent
+                formerChildren = children(vertex)
+                merge_into_parent!(vertex)
+
+                # recanonicalize children since their new parent's default frame may be different
+                for child in formerChildren
+                    canonicalize_frame_definitions!(m, child)
+                end
+            end
+        end
+    end
+    m.toposortedTree = toposort(tree(m))
+    m
+end
+
+function maximal_coordinates(mechanism::Mechanism)
+    T = eltype(mechanism)
+    bodymap = Dict{RigidBody{T}, RigidBody{T}}()
+    jointmap = Dict{Joint{T}, Joint{T}}()
+    newfloatingjoints = Dict{RigidBody{T}, Joint{T}}()
+    oldroot = root_body(mechanism)
+    newroot = bodymap[oldroot] = deepcopy(oldroot)
+    ret = Mechanism(newroot, gravity = mechanism.gravitationalAcceleration.v)
+
+    # Copy bodies and attach them to the root with a floating joint.
+    for oldbody in non_root_bodies(mechanism)
+        newbody = bodymap[oldbody] = deepcopy(oldbody)
+        frameBefore = default_frame(newroot)
+        frameAfter = default_frame(newbody)
+        floatingjoint = newfloatingjoints[newbody] = Joint(name(newbody), frameBefore, frameAfter, QuaternionFloating{T}())
+        attach!(ret, newroot, floatingjoint, Transform3D(T, frameBefore), newbody, Transform3D(T, frameAfter))
+    end
+
+    # Copy input Mechanism's joints.
+    function copy_edge(oldpredecessor::RigidBody, oldjoint::Joint, oldsuccessor::RigidBody)
+        newjoint = jointmap[oldjoint] = deepcopy(oldjoint)
+        jointToPredecessor = fixed_transform(mechanism, newjoint.frameBefore, default_frame(oldpredecessor))
+        successorToJoint = fixed_transform(mechanism, default_frame(oldsuccessor), newjoint.frameAfter)
+        attach!(ret, bodymap[oldpredecessor], newjoint, jointToPredecessor, bodymap[oldsuccessor], successorToJoint)
+    end
+
+    for vertex in non_root_vertices(mechanism)
+        copy_edge(vertex_data(parent(vertex)), edge_to_parent_data(vertex), vertex_data(vertex))
+    end
+
+    for nonTreeEdge in mechanism.nonTreeEdges
+        copy_edge(nonTreeEdge.predecessor, nonTreeEdge.successor, nonTreeEdge.joint)
+    end
+
+    ret, newfloatingjoints, bodymap, jointmap
+end
+
+function rand_mechanism{T}(::Type{T}, parentSelector::Function, jointTypes...)
+    parentBody = RigidBody{T}("world")
+    m = Mechanism(parentBody)
+    for i = 1 : length(jointTypes)
+        @assert jointTypes[i] <: JointType{T}
+        joint = Joint("joint$i", rand(jointTypes[i]))
+        jointToParentBody = rand(Transform3D{T}, joint.frameBefore, default_frame(parentBody))
+        body = RigidBody(rand(SpatialInertia{T}, CartesianFrame3D("body$i")))
+        bodyToJoint = Transform3D{T}(default_frame(body), joint.frameAfter)
+        attach!(m, parentBody, joint, jointToParentBody, body, bodyToJoint)
+        parentBody = parentSelector(m)
+    end
+    return m
+end
+
+rand_chain_mechanism{T}(t::Type{T}, jointTypes...) = rand_mechanism(t, m::Mechanism -> vertex_data(m.toposortedTree[end]), jointTypes...)
+rand_tree_mechanism{T}(t::Type{T}, jointTypes...) = rand_mechanism(t, m::Mechanism -> rand(collect(bodies(m))), jointTypes...)
+function rand_floating_tree_mechanism{T}(t::Type{T}, nonFloatingJointTypes...)
+    parentSelector = (m::Mechanism) -> begin
+        only_root = length(bodies(m)) == 1
+        only_root ? root_body(m) : rand(collect(non_root_bodies(m)))
+    end
+    rand_mechanism(t, parentSelector, [QuaternionFloating{T}; nonFloatingJointTypes...]...)
+end

--- a/src/parse_urdf.jl
+++ b/src/parse_urdf.jl
@@ -88,7 +88,12 @@ function parse_vertex{T}(mechanism::Mechanism{T}, vertex::TreeVertex{XMLElement,
     attach!(mechanism, parent, joint, jointToParent, body)
 end
 
-function parse_urdf{T}(::Type{T}, filename)
+"""
+$(SIGNATURES)
+
+Create a `Mechanism` by parsing a [URDF](http://wiki.ros.org/urdf) file.
+"""
+function parse_urdf{T}(scalar::Type{T}, filename)
     xdoc = parse_file(filename)
     xroot = root(xdoc)
     @assert LightXML.name(xroot) == "robot"

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -1,5 +1,13 @@
 using RigidBodyDynamics.OdeIntegrators
 
+"""
+$(SIGNATURES)
+
+Simple `Mechanism` simulation.
+
+Uses `MuntheKaasIntegrator`. See [`MuntheKaasIntegrator`](@ref) for a lower
+level interface with more options.
+"""
 function simulate(state0::MechanismState, finalTime)
     T = cache_eltype(state0)
     result = DynamicsResult(T, state0.mechanism)


### PR DESCRIPTION
Currently, mostly just display of docstrings using `@autodocs`. It would be good to add some higher level explanations later.

Still missing: a proper quickstart guide. Plan is to point to create a Jupyter notebook and point to it in the documentation. Doing this with Documenter `@example` blocks is annoying since there is no shared state between `@example` blocks.