### PR TITLE
Fix two bugs in Point3D/FreeVector3D

### DIFF
--- a/src/frames.jl
+++ b/src/frames.jl
@@ -129,13 +129,13 @@ end
 # whereas a Point3D is also translated
 for VectorType in (:FreeVector3D, :Point3D)
     @eval begin
-        type $VectorType{V<:AbstractVector}
+        immutable $VectorType{V<:AbstractVector}
             frame::CartesianFrame3D
             v::V
 
-            function (::Type{$VectorType{V}}){V<:AbstractVector}(frame::CartesianFrame3D, v::V)
-                @boundscheck length(v) == 3
-                new{V}(frame, v)
+            function $VectorType(frame::CartesianFrame3D, v::V)
+                @boundscheck length(v) == 3 || throw(DimensionMismatch())
+                new(frame, v)
             end
         end
 

--- a/test/test_frames.jl
+++ b/test/test_frames.jl
@@ -25,6 +25,9 @@
     @test isapprox(inv(t1) * (t1 * v), v)
     @test isapprox(t1 * p - t1 * v, Point3D(f1, t1.trans))
 
+    @test_throws DimensionMismatch Point3D(f2, rand(2))
+    @test_throws DimensionMismatch Point3D(f2, rand(4))
+
     show(DevNull, t1)
     show(DevNull, p)
     show(DevNull, v)


### PR DESCRIPTION
* was accidentally using `type` instead of `immutable` (performance issue)
* bounds check didn't actually throw an error 