### PR TITLE
Use a single Array in Transform3D, parameterize Transform3D on array type

### DIFF
--- a/notebooks/Quickstart - double pendulum.ipynb
+++ b/notebooks/Quickstart - double pendulum.ipynb
@@ -193,7 +193,7 @@
     }
    ],
    "source": [
-    "beforeShoulderToWorld = Transform3D{Float64}(frame_before(shoulder), default_frame(world)) # creates an identity transform"
+    "beforeShoulderToWorld = eye(Transform3D, frame_before(shoulder), default_frame(world))"
    ]
   },
   {

--- a/notebooks/Symbolic double pendulum.ipynb
+++ b/notebooks/Symbolic double pendulum.ipynb
@@ -118,7 +118,7 @@
     "inertia1 = SpatialInertia(CartesianFrame3D(\"upper_link\"), I_1 * axis * axis', SVector(0, 0, c_1), m_1)\n",
     "body1 = RigidBody(inertia1)\n",
     "joint1 = Joint(\"shoulder\", Revolute(axis))\n",
-    "joint1ToWorld = Transform3D{T}(frame_before(joint1), default_frame(world))\n",
+    "joint1ToWorld = eye(Transform3D, frame_before(joint1), default_frame(world))\n",
     "attach!(doublePendulum, world, joint1, joint1ToWorld, body1)\n",
     "\n",
     "# Attach the second (lower) link to the world via a revolute joint named 'elbow'\n",

--- a/src/RigidBodyDynamics.jl
+++ b/src/RigidBodyDynamics.jl
@@ -37,6 +37,8 @@ export
     MechanismState,
     DynamicsResult,
     # functions
+    rotation,
+    translation,
     name, # TODO: remove?
     has_defined_inertia,
     default_frame,

--- a/src/frames.jl
+++ b/src/frames.jl
@@ -69,59 +69,91 @@ $(TYPEDEF)
 A homogeneous transformation matrix representing the transformation from one
 three-dimensional Cartesian coordinate system to another.
 """
-immutable Transform3D{T<:Number}
+immutable Transform3D{A<:AbstractMatrix}
     from::CartesianFrame3D
     to::CartesianFrame3D
-    rot::RotMatrix3{T}
-    trans::SVector{3, T}
+    mat::A
 
-    function (::Type{Transform3D{T}}){T<:Number}(from::CartesianFrame3D, to::CartesianFrame3D, rot::Rotation{3, T}, trans::SVector{3, T})
-        new{T}(from, to, rot, trans)
-    end
-
-    function (::Type{Transform3D{T}}){T<:Number}(from::CartesianFrame3D, to::CartesianFrame3D)
-        new{T}(from, to, eye(RotMatrix3{T}), zeros(SVector{3, T}))
-    end
-
-    function (::Type{Transform3D{T}}){T<:Number}(frame::CartesianFrame3D)
-        new{T}(frame, frame, eye(RotMatrix3{T}), zeros(SVector{3, T}))
+    function (::Type{Transform3D{A}}){A<:AbstractArray}(from::CartesianFrame3D, to::CartesianFrame3D, mat::A)
+        @boundscheck size(mat) == (4, 4) || throw(DimensionMismatch())
+        new{A}(from, to, mat)
     end
 end
-Transform3D{T}(from::CartesianFrame3D, to::CartesianFrame3D, rot::Rotation{3, T}, trans::SVector{3, T}) = Transform3D{T}(from, to, rot, trans)
-Transform3D{T}(from::CartesianFrame3D, to::CartesianFrame3D, rot::Rotation{3, T}) = Transform3D{T}(from, to, rot, zeros(SVector{3, T}))
-Transform3D{T}(from::CartesianFrame3D, to::CartesianFrame3D, trans::SVector{3, T}) = Transform3D{T}(from, to, eye(RotMatrix3{T}), trans)
-Transform3D{T}(::Type{T}, from::CartesianFrame3D, to::CartesianFrame3D) = Transform3D{T}(from, to, eye(RotMatrix3{T}), zeros(SVector{3, T}))
-Transform3D{T}(::Type{T}, frame::CartesianFrame3D) = Transform3D{T}(frame, frame, eye(RotMatrix3{T}), zeros(SVector{3, T}))
 
-Base.convert{T}(::Type{Transform3D{T}}, t::Transform3D{T}) = t
-Base.convert{T}(::Type{Transform3D{T}}, t::Transform3D) = Transform3D(t.from, t.to, convert(RotMatrix3{T}, t.rot), convert(SVector{3, T}, t.trans))
+@inline Transform3D{A}(from::CartesianFrame3D, to::CartesianFrame3D, mat::A) = Transform3D{A}(from, to, mat)
+
+Base.eltype{A}(::Type{Transform3D{A}}) = eltype(A)
+@compat const Transform3DS{T} = Transform3D{SMatrix{4, 4, T, 16}}
+
+@inline function Transform3D(from::CartesianFrame3D, to::CartesianFrame3D, rot::Rotation{3}, trans::SVector{3})
+    T = promote_type(eltype(typeof(rot)), eltype(typeof(trans)))
+    @inbounds mat = @SMatrix [rot[1] rot[4] rot[7] trans[1];
+                              rot[2] rot[5] rot[8] trans[2];
+                              rot[3] rot[6] rot[9] trans[3];
+                              zero(T) zero(T) zero(T) one(T)]
+   Transform3D(from, to, mat)
+end
+
+@inline function Transform3D{T}(from::CartesianFrame3D, to::CartesianFrame3D, rot::Rotation{3, T})
+    @inbounds mat = @SMatrix [rot[1] rot[4] rot[7] zero(T);
+                              rot[2] rot[5] rot[8] zero(T);
+                              rot[3] rot[6] rot[9] zero(T);
+                              zero(T) zero(T) zero(T) one(T)]
+   Transform3D(from, to, mat)
+end
+
+@inline function Transform3D{T}(from::CartesianFrame3D, to::CartesianFrame3D, trans::SVector{3, T})
+    @inbounds mat = @SMatrix [one(T) zero(T) zero(T) trans[1];
+                              zero(T) one(T) zero(T) trans[2];
+                              zero(T) zero(T) one(T) trans[3];
+                              zero(T) zero(T) zero(T) one(T)]
+    Transform3D(from, to, mat)
+end
+
+@inline Base.convert{A}(::Type{Transform3D{A}}, t::Transform3D{A}) = t
+@inline Base.convert{A}(::Type{Transform3D{A}}, t::Transform3D) = Transform3D(t.from, t.to, convert(A, t.mat))
+
+@inline rotation(t::Transform3D) = @inbounds return RotMatrix(t.mat[1], t.mat[2], t.mat[3], t.mat[5], t.mat[6], t.mat[7], t.mat[9], t.mat[10], t.mat[11])
+@inline translation(t::Transform3D) = @inbounds return SVector(t.mat[13], t.mat[14], t.mat[15])
 
 function Base.show(io::IO, t::Transform3D)
     println(io, "Transform3D from \"$(name(t.from))\" to \"$(name(t.to))\":")
-    angleAxis = AngleAxis(t.rot)
+    angleAxis = AngleAxis(rotation(t))
     angle = rotation_angle(angleAxis)
     axis = rotation_axis(angleAxis)
-    println(io, "rotation: $(angle) rad about $(axis), translation: $(t.trans)") # TODO: use fixed Quaternions.jl version once it's updated
+    println(io, "rotation: $(angle) rad about $(axis), translation: $(translation(t))") # TODO: use fixed Quaternions.jl version once it's updated
 end
 
 @inline function *(t1::Transform3D, t2::Transform3D)
     @framecheck(t1.from, t2.to)
-    rot = t1.rot * t2.rot
-    trans = t1.trans + t1.rot * t2.trans
-    Transform3D(t2.from, t1.to, rot, trans)
+    mat = t1.mat * t2.mat
+    Transform3D(t2.from, t1.to, mat)
 end
 
 @inline function Base.inv(t::Transform3D)
-    rotinv = inv(t.rot)
-    Transform3D(t.to, t.from, rotinv, -(rotinv * t.trans))
+    rotinv = inv(rotation(t))
+    Transform3D(t.to, t.from, rotinv, -(rotinv * translation(t)))
 end
 
-function Random.rand{T}(::Type{Transform3D{T}}, from::CartesianFrame3D, to::CartesianFrame3D)
-    Transform3D(from, to, rand(RotMatrix3{T}), rand(SVector{3, T}))
+@inline Base.eye{A<:StaticArray}(::Type{Transform3D{A}}, from::CartesianFrame3D, to::CartesianFrame3D) = Transform3D(from, to, eye(A))
+@inline function Base.eye{A<:AbstractMatrix}(::Type{Transform3D{A}}, from::CartesianFrame3D, to::CartesianFrame3D)
+    T = eltype(A)
+    convert(Transform3D{A}, eye(Transform3DS{T}, from, to))
+end
+@inline Base.eye(::Type{Transform3D}, from::CartesianFrame3D, to::CartesianFrame3D) = eye(Transform3DS{Float64}, from, to)
+@inline Base.eye{T<:Transform3D}(::Type{T}, frame::CartesianFrame3D) = eye(T, frame, frame)
+
+function Random.rand{A}(::Type{Transform3D{A}}, from::CartesianFrame3D, to::CartesianFrame3D)
+    T = eltype(A)
+    rot = rand(RotMatrix3{T})
+    trans = rand(SVector{3, T})
+    convert(Transform3D{A}, Transform3D(from, to, rot, trans))
 end
 
-function Base.isapprox{T}(x::Transform3D{T}, y::Transform3D{T}; atol::Real = 1e-12)
-    x.from == y.from && x.to == y.to && isapprox(x.rot, y.rot, atol = atol) && isapprox(x.trans, y.trans, atol = atol)
+Random.rand(::Type{Transform3D}, from::CartesianFrame3D, to::CartesianFrame3D) = rand(Transform3DS{Float64}, from, to)
+
+function Base.isapprox(x::Transform3D, y::Transform3D; atol::Real = 1e-12)
+    x.from == y.from && x.to == y.to && isapprox(rotation(x), rotation(y), atol = atol) && isapprox(translation(x), translation(y), atol = atol)
 end
 
 
@@ -129,6 +161,7 @@ end
 # whereas a Point3D is also translated
 for VectorType in (:FreeVector3D, :Point3D)
     @eval begin
+        # TODO: consider storing as a homogeneous vector
         immutable $VectorType{V<:AbstractVector}
             frame::CartesianFrame3D
             v::V
@@ -173,7 +206,6 @@ for VectorType in (:FreeVector3D, :Point3D)
         invtransform(x::$VectorType, t::Transform3D) = t \ x
 
         Base.eltype{V}(::Type{$VectorType{V}}) = eltype(V)
-        Base.eltype(v::$VectorType) = eltype(typeof(v))
         StaticArrays.similar_type{V, T}(x::Type{$VectorType{V}}, ::Type{T}) = $VectorType{SVector{3, T}}
     end
 end
@@ -202,16 +234,16 @@ FreeVector3D
 
 # Point3D-specific
 (-)(p1::Point3D, p2::Point3D) = begin @framecheck(p1.frame, p2.frame); FreeVector3D(p1.frame, p1.v - p2.v) end
-(*)(t::Transform3D, point::Point3D) = begin @framecheck(t.from, point.frame); Point3D(t.to, t.rot * point.v + t.trans) end
-(\)(t::Transform3D, point::Point3D) = begin @framecheck point.frame t.to; Point3D(t.from, At_mul_B(t.rot, point.v - t.trans)) end
+(*)(t::Transform3D, point::Point3D) = begin @framecheck(t.from, point.frame); Point3D(t.to, rotation(t) * point.v + translation(t)) end
+(\)(t::Transform3D, point::Point3D) = begin @framecheck point.frame t.to; Point3D(t.from, At_mul_B(rotation(t), point.v - translation(t))) end
 
 # FreeVector3D-specific
 FreeVector3D(p::Point3D) = FreeVector3D(p.frame, p.v)
 (-)(v1::FreeVector3D, v2::FreeVector3D) = begin @framecheck(v1.frame, v2.frame); FreeVector3D(v1.frame, v1.v - v2.v) end
 Base.cross(v1::FreeVector3D, v2::FreeVector3D) = begin @framecheck(v1.frame, v2.frame); FreeVector3D(v1.frame, cross(v1.v, v2.v)) end
 Base.dot(v1::FreeVector3D, v2::FreeVector3D) = begin @framecheck(v1.frame, v2.frame); dot(v1.v, v2.v) end
-(*)(t::Transform3D, vector::FreeVector3D) = begin @framecheck(t.from, vector.frame); FreeVector3D(t.to, t.rot * vector.v) end
-(\)(t::Transform3D, point::FreeVector3D) = begin @framecheck point.frame t.to; FreeVector3D(t.from, At_mul_B(t.rot, point.v)) end
+(*)(t::Transform3D, vector::FreeVector3D) = begin @framecheck(t.from, vector.frame); FreeVector3D(t.to, rotation(t) * vector.v) end
+(\)(t::Transform3D, point::FreeVector3D) = begin @framecheck point.frame t.to; FreeVector3D(t.from, At_mul_B(rotation(t), point.v)) end
 Base.norm(v::FreeVector3D) = norm(v.v)
 Base.normalize(v::FreeVector3D, p = 2) = FreeVector3D(v.frame, normalize(v.v, p))
 

--- a/src/joint.jl
+++ b/src/joint.jl
@@ -101,7 +101,7 @@ $(SIGNATURES)
 Return a `Transform3D` representing the homogeneous transform from the frame
 after the joint to the frame before the joint for joint configuration vector ``q``.
 """
-function joint_transform{M, X}(joint::Joint{M}, q::AbstractVector{X})::Transform3D{promote_type(M, X)}
+function joint_transform{M, X}(joint::Joint{M}, q::AbstractVector{X})::Transform3DS{promote_type(M, X)}
     @boundscheck check_num_positions(joint, q)
     @rtti_dispatch (QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}) _joint_transform(joint.jointType, frame_after(joint), frame_before(joint), q)
 end
@@ -135,7 +135,7 @@ its successor.
 
 The constraint wrench subspace is orthogonal to the motion subspace.
 """
-function constraint_wrench_subspace{M, X}(joint::Joint{M}, jointTransform::Transform3D{X})#::WrenchSubspace{promote_type(M, X)} # FIXME: type assertion causes segfault! see https://github.com/JuliaLang/julia/issues/20034. should be fixed in 0.6
+function constraint_wrench_subspace{M, A}(joint::Joint{M}, jointTransform::Transform3D{A})#::WrenchSubspace{promote_type(M, X)} # FIXME: type assertion causes segfault! see https://github.com/JuliaLang/julia/issues/20034. should be fixed in 0.6
     @framecheck jointTransform.from frame_after(joint)
     @framecheck jointTransform.to frame_before(joint)
     @rtti_dispatch (QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}) _constraint_wrench_subspace(joint.jointType, jointTransform)

--- a/src/mechanism.jl
+++ b/src/mechanism.jl
@@ -227,8 +227,8 @@ Return the joint that is part of the mechanism's kinematic tree and has
 joint_to_parent(body::RigidBody, mechanism::Mechanism) = edge_to_parent(body, mechanism.tree)
 
 
-Base.@deprecate add_body_fixed_frame!{T}(mechanism::Mechanism{T}, body::RigidBody{T}, transform::Transform3D{T}) add_frame!(body, transform)
-function add_body_fixed_frame!{T}(mechanism::Mechanism{T}, transform::Transform3D{T})
+Base.@deprecate add_body_fixed_frame!{T}(mechanism::Mechanism{T}, body::RigidBody{T}, transform::Transform3D) add_frame!(body, transform)
+function add_body_fixed_frame!{T}(mechanism::Mechanism{T}, transform::Transform3D)
     add_frame!(body_fixed_frame_to_body(mechanism, transform.to), transform)
 end
 

--- a/src/mechanism_manipulation.jl
+++ b/src/mechanism_manipulation.jl
@@ -18,8 +18,8 @@ If `successor` is not yet a part of the `Mechanism`, it will be added to the
 `Mechanism`, effectively creating a loop constraint that will be enforced
 using Lagrange multipliers (as opposed to using recursive algorithms).
 """
-function attach!{T}(mechanism::Mechanism{T}, predecessor::RigidBody{T}, joint::Joint, jointToPredecessor::Transform3D{T},
-        successor::RigidBody{T}, successorToJoint::Transform3D{T} = Transform3D{T}(default_frame(successor), frame_after(joint)))
+function attach!{T}(mechanism::Mechanism{T}, predecessor::RigidBody{T}, joint::Joint{T}, jointToPredecessor::Transform3D,
+        successor::RigidBody{T}, successorToJoint::Transform3D = eye(Transform3DS{T}, default_frame(successor), frame_after(joint)))
     @assert jointToPredecessor.from == frame_before(joint)
     @assert successorToJoint.to == frame_after(joint)
 
@@ -64,7 +64,7 @@ belongs to `mechanism`).
 Note: gravitational acceleration for childmechanism is ignored.
 """
 function attach!{T}(mechanism::Mechanism{T}, parentbody::RigidBody{T}, childmechanism::Mechanism{T},
-        childroot_to_parent::Transform3D{T} = Transform3D(T, default_frame(root_body(childmechanism)), default_frame(parentbody)))
+        childroot_to_parent::Transform3D = eye(Transform3DS{T}, default_frame(root_body(childmechanism)), default_frame(parentbody)))
     # FIXME: test with cycles
 
     @assert mechanism != childmechanism # infinite loop otherwise
@@ -151,8 +151,8 @@ end
 
 Base.@deprecate(
 reattach!{T}(mechanism::Mechanism{T}, oldSubtreeRootBody::RigidBody{T},
-    parentBody::RigidBody{T}, joint::Joint, jointToParent::Transform3D{T},
-    newSubtreeRootBody::RigidBody{T}, newSubTreeRootBodyToJoint::Transform3D{T} = Transform3D{T}(default_frame(newSubtreeRootBody), frame_after(joint))),
+    parentBody::RigidBody{T}, joint::Joint, jointToParent::Transform3D,
+    newSubtreeRootBody::RigidBody{T}, newSubTreeRootBodyToJoint::Transform3D = eye(Transform3DS{T}, default_frame(newSubtreeRootBody), frame_after(joint))),
     begin
         attach!(mechanism, parentBody, joint, jointToParent, newSubtreeRootBody, newSubTreeRootBodyToJoint)
         remove_joint!(mechanism, joint_to_parent(oldSubtreeRootBody, mechanism))
@@ -180,7 +180,7 @@ function remove_fixed_tree_joints!(mechanism::Mechanism)
         succ = target(fixedjoint, graph)
 
         # Add identity joint transform as a body-fixed frame definition.
-        jointtransform = Transform3D{T}(frame_after(fixedjoint), frame_before(fixedjoint))
+        jointtransform = eye(Transform3DS{T}, frame_after(fixedjoint), frame_before(fixedjoint))
         add_frame!(pred, jointtransform)
 
         # Migrate body fixed frames to parent body.
@@ -251,7 +251,7 @@ function maximal_coordinates(mechanism::Mechanism)
         frameafter = default_frame(srcbody)
         body = bodymap[srcbody] = deepcopy(srcbody)
         floatingjoint = newfloatingjoints[body] = Joint(name(body), framebefore, frameafter, QuaternionFloating{T}())
-        attach!(ret, root, floatingjoint, Transform3D(T, framebefore), body, Transform3D(T, frameafter))
+        attach!(ret, root, floatingjoint, eye(Transform3DS{T}, framebefore), body, eye(Transform3DS{T}, frameafter))
     end
 
     # Copy input Mechanism's joints.
@@ -275,9 +275,9 @@ function rand_tree_mechanism{T}(::Type{T}, parentselector::Function, jointTypes.
     for i = 1 : length(jointTypes)
         @assert jointTypes[i] <: JointType{T}
         joint = Joint("joint$i", rand(jointTypes[i]))
-        jointToParentBody = rand(Transform3D{T}, frame_before(joint), default_frame(parentbody))
+        jointToParentBody = rand(Transform3DS{T}, frame_before(joint), default_frame(parentbody))
         body = RigidBody(rand(SpatialInertia{T}, CartesianFrame3D("body$i")))
-        body_to_joint = Transform3D{T}(default_frame(body), frame_after(joint))
+        body_to_joint = eye(Transform3DS{T}, default_frame(body), frame_after(joint))
         attach!(mechanism, parentbody, joint, jointToParentBody, body, body_to_joint)
         parentbody = parentselector(mechanism)
     end

--- a/src/mechanism_state.jl
+++ b/src/mechanism_state.jl
@@ -25,14 +25,14 @@ immutable MechanismState{X<:Number, M<:Number, C<:Number}
     # joint-specific
     qs::Vector{VectorSegment{X}}
     vs::Vector{VectorSegment{X}}
-    joint_transforms::Vector{CacheElement{Transform3D{C}}}
+    joint_transforms::Vector{CacheElement{Transform3DS{C}}}
     joint_twists::Vector{CacheElement{Twist{C}}}
     joint_bias_accelerations::Vector{CacheElement{SpatialAcceleration{C}}}
     motion_subspaces::Vector{CacheElement{MotionSubspace{C}}}
     motion_subspaces_in_world::Vector{CacheElement{MotionSubspace{C}}} # TODO: should this be here?
 
     # body-specific
-    transforms_to_world::Vector{CacheElement{Transform3D{C}}}
+    transforms_to_world::Vector{CacheElement{Transform3DS{C}}}
     twists_wrt_world::Vector{CacheElement{Twist{C}}}
     bias_accelerations_wrt_world::Vector{CacheElement{SpatialAcceleration{C}}}
     inertias::Vector{CacheElement{SpatialInertia{C}}}
@@ -62,14 +62,14 @@ immutable MechanismState{X<:Number, M<:Number, C<:Number}
         end
 
         # joint-specific
-        joint_transforms = [CacheElement{Transform3D{C}}() for i = 1 : nb]
+        joint_transforms = [CacheElement{Transform3DS{C}}() for i = 1 : nb]
         joint_twists = [CacheElement{Twist{C}}() for i = 1 : nb]
         joint_bias_accelerations = [CacheElement{SpatialAcceleration{C}}() for i = 1 : nb]
         motion_subspaces = [CacheElement{MotionSubspace{C}}() for i = 1 : nb]
         motion_subspaces_in_world = [CacheElement{MotionSubspace{C}}() for i = 1 : nb]
 
         # body-specific
-        transforms_to_world = [CacheElement{Transform3D{C}}() for i = 1 : nb]
+        transforms_to_world = CacheElement{Transform3DS{C}}[CacheElement{Transform3DS{C}}() for i = 1 : nb]
         twists_wrt_world = [CacheElement{Twist{C}}() for i = 1 : nb]
         bias_accelerations_wrt_world = [CacheElement{SpatialAcceleration{C}}() for i = 1 : nb]
         inertias = [CacheElement{SpatialInertia{C}}() for i = 1 : nb]
@@ -87,7 +87,7 @@ immutable MechanismState{X<:Number, M<:Number, C<:Number}
         # Set root-body related cache elements once and for all.
         rootindex = vertex_index(root_body(mechanism))
         rootframe = root_frame(mechanism)
-        update!(transforms_to_world[rootindex], Transform3D(C, rootframe))
+        update!(transforms_to_world[rootindex], eye(Transform3DS{C}, rootframe))
         update!(twists_wrt_world[rootindex], zero(Twist{C}, rootframe, rootframe, rootframe))
         update!(bias_accelerations_wrt_world[rootindex], zero(SpatialAcceleration{C}, rootframe, rootframe, rootframe))
 

--- a/src/parse_urdf.jl
+++ b/src/parse_urdf.jl
@@ -73,7 +73,7 @@ function parse_root_link{T}(mechanism::Mechanism{T}, xml_link::XMLElement)
     parent = root_body(mechanism)
     body = parse_body(T, xml_link)
     joint = Joint("$(name(body))_to_world", Fixed{T}())
-    joint_to_parent = Transform3D{T}(frame_before(joint), default_frame(parent))
+    joint_to_parent = eye(Transform3DS{T}, frame_before(joint), default_frame(parent))
     attach!(mechanism, parent, joint, joint_to_parent, body)
 end
 

--- a/src/rigid_body.jl
+++ b/src/rigid_body.jl
@@ -10,19 +10,19 @@ a list of definitions of coordinate systems that are rigidly attached to it.
 type RigidBody{T<:Number}
     name::String
     inertia::Nullable{SpatialInertia{T}}
-    frameDefinitions::Vector{Transform3D{T}}
+    frameDefinitions::Vector{Transform3DS{T}}
     contact_points::Vector{DefaultContactPoint{T}} # TODO: allow different contact models
     id::Int64
 
     # inertia undefined; can be used for the root of a kinematic tree
     function (::Type{RigidBody{T}}){T<:Number}(name::String)
         frame = CartesianFrame3D(name)
-        new{T}(name, Nullable{SpatialInertia{T}}(), [Transform3D{T}(frame)], DefaultContactPoint{T}[], -1)
+        new{T}(name, Nullable{SpatialInertia{T}}(), [eye(Transform3DS{T}, frame)], DefaultContactPoint{T}[], -1)
     end
 
     # other bodies
     function (::Type{RigidBody{T}}){T<:Number}(name::String, inertia::SpatialInertia{T})
-        new{T}(name, Nullable(inertia), [Transform3D{T}(inertia.frame)], DefaultContactPoint{T}[], -1)
+        new{T}(name, Nullable(inertia), [eye(Transform3DS{T}, inertia.frame)], DefaultContactPoint{T}[], -1)
     end
 end
 
@@ -123,7 +123,7 @@ Add a new frame definition to `body`, represented by a homogeneous transform
 from the `CartesianFrame3D` to be added to any other frame that is already
 attached to `body`.
 """
-function add_frame!{T}(body::RigidBody{T}, transform::Transform3D{T})
+function add_frame!{T}(body::RigidBody{T}, transform::Transform3D)
     # note: overwrites any existing frame definition
     # transform.to needs to be among (transform.from for transform in frame_definitions(body))
     definitions = body.frameDefinitions

--- a/src/spatial.jl
+++ b/src/spatial.jl
@@ -179,19 +179,17 @@ expressed in a centroidal frame.
 MomentumMatrix
 
 # SpatialInertia-specific functions
-Base.convert{T<:Number}(::Type{SpatialInertia{T}}, inertia::SpatialInertia{T}) = inertia
-
-function Base.convert{T<:Number}(::Type{SpatialInertia{T}}, inertia::SpatialInertia)
+Base.eltype{T<:Number}(::Type{SpatialInertia{T}}) = T
+@inline Base.convert{T<:Number}(::Type{SpatialInertia{T}}, inertia::SpatialInertia{T}) = inertia
+@inline function Base.convert{T<:Number}(::Type{SpatialInertia{T}}, inertia::SpatialInertia)
     SpatialInertia(inertia.frame, convert(SMatrix{3, 3, T}, inertia.moment), convert(SVector{3, T}, inertia.crossPart), convert(T, inertia.mass))
 end
-
 function Base.convert{T}(::Type{SMatrix{6, 6, T}}, inertia::SpatialInertia)
     J = inertia.moment
     C = hat(inertia.crossPart)
     m = inertia.mass
     [J  C; C' m * eye(SMatrix{3, 3, T})]
 end
-
 Base.convert{T<:Matrix}(::Type{T}, inertia::SpatialInertia) = convert(T, convert(SMatrix{6, 6, eltype(T)}, inertia))
 
 Base.Array{T}(inertia::SpatialInertia{T}) = convert(Matrix{T}, inertia)
@@ -229,21 +227,21 @@ $(SIGNATURES)
 
 Transform the `SpatialInertia` to a different frame.
 """
-function transform{I, T}(inertia::SpatialInertia{I}, t::Transform3D{T})::SpatialInertia{promote_type(I, T)}
+function transform(inertia::SpatialInertia, t::Transform3D)
     @framecheck(t.from, inertia.frame)
-    S = promote_type(I, T)
+    T = promote_type(eltype(typeof(inertia)), eltype(typeof(t)))
 
     if t.from == t.to
-        return convert(SpatialInertia{S}, inertia)
-    elseif inertia.mass == zero(I)
-        return zero(SpatialInertia{S}, t.to)
+        return convert(SpatialInertia{T}, inertia)
+    elseif inertia.mass == 0
+        return zero(SpatialInertia{T}, t.to)
     else
         J = inertia.moment
         m = inertia.mass
         c = inertia.crossPart
 
-        R = t.rot
-        p = t.trans
+        R = rotation(t)
+        p = translation(t)
 
         cnew = R * c
         Jnew = hat_squared(cnew)
@@ -252,7 +250,7 @@ function transform{I, T}(inertia::SpatialInertia{I}, t::Transform3D{T})::Spatial
         mInv = inv(m)
         Jnew *= mInv
         Jnew += R * J * R'
-        return SpatialInertia{S}(t.to, Jnew, cnew, m)
+        return SpatialInertia{T}(t.to, Jnew, cnew, m)
     end
 end
 
@@ -277,7 +275,7 @@ function Random.rand{T}(::Type{SpatialInertia{T}}, frame::CartesianFrame3D)
     J = SMatrix{3, 3, T}(Q * diagm(principalMoments) * Q')
 
     # Construct the inertia in CoM frame
-    comFrame = CartesianFrame3D("com")
+    comFrame = CartesianFrame3D()
     spatialInertia = SpatialInertia(comFrame, J, zeros(SVector{3, T}), rand(T))
 
     # Put the center of mass at a random offset
@@ -342,15 +340,15 @@ Transform the `Twist` to a different frame.
 """
 function transform(twist::Twist, transform::Transform3D)
     @framecheck(twist.frame, transform.from)
-    angular, linear = transform_spatial_motion(twist.angular, twist.linear, transform.rot, transform.trans)
+    angular, linear = transform_spatial_motion(twist.angular, twist.linear, rotation(transform), translation(transform))
     Twist(twist.body, twist.base, transform.to, angular, linear)
 end
 
 # log(::Transform3D) + some extra outputs that make log_with_time_derivative faster
 function _log(t::Transform3D)
     # Proposition 2.9 in Murray et al, "A mathematical introduction to robotic manipulation."
-    rot = t.rot
-    p = t.trans
+    rot = rotation(t)
+    p = translation(t)
 
     # Rotational part of local coordinates is simply the rotation vector.
     aa = AngleAxis(rot)
@@ -493,7 +491,7 @@ function transform(accel::SpatialAcceleration, oldToNew::Transform3D, twistOfCur
     linear += accel.linear
 
     # transform to new frame
-    angular, linear = transform_spatial_motion(angular, linear, oldToNew.rot, oldToNew.trans)
+    angular, linear = transform_spatial_motion(angular, linear, rotation(oldToNew), translation(oldToNew))
 
     SpatialAcceleration(accel.body, accel.base, oldToNew.to, angular, linear)
 end
@@ -536,8 +534,8 @@ for ForceSpaceElement in (:Momentum, :Wrench)
         """
         function transform(f::$ForceSpaceElement, transform::Transform3D)
             @framecheck(f.frame, transform.from)
-            linear = transform.rot * f.linear
-            angular = transform.rot * f.angular + cross(transform.trans, linear)
+            linear = rotation(transform) * f.linear
+            angular = rotation(transform) * f.angular + cross(translation(transform), linear)
             $ForceSpaceElement(transform.to, angular, linear)
         end
 
@@ -614,9 +612,9 @@ Transform the `GeometricJacobian` to a different frame.
 """
 function transform(jac::GeometricJacobian, transform::Transform3D)
     @framecheck(jac.frame, transform.from)
-    R = transform.rot
+    R = rotation(transform)
     angular = R * jac.angular
-    linear = R * jac.linear + colwise(cross, transform.trans, angular)
+    linear = R * jac.linear + colwise(cross, translation(transform), angular)
     GeometricJacobian(jac.body, jac.base, transform.to, angular, linear)
 end
 
@@ -653,10 +651,10 @@ for ForceSpaceMatrix in (:MomentumMatrix, :WrenchMatrix)
 
         function transform(mat::$ForceSpaceMatrix, transform::Transform3D)
             @framecheck(mat.frame, transform.from)
-            R = transform.rot
+            R = rotation(transform)
             linear = R * linear_part(mat)
             T = eltype(linear)
-            angular = R * angular_part(mat) + colwise(cross, transform.trans, linear)
+            angular = R * angular_part(mat) + colwise(cross, translation(transform), linear)
             $ForceSpaceMatrix(transform.to, angular, linear)
         end
     end

--- a/src/spatial.jl
+++ b/src/spatial.jl
@@ -534,8 +534,9 @@ for ForceSpaceElement in (:Momentum, :Wrench)
         """
         function transform(f::$ForceSpaceElement, transform::Transform3D)
             @framecheck(f.frame, transform.from)
-            linear = rotation(transform) * f.linear
-            angular = rotation(transform) * f.angular + cross(translation(transform), linear)
+            rot = rotation(transform)
+            linear = rot * f.linear
+            angular = rot * f.angular + cross(translation(transform), linear)
             $ForceSpaceElement(transform.to, angular, linear)
         end
 

--- a/test/test_double_pendulum.jl
+++ b/test/test_double_pendulum.jl
@@ -17,7 +17,7 @@
     inertia1 = SpatialInertia(CartesianFrame3D("upper_link"), I1 * axis * axis', SVector(0, 0, lc1), m1)
     body1 = RigidBody(inertia1)
     joint1 = Joint("shoulder", Revolute(axis))
-    joint1ToWorld = Transform3D{Float64}(joint1.frameBefore, default_frame(world))
+    joint1ToWorld = eye(Transform3D, joint1.frameBefore, default_frame(world))
     attach!(doublePendulum, world, joint1, joint1ToWorld, body1)
 
     inertia2 = SpatialInertia(CartesianFrame3D("lower_link"), I2 * axis * axis', SVector(0, 0, lc2), m2)

--- a/test/test_frames.jl
+++ b/test/test_frames.jl
@@ -13,17 +13,17 @@
     end
     @framecheck(f1, f1)
 
-    t1 = rand(Transform3D{Float64}, f2, f1)
-    @test isapprox(t1 * inv(t1), Transform3D{Float64}(f1))
-    @test isapprox(inv(t1) * t1, Transform3D{Float64}(f2))
+    t1 = rand(Transform3D, f2, f1)
+    @test isapprox(t1 * inv(t1), eye(Transform3D, f1))
+    @test isapprox(inv(t1) * t1, eye(Transform3D, f2))
 
-    @test isapprox(t1 * Point3D(Float64, f2), Point3D(f1, t1.trans))
+    @test isapprox(t1 * Point3D(Float64, f2), Point3D(f1, translation(t1)))
 
     p = rand(Point3D, Float64, f2)
     v = FreeVector3D(f2, p.v)
     @test isapprox(inv(t1) * (t1 * p), p)
     @test isapprox(inv(t1) * (t1 * v), v)
-    @test isapprox(t1 * p - t1 * v, Point3D(f1, t1.trans))
+    @test isapprox(t1 * p - t1 * v, Point3D(f1, translation(t1)))
 
     @test_throws DimensionMismatch Point3D(f2, rand(2))
     @test_throws DimensionMismatch Point3D(f2, rand(4))

--- a/test/test_mechanism_algorithms.jl
+++ b/test/test_mechanism_algorithms.jl
@@ -9,7 +9,7 @@
             pred = rand(bodies(mechanism_with_loops))
             succ = rand(bodies(mechanism_with_loops))
             joint = Joint("non-tree-$i", Fixed{Float64}())
-            attach!(mechanism_with_loops, pred, joint, Transform3D{Float64}(frame_before(joint), default_frame(pred)), succ)
+            attach!(mechanism_with_loops, pred, joint, eye(Transform3D, frame_before(joint), default_frame(pred)), succ)
         end
 
         show(DevNull, mechanism_with_loops)
@@ -103,7 +103,7 @@
             geometric_jacobian!(J1, x, p)
             @test isapprox(Twist(J1, vpath), T; atol = 1e-12)
 
-            H = rand(Transform3D{Float64}, root_frame(mechanism), frame)
+            H = rand(Transform3D, root_frame(mechanism), frame)
             J2 = GeometricJacobian(J.body, J.base, frame, similar(J.angular), similar(J.linear))
             @test_throws ArgumentError geometric_jacobian!(J, x, p, H)
             geometric_jacobian!(J2, x, p, H)
@@ -214,7 +214,7 @@
 
         frame = CartesianFrame3D()
         A2 = MomentumMatrix(frame, similar(A.angular), similar(A.linear))
-        H = rand(Transform3D{Float64}, root_frame(mechanism), frame)
+        H = rand(Transform3D, root_frame(mechanism), frame)
         @test_throws ArgumentError momentum_matrix!(A, x, H)
         momentum_matrix!(A2, x, H)
         @test isapprox(Momentum(A2, v), transform(hSum, H); atol = 1e-12)

--- a/test/test_mechanism_manipulation.jl
+++ b/test/test_mechanism_manipulation.jl
@@ -2,8 +2,8 @@ function floating_joint_transform_to_configuration!(joint::Joint, q::AbstractVec
     @framecheck frame_before(joint) jointTransform.to
     @framecheck frame_after(joint) jointTransform.from
     joint.jointType::QuaternionFloating
-    RigidBodyDynamics.rotation!(joint.jointType, q, jointTransform.rot)
-    RigidBodyDynamics.translation!(joint.jointType, q, jointTransform.trans)
+    RigidBodyDynamics.rotation!(joint.jointType, q, rotation(jointTransform))
+    RigidBodyDynamics.translation!(joint.jointType, q, translation(jointTransform))
 end
 
 function floating_joint_twist_to_velocity!(joint::Joint, v::AbstractVector, jointTwist::Twist)
@@ -26,7 +26,7 @@ end
         for body in bodies(mechanism2)
             for i = 1 : 5
                 frame = CartesianFrame3D("frame_$i")
-                tf = rand(Transform3D{Float64}, frame, default_frame(body))
+                tf = rand(Transform3D, frame, default_frame(body))
                 add_frame!(body, tf)
                 additionalFrames[frame] = body
             end
@@ -145,8 +145,8 @@ end
 
             # reroot mechanism2
             newfloatingjoint = Joint("newFloating", QuaternionFloating{Float64}())
-            joint_to_world = Transform3D{Float64}(frame_before(newfloatingjoint), default_frame(world))
-            body_to_joint = Transform3D{Float64}(default_frame(newfloatingbody), frame_after(newfloatingjoint))
+            joint_to_world = eye(Transform3D, frame_before(newfloatingjoint), default_frame(world))
+            body_to_joint = eye(Transform3D, default_frame(newfloatingbody), frame_after(newfloatingjoint))
             attach!(mechanism2, bodymap[world], newfloatingjoint, joint_to_world, bodymap[newfloatingbody], body_to_joint)
             remove_joint!(mechanism2, jointmap[floatingjoint])
 

--- a/test/test_simulate.jl
+++ b/test/test_simulate.jl
@@ -40,7 +40,7 @@
         bodyframe = CartesianFrame3D()
         body = RigidBody("body", rand(SpatialInertia{Float64}, bodyframe))
         floatingjoint = Joint("floating", QuaternionFloating{Float64}())
-        attach!(mechanism, world, floatingjoint, Transform3D{Float64}(frame_before(floatingjoint), root_frame(mechanism)), body)
+        attach!(mechanism, world, floatingjoint, eye(Transform3D, frame_before(floatingjoint), root_frame(mechanism)), body)
 
         com = center_of_mass(spatial_inertia(body))
         model = SoftContactModel(hunt_crossley_hertz(; α = 0.), ViscoelasticCoulombModel(0.5, 1e3, 1e3))
@@ -95,7 +95,7 @@
         mechanism = Mechanism(world)
         floatingjoint = Joint("floating", QuaternionFloating{Float64}())
         body = RigidBody("body", SpatialInertia(CartesianFrame3D("inertia"), eye(SMatrix{3, 3}), zeros(SVector{3}), 2.))
-        attach!(mechanism, world, floatingjoint, Transform3D{Float64}(frame_before(floatingjoint), default_frame(world)), body)
+        attach!(mechanism, world, floatingjoint, eye(Transform3D, frame_before(floatingjoint), default_frame(world)), body)
         worldframe = root_frame(mechanism)
         inclinedplane = HalfSpace3D(Point3D(worldframe, zeros(SVector{3})), FreeVector3D(worldframe, sin(θ), 0., cos(θ)))
         add_environment_primitive!(mechanism, inclinedplane)


### PR DESCRIPTION
Towards https://github.com/tkoolen/RigidBodyDynamics.jl/issues/212, https://github.com/tkoolen/RigidBodyDynamics.jl/issues/207.

Other changes required by this move:
* add `rotation` and `translation` functions to replace accessing members of `Transform3D`
* change signatures of `eye` and `rand` methods.

A bit faster on 0.6, as expected.