### PR TITLE
Random mechanism updates: make it easier for the user.

### DIFF
--- a/test/test_mechanism_manipulation.jl
+++ b/test/test_mechanism_manipulation.jl
@@ -124,7 +124,7 @@ end
             # create random floating mechanism
             jointTypes = [[Prismatic{Float64} for i = 1 : 10]; [Revolute{Float64} for i = 1 : 10]; [Fixed{Float64} for i = 1 : 10]]
             shuffle!(jointTypes)
-            mechanism1 = rand_floating_tree_mechanism(Float64, jointTypes)
+            mechanism1 = rand_floating_tree_mechanism(Float64, jointTypes...)
 
             # random state
             x1 = MechanismState(Float64, mechanism1)


### PR DESCRIPTION
Now the scalar type of the mechanism can be inferred from the joint types (unless there are no joint types; a case that also still works). Type signatures are also tightened a bit using new 0.6 syntax.