### PR TITLE
Fix benchmarks.

### DIFF
--- a/perf/runbenchmarks.jl
+++ b/perf/runbenchmarks.jl
@@ -59,6 +59,10 @@ end
 function runbenchmarks()
     suite = create_benchmark_suite()
     tune!(suite)
+    for benchmark in values(suite)
+        benchmark.params.evals = 1 # IMPORTANT: otherwise we're testing caching
+    end
+
     Profile.clear_malloc_data()
     results = run(suite, verbose = true)
     for result in results


### PR DESCRIPTION
If evals is not equal to 1, the setup code will not be called every sample, in which case we were using cached results!