### PR TITLE
Make TreePath iterable

### DIFF
--- a/src/mechanism_algorithms.jl
+++ b/src/mechanism_algorithms.jl
@@ -566,11 +566,6 @@ function constraint_jacobian_and_bias!(state::MechanismState, constraintjacobian
             sign = ifelse(direction == :up, -1, 1)
             force_space_matrix_transpose_mul_jacobian!(constraintjacobian, rowstart, colstart, T, J, sign)
         end
-        for treejoint in path.target_to_lca
-            J = motion_subspace_in_world(state, treejoint)
-            colstart = first(velocity_range(state, treejoint))
-            force_space_matrix_transpose_mul_jacobian!(constraintjacobian, rowstart, colstart, T, J, 1)
-        end
 
         # Constraint bias.
         has_fixed_subspaces(nontreejoint) || error("Only joints with fixed motion subspace (Ṡ = 0) supported at this point.")

--- a/src/mechanism_algorithms.jl
+++ b/src/mechanism_algorithms.jl
@@ -90,17 +90,12 @@ function geometric_jacobian!(out::GeometricJacobian, state::MechanismState, path
     mechanism = state.mechanism
     nextbaseframe = out.base
     startind = 1
-    for joint in path.source_to_lca
-        S = -transformfun(motion_subspace_in_world(state, joint))
-        startind, nextbaseframe = _set_jacobian_part!(out, S, nextbaseframe, startind)
-    end
-    for i = length(path.target_to_lca) : -1 : 1
-        joint = path.target_to_lca[i]
+    lastjoint = last(path)
+    for (joint, direction) in path
         S = transformfun(motion_subspace_in_world(state, joint))
+        direction == :up && (S = -S)
         startind, nextbaseframe = _set_jacobian_part!(out, S, nextbaseframe, startind)
-        if i == 1
-            @framecheck S.body out.body
-        end
+        joint == lastjoint && (@framecheck S.body out.body)
     end
     out
 end
@@ -565,10 +560,11 @@ function constraint_jacobian_and_bias!(state::MechanismState, constraintjacobian
         T = transform(T, transform_to_root(state, T.frame)) # TODO: expensive
 
         # Jacobian rows.
-        for treejoint in path.source_to_lca
+        for (treejoint, direction) in path
             J = motion_subspace_in_world(state, treejoint)
             colstart = first(velocity_range(state, treejoint))
-            force_space_matrix_transpose_mul_jacobian!(constraintjacobian, rowstart, colstart, T, J, -1)
+            sign = ifelse(direction == :up, -1, 1)
+            force_space_matrix_transpose_mul_jacobian!(constraintjacobian, rowstart, colstart, T, J, sign)
         end
         for treejoint in path.target_to_lca
             J = motion_subspace_in_world(state, treejoint)

--- a/src/mechanism_state.jl
+++ b/src/mechanism_state.jl
@@ -304,7 +304,7 @@ state_vector(state::MechanismState) = [configuration(state); velocity(state); ad
 
 for fun in (:num_velocities, :num_positions)
     @eval function $fun{T}(path::TreePath{RigidBody{T}, Joint{T}})
-        mapreduce($fun, +, 0, path.source_to_lca) + mapreduce($fun, +, 0, path.target_to_lca)
+        mapreduce(it -> $fun(first(it)), +, 0, path)
     end
 end
 
@@ -315,11 +315,7 @@ function set_path_vector!{X, M, C}(ret::AbstractVector, state::MechanismState{X,
         startind + n
     end
     startind = 1
-    for joint in path.source_to_lca
-        startind = setvectorpart!(ret, fun(state, joint), startind)
-    end
-    for i = length(path.target_to_lca) : -1 : 1
-        joint = path.target_to_lca[i]
+    for (joint, direction) in path
         startind = setvectorpart!(ret, fun(state, joint), startind)
     end
     ret

--- a/test/test_graph.jl
+++ b/test/test_graph.jl
@@ -197,11 +197,17 @@ Graphs.flip_direction!(edge::Edge{Float64}) = (edge.data = -edge.data)
                 dest_ancestors = ancestors(dest, tree)
                 lca = lowest_common_ancestor(src, dest, tree)
                 p = path(src, dest, tree)
+
+                show(DevNull, p)
+                @inferred collect(p)
+
                 @test source(p) == src
                 @test target(p) == dest
-                @test all(map(first, p) .== [p.source_to_lca; reverse(p.target_to_lca)])
 
-                for (v, v_ancestors, pathsegment) in [(src, src_ancestors, p.source_to_lca); (dest, dest_ancestors, p.target_to_lca)]
+                source_to_lca = collect(edge for (edge, direction) in p if direction == :up)
+                target_to_lca = reverse!(collect(edge for (edge, direction) in p if direction == :down))
+
+                for (v, v_ancestors, pathsegment) in [(src, src_ancestors, source_to_lca); (dest, dest_ancestors, target_to_lca)]
                     if v == root(tree)
                         @test tree_index(v, tree) == 1
                         @test lca == v
@@ -220,8 +226,8 @@ Graphs.flip_direction!(edge::Edge{Float64}) = (edge.data = -edge.data)
                 for v in intersect(src_ancestors, dest_ancestors)
                     @test tree_index(v, tree) <= tree_index(lca, tree)
                     if v != lca
-                        @test v ∉ (v -> source(v, tree)).(p.source_to_lca)
-                        @test v ∉ (v -> source(v, tree)).(p.target_to_lca)
+                        @test v ∉ (v -> source(v, tree)).(source_to_lca)
+                        @test v ∉ (v -> source(v, tree)).(target_to_lca)
                     end
                 end
                 for v in setdiff(src_ancestors, dest_ancestors)

--- a/test/test_graph.jl
+++ b/test/test_graph.jl
@@ -199,6 +199,7 @@ Graphs.flip_direction!(edge::Edge{Float64}) = (edge.data = -edge.data)
                 p = path(src, dest, tree)
                 @test source(p) == src
                 @test target(p) == dest
+                @test all(map(first, p) .== [p.source_to_lca; reverse(p.target_to_lca)])
 
                 for (v, v_ancestors, pathsegment) in [(src, src_ancestors, p.source_to_lca); (dest, dest_ancestors, p.target_to_lca)]
                     if v == root(tree)


### PR DESCRIPTION
Iterator `eltype` is a `Pair{E, Symbol}`, where the `Symbol` is `:up` if going from source to LCA and `:down` if going from LCA to target. Change `TreePath` so that this is easier to implement and iteration doesn't allocate.