### PR TITLE
Add colwise method that works with AbstractArrays.

### DIFF
--- a/src/util.jl
+++ b/src/util.jl
@@ -164,6 +164,14 @@ Return a matrix `A` such that `A[:, i] == f(vec, mat[:, i])`.
 end
 
 """
+    colwise(f, vec, mat)
+Return a matrix `A` such that `A[:, i] == f(vec, mat[:, i])`.
+"""
+function colwise(f, vec::AbstractVector, mat::AbstractMatrix)
+    mapslices(x -> f(vec, x), mat, (1,))
+end
+
+"""
     colwise(f, mat, vec)
 Return a matrix `A` such that `A[:, i] == f(mat[:, i], vec)`.
 """

--- a/test/test_spatial.jl
+++ b/test/test_spatial.jl
@@ -113,6 +113,9 @@ end
         @test isapprox(dot(Array(τ), v), dot(T, W); atol = 1e-12) # power equality
         @test_throws ArgumentError dot(transform(T, H), W)
         @test_throws ArgumentError torque(transform(J, H), W)
+
+        Jmutable = GeometricJacobian(f2, f1, f3, rand(3, n), rand(3, n))
+        @test isapprox(Twist(transform(Jmutable, H), v), transform(Twist(Jmutable, v), H))
     end
 
     @testset "At_mul_B!" begin


### PR DESCRIPTION
Makes `transform` work for `GeometricJacobian`s and `WrenchMatrix`es with a mutable backing array type.