### PR TITLE
Simulate fixes

### DIFF
--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -10,7 +10,7 @@ starting from the initial state `state0`. Return a `Vector` of times, as well as
 Uses `MuntheKaasIntegrator`. See [`MuntheKaasIntegrator`](@ref) for a lower
 level interface with more options.
 """
-function simulate(state0::MechanismState, finalTime)
+function simulate(state0::MechanismState, finalTime; Δt = 1e-4)
     T = cache_eltype(state0)
     result = DynamicsResult(T, state0.mechanism)
     passive_dynamics! = (vd::AbstractArray, t, state) -> begin
@@ -18,9 +18,8 @@ function simulate(state0::MechanismState, finalTime)
         copy!(vd, result.v̇)
         nothing
     end
-    Δt = 1e-4
     tableau = runge_kutta_4(Float64)
-    storage = OdeRingBufferStorage{Float64}(ceil(Int64, finalTime / Δt) + 2)
+    storage = ExpandingStorage{Float64}(ceil(Int64, finalTime / Δt) + 5) # rough estimate of number of time steps
     integrator = MuntheKaasIntegrator(passive_dynamics!, tableau, storage)
     integrate(integrator, state0, finalTime, Δt)
     storage.ts, storage.qs, storage.vs


### PR DESCRIPTION
Allow option to specify dt in simulate, add and use ExpandingStorage instead of RingBufferStorage in simulate to avoid problems with determining proper size a priori.