### PR TITLE
Simplify constraint Jacobian structure

### DIFF
--- a/src/mechanism.jl
+++ b/src/mechanism.jl
@@ -253,24 +253,5 @@ end
 tree_index(joint::Joint, mechanism::Mechanism) = Graphs.tree_index(joint, mechanism.tree)
 tree_index(body::RigidBody, mechanism::Mechanism) = Graphs.tree_index(body, mechanism.tree)
 
-function constraint_jacobian_structure(mechanism::Mechanism)
-    # TODO: move to MechanismState
-    # columns correspond to non-tree joints, rows correspond to tree joints
-    nonTreeJoints = non_tree_joints(mechanism)
-    ret = spzeros(Int64, num_edges(mechanism.tree), length(nonTreeJoints))
-    for (col, nonTreeJoint) in enumerate(nonTreeJoints)
-        pred = predecessor(nonTreeJoint, mechanism)
-        succ = successor(nonTreeJoint, mechanism)
-        for (body, sign) in Dict(succ => 1, pred => -1)
-            while !isroot(body, mechanism)
-                joint = joint_to_parent(body, mechanism)
-                ret[tree_index(joint, mechanism), col] += sign
-                body = predecessor(joint, mechanism)
-            end
-        end
-    end
-    dropzeros!(ret)
-end
-
 findbody(mechanism::Mechanism, name::String) = findunique(b -> b.name == name, bodies(mechanism))
 findjoint(mechanism::Mechanism, name::String) = findunique(j -> j.name == name, joints(mechanism))

--- a/src/mechanism_state.jl
+++ b/src/mechanism_state.jl
@@ -13,8 +13,7 @@ Type parameters:
 """
 immutable MechanismState{X<:Number, M<:Number, C<:Number}
     mechanism::Mechanism{M}
-    nontreejoints::Vector{Joint{M}}
-    constraint_jacobian_structure::SparseMatrixCSC{Int64,Int64} # TODO: replace with a Vector{Path{RigidBody{M}, Joint{M}}}
+    constraint_jacobian_structure::Vector{Tuple{Joint{M}, TreePath{RigidBody{M}, Joint{M}}}}
 
     # configurations, velocities
     q::Vector{X}
@@ -92,7 +91,10 @@ immutable MechanismState{X<:Number, M<:Number, C<:Number}
         update!(twists_wrt_world[rootindex], zero(Twist{C}, rootframe, rootframe, rootframe))
         update!(bias_accelerations_wrt_world[rootindex], zero(SpatialAcceleration{C}, rootframe, rootframe, rootframe))
 
-        new{X, M, C}(mechanism, non_tree_joints(mechanism), constraint_jacobian_structure(mechanism),
+        m = mechanism
+        constraint_jacobian_structure = [(j, path(m, predecessor(j, m), successor(j, m))) for j in non_tree_joints(m)]
+
+        new{X, M, C}(mechanism, constraint_jacobian_structure,
             q, v, s, qs, vs,
             joint_transforms, joint_twists, joint_bias_accelerations, motion_subspaces, motion_subspaces_in_world,
             transforms_to_world, twists_wrt_world, bias_accelerations_wrt_world, inertias, crb_inertias,


### PR DESCRIPTION
Instead of using a SparseMatrixCSC, just store the TreePaths associated with each non-tree joint.