### PR TITLE
Introduce UnsafeFastDict, BodyDict, JointDict

### DIFF
--- a/perf/runbenchmarks.jl
+++ b/perf/runbenchmarks.jl
@@ -33,19 +33,19 @@ function create_benchmark_suite()
 
     suite["mass_matrix"] = @benchmarkable mass_matrix!($(result.massmatrix), $state) setup = rand!($state)
     suite["inverse_dynamics"] = @benchmarkable(
-        inverse_dynamics!($torques, $(result.jointwrenches), $(result.accelerations), $state, v̇, externalWrenches),
-        setup = (
-            v̇ = rand(num_velocities($mechanism));
-            externalWrenches = [rand(Wrench{ScalarType}, root_frame($mechanism)) for i = 1 : num_bodies($mechanism)];
+        inverse_dynamics!($torques, $(result.jointwrenches), $(result.accelerations), $state, v̇, externalwrenches),
+        setup = begin
+            v̇ = rand(num_velocities($mechanism))
+            externalwrenches = RigidBodyDynamics.BodyDict(body => rand(Wrench{ScalarType}, root_frame($mechanism)) for body in bodies($mechanism))
             rand!($state)
-        )
+        end
     )
-    suite["dynamics"] = @benchmarkable(dynamics!($result, $state, τ, externalWrenches),
-        setup=(
-            rand!($state);
-            τ = rand(num_velocities($mechanism));
-            externalWrenches = [rand(Wrench{ScalarType}, root_frame($mechanism)) for i = 1 : num_bodies($mechanism)];
-        )
+    suite["dynamics"] = @benchmarkable(dynamics!($result, $state, τ, externalwrenches),
+        setup = begin
+            rand!($state)
+            τ = rand(num_velocities($mechanism))
+            externalwrenches = RigidBodyDynamics.BodyDict(body => rand(Wrench{ScalarType}, root_frame($mechanism)) for body in bodies($mechanism))
+        end
     )
     suite["momentum_matrix"] = @benchmarkable(momentum_matrix!($mat, $state), setup = rand!($state))
     suite["geometric_jacobian"] = @benchmarkable(geometric_jacobian!($jac, $state, $p), setup = rand!($state))

--- a/src/util.jl
+++ b/src/util.jl
@@ -6,6 +6,11 @@ Base.size(A::ConstVector) = (A.length, )
 Base.getindex{T}(A::ConstVector{T}, i::Int) = (@boundscheck checkbounds(A, i); A.val)
 @compat Base.IndexStyle{T}(::Type{ConstVector{T}}) = IndexLinear()
 
+# associative type that signifies an empty dictionary and does not allocate memory
+immutable NullDict{K, V} <: Associative{K, V}
+end
+Base.haskey(::NullDict, k) = false
+
 
 # type of a view of a vector
 # TODO: a bit too specific

--- a/test/test_mechanism_algorithms.jl
+++ b/test/test_mechanism_algorithms.jl
@@ -353,7 +353,7 @@
         rand_velocity!(x)
 
         v̇ = rand(num_velocities(mechanism))
-        externalwrenches = [rand(Wrench{Float64}, root_frame(mechanism)) for i = 1 : num_bodies(mechanism)]
+        externalwrenches = Dict(body => rand(Wrench{Float64}, root_frame(mechanism)) for body in bodies(mechanism))
         τ = inverse_dynamics(x, v̇, externalwrenches)
         floatingjoint = first(out_joints(root_body(mechanism), mechanism))
         τfloating = τ[velocity_range(x, floatingjoint)]
@@ -363,7 +363,7 @@
         gravitational_force = mass(mechanism) * mechanism.gravitationalAcceleration
         com = center_of_mass(x)
         gravitational_wrench = Wrench(gravitational_force.frame, cross(com, gravitational_force).v, gravitational_force.v)
-        total_wrench = floatingjointwrench + gravitational_wrench + sum((b) -> transform(x, externalwrenches[vertex_index(b)], root_frame(mechanism)), non_root_bodies(mechanism))
+        total_wrench = floatingjointwrench + gravitational_wrench + sum((b) -> transform(x, externalwrenches[b], root_frame(mechanism)), non_root_bodies(mechanism))
         @test isapprox(total_wrench, ḣ; atol = 1e-12)
     end
 
@@ -372,7 +372,7 @@
         x = MechanismState(Float64, mechanism)
         rand!(x)
         externalTorques = rand(num_velocities(mechanism))
-        externalwrenches = [rand(Wrench{Float64}, root_frame(mechanism)) for i = 1 : num_bodies(mechanism)]
+        externalwrenches = Dict(body => rand(Wrench{Float64}, root_frame(mechanism)) for body in bodies(mechanism))
 
         result = DynamicsResult(Float64, mechanism)
         dynamics!(result, x, externalTorques, externalwrenches)
@@ -385,7 +385,7 @@
         x = MechanismState(Float64, mechanism)
         rand!(x)
         torques = rand(num_velocities(mechanism))
-        externalwrenches = [rand(Wrench{Float64}, root_frame(mechanism)) for i = 1 : num_bodies(mechanism)]
+        externalwrenches = Dict(body => rand(Wrench{Float64}, root_frame(mechanism)) for body in bodies(mechanism))
 
         result1 = DynamicsResult(Float64, mechanism)
         ẋ = Vector{Float64}(length(state_vector(x)))
@@ -402,7 +402,7 @@
         x = MechanismState(Float64, mechanism)
         rand_configuration!(x)
         rand_velocity!(x)
-        externalwrenches = [rand(Wrench{Float64}, root_frame(mechanism)) for i = 1 : num_bodies(mechanism)]
+        externalwrenches = Dict(body => rand(Wrench{Float64}, root_frame(mechanism)) for body in bodies(mechanism))
         τ = rand(num_velocities(mechanism))
         result = DynamicsResult(Float64, mechanism)
         dynamics!(result, x, τ, externalwrenches)
@@ -411,7 +411,7 @@
         q̇ = configuration_derivative(x)
         v = velocity(x)
         v̇ = result.v̇
-        power = τ ⋅ v + sum(body -> externalwrenches[vertex_index(body)] ⋅ twist_wrt_world(x, body), non_root_bodies(mechanism))
+        power = τ ⋅ v + sum(body -> externalwrenches[body] ⋅ twist_wrt_world(x, body), non_root_bodies(mechanism))
 
         q_autodiff = create_autodiff(q, q̇)
         v_autodiff = create_autodiff(v, v̇)

--- a/test/test_util.jl
+++ b/test/test_util.jl
@@ -42,4 +42,10 @@ import RigidBodyDynamics: hat, rotation_vector_rate, colwise
             end
         end
     end
+
+    @testset "UnsafeFastDict" begin
+        d = RigidBodyDynamics.UnsafeFastDict((i => 3 * i for i in 1 : 3), identity)
+        show(DevNull, d)
+        @test all(keys(d) .== 1 : 3)
+    end
 end


### PR DESCRIPTION
Retains (almost all of) the speed improvements made in https://github.com/tkoolen/RigidBodyDynamics.jl/pull/126 and https://github.com/tkoolen/RigidBodyDynamics.jl/pull/194, while making code cleaner and providing an easier interface for the user, by introducing a new `Associative` type, `UnsafeFastDict`, and two type aliases: `JointDict` and `BodyDict`.

Now, users won't have to deal explicitly with `Vector`'s of `RigidBody`-related stuff (e.g. external wrenches passed into `inverse_dynamics`) with the convention that the vector is indexed using `vertex_index(body)`. Instead, they can simply use a `BodyDict` (or just a `Dict` if they don't care about speed; `inverse_dynamics` et al. accept general `Associative` types).