### PR TITLE
Improve UnsafeFastDict using new 0.6 features.

### DIFF
--- a/perf/runbenchmarks.jl
+++ b/perf/runbenchmarks.jl
@@ -36,7 +36,7 @@ function create_benchmark_suite()
         inverse_dynamics!($torques, $(result.jointwrenches), $(result.accelerations), $state, v̇, externalwrenches),
         setup = begin
             v̇ = rand(num_velocities($mechanism))
-            externalwrenches = RigidBodyDynamics.BodyDict(body => rand(Wrench{ScalarType}, root_frame($mechanism)) for body in bodies($mechanism))
+            externalwrenches = RigidBodyDynamics.BodyDict{ScalarType}(body => rand(Wrench{ScalarType}, root_frame($mechanism)) for body in bodies($mechanism))
             rand!($state)
         end
     )
@@ -44,7 +44,7 @@ function create_benchmark_suite()
         setup = begin
             rand!($state)
             τ = rand(num_velocities($mechanism))
-            externalwrenches = RigidBodyDynamics.BodyDict(body => rand(Wrench{ScalarType}, root_frame($mechanism)) for body in bodies($mechanism))
+            externalwrenches = RigidBodyDynamics.BodyDict{ScalarType}(body => rand(Wrench{ScalarType}, root_frame($mechanism)) for body in bodies($mechanism))
         end
     )
     suite["momentum_matrix"] = @benchmarkable(momentum_matrix!($mat, $state), setup = rand!($state))

--- a/src/dynamics_result.jl
+++ b/src/dynamics_result.jl
@@ -48,11 +48,11 @@ type DynamicsResult{M<:Number, T<:Number}
         ṡ = Vector{T}(num_additional_states(mechanism))
 
         rootframe = root_frame(mechanism)
-        contactwrenches = BodyDict(b => zero(Wrench{T}, rootframe) for b in bodies(mechanism))
-        totalwrenches = BodyDict(b => zero(Wrench{T}, rootframe) for b in bodies(mechanism))
-        accelerations = BodyDict(b => zero(SpatialAcceleration{T}, rootframe, rootframe, rootframe) for b in bodies(mechanism))
-        jointwrenches = BodyDict(b => zero(Wrench{T}, rootframe) for b in bodies(mechanism))
-        contact_state_derivs = BodyDict(b => Vector{Vector{DefaultSoftContactStateDeriv{T}}}() for b in bodies(mechanism))
+        contactwrenches = BodyDict{M}(b => zero(Wrench{T}, rootframe) for b in bodies(mechanism))
+        totalwrenches = BodyDict{M}(b => zero(Wrench{T}, rootframe) for b in bodies(mechanism))
+        accelerations = BodyDict{M}(b => zero(SpatialAcceleration{T}, rootframe, rootframe, rootframe) for b in bodies(mechanism))
+        jointwrenches = BodyDict{M}(b => zero(Wrench{T}, rootframe) for b in bodies(mechanism))
+        contact_state_derivs = BodyDict{M}(b => Vector{Vector{DefaultSoftContactStateDeriv{T}}}() for b in bodies(mechanism))
         startind = 1
         for body in bodies(mechanism), point in contact_points(body)
             model = contact_model(point)

--- a/src/mechanism_state.jl
+++ b/src/mechanism_state.jl
@@ -77,7 +77,7 @@ immutable MechanismState{X<:Number, M<:Number, C<:Number}
         bias_accelerations_wrt_world = BodyDict{M}(b => CacheElement{SpatialAcceleration{C}}() for b in bodies(mechanism))
         inertias = BodyDict{M}(b => CacheElement{SpatialInertia{C}}() for b in bodies(mechanism))
         crb_inertias = BodyDict{M}(b => CacheElement{SpatialInertia{C}}() for b in bodies(mechanism))
-        contact_states = BodyDict{M}(b => Vector{Vector{DefaultSoftContactState{C}}}() for b in bodies(mechanism))
+        contact_states = BodyDict{M, Vector{Vector{DefaultSoftContactState{C}}}}(b => Vector{Vector{DefaultSoftContactState{C}}}() for b in bodies(mechanism))
         startind = 1
         for body in bodies(mechanism), point in contact_points(body)
             model = contact_model(point)

--- a/src/mechanism_state.jl
+++ b/src/mechanism_state.jl
@@ -1,8 +1,5 @@
-const BodyDict{T, V} = UnsafeFastDict{Graphs.vertex_index, RigidBody{T}, V}
-BodyDict(kv) = UnsafeFastDict(kv, Graphs.vertex_index) # TODO: handle this in UnsafeFastDict
-
-const JointDict{T, V} = UnsafeFastDict{Graphs.edge_index, Joint{T}, V}
-JointDict(kv) = UnsafeFastDict(kv, Graphs.edge_index) # TODO: handle this in UnsafeFastDict
+const BodyDict{T} = UnsafeFastDict{Graphs.vertex_index, RigidBody{T}}
+const JointDict{T} = UnsafeFastDict{Graphs.edge_index, Joint{T}}
 
 """
 $(TYPEDEF)
@@ -68,19 +65,19 @@ immutable MechanismState{X<:Number, M<:Number, C<:Number}
         end for joint in tree_joints(mechanism))
 
         # joint-specific
-        joint_transforms = JointDict(j => CacheElement{Transform3DS{C}}() for j in tree_joints(mechanism))
-        joint_twists = JointDict(j => CacheElement{Twist{C}}() for j in tree_joints(mechanism))
-        joint_bias_accelerations = JointDict(j => CacheElement{SpatialAcceleration{C}}() for j in tree_joints(mechanism))
-        motion_subspaces = JointDict(j => CacheElement{MotionSubspace{C}}() for j in tree_joints(mechanism))
-        motion_subspaces_in_world = JointDict(j => CacheElement{MotionSubspace{C}}() for j in tree_joints(mechanism))
+        joint_transforms = JointDict{M}(j => CacheElement{Transform3DS{C}}() for j in tree_joints(mechanism))
+        joint_twists = JointDict{M}(j => CacheElement{Twist{C}}() for j in tree_joints(mechanism))
+        joint_bias_accelerations = JointDict{M}(j => CacheElement{SpatialAcceleration{C}}() for j in tree_joints(mechanism))
+        motion_subspaces = JointDict{M}(j => CacheElement{MotionSubspace{C}}() for j in tree_joints(mechanism))
+        motion_subspaces_in_world = JointDict{M}(j => CacheElement{MotionSubspace{C}}() for j in tree_joints(mechanism))
 
         # body-specific
-        transforms_to_world = BodyDict(b => CacheElement{Transform3DS{C}}() for b in bodies(mechanism))
-        twists_wrt_world = BodyDict(b => CacheElement{Twist{C}}() for b in bodies(mechanism))
-        bias_accelerations_wrt_world = BodyDict(b => CacheElement{SpatialAcceleration{C}}() for b in bodies(mechanism))
-        inertias = BodyDict(b => CacheElement{SpatialInertia{C}}() for b in bodies(mechanism))
-        crb_inertias = BodyDict(b => CacheElement{SpatialInertia{C}}() for b in bodies(mechanism))
-        contact_states = BodyDict{M, Vector{Vector{DefaultSoftContactState{C}}}}(b => Vector{Vector{DefaultSoftContactState{C}}}() for b in bodies(mechanism))
+        transforms_to_world = BodyDict{M}(b => CacheElement{Transform3DS{C}}() for b in bodies(mechanism))
+        twists_wrt_world = BodyDict{M}(b => CacheElement{Twist{C}}() for b in bodies(mechanism))
+        bias_accelerations_wrt_world = BodyDict{M}(b => CacheElement{SpatialAcceleration{C}}() for b in bodies(mechanism))
+        inertias = BodyDict{M}(b => CacheElement{SpatialInertia{C}}() for b in bodies(mechanism))
+        crb_inertias = BodyDict{M}(b => CacheElement{SpatialInertia{C}}() for b in bodies(mechanism))
+        contact_states = BodyDict{M}(b => Vector{Vector{DefaultSoftContactState{C}}}() for b in bodies(mechanism))
         startind = 1
         for body in bodies(mechanism), point in contact_points(body)
             model = contact_model(point)

--- a/src/util.jl
+++ b/src/util.jl
@@ -153,7 +153,7 @@ immutable UnsafeFastDict{I, K, V} <: Associative{K, V}
     function UnsafeFastDict{I}(kv) where {I}
         T = Core.Inference.return_type(first, Tuple{typeof(kv)})
         K = Core.Inference.return_type(first, Tuple{T})
-        V = Core.Inference.return_type(first, Tuple{T})
+        V = Core.Inference.return_type(last, Tuple{T})
         UnsafeFastDict{I, K, V}(kv)
     end
 end

--- a/src/util.jl
+++ b/src/util.jl
@@ -126,7 +126,8 @@ immutable UnsafeFastDict{I, K, V} <: Associative{K, V}
     keys::Vector{K}
     values::Vector{V}
 
-    function (::Type{UnsafeFastDict{I, K, V}}){I, K, V}(kv)
+    # specify index function, key type, and value type
+    function UnsafeFastDict{I, K, V}(kv) where {I, K, V}
         keys = K[]
         values = V[]
         for (k, v) in kv
@@ -138,11 +139,24 @@ immutable UnsafeFastDict{I, K, V} <: Associative{K, V}
             keys[index] = k
             values[index] = v
         end
-        new{I, K, V}(keys, values)
+        new(keys, values)
+    end
+
+    # infer value type
+    function UnsafeFastDict{I, K}(kv) where {I, K}
+        T = Core.Inference.return_type(first, Tuple{typeof(kv)})
+        V = Core.Inference.return_type(last, Tuple{T})
+        UnsafeFastDict{I, K, V}(kv)
+    end
+
+    # infer key type and value type
+    function UnsafeFastDict{I}(kv) where {I}
+        T = Core.Inference.return_type(first, Tuple{typeof(kv)})
+        K = Core.Inference.return_type(first, Tuple{T})
+        V = Core.Inference.return_type(first, Tuple{T})
+        UnsafeFastDict{I, K, V}(kv)
     end
 end
-UnsafeFastDict{K, V}(kv, ::Type{Pair{K, V}}, indexfun) = UnsafeFastDict{indexfun, K, V}(kv)
-UnsafeFastDict(kv, indexfun) = UnsafeFastDict(kv, Core.Inference.return_type(first, Tuple{typeof(kv)}), indexfun)
 
 # Iteration
 Base.start(d::UnsafeFastDict) = 1

--- a/test/test_util.jl
+++ b/test/test_util.jl
@@ -44,10 +44,11 @@ import RigidBodyDynamics: hat, rotation_vector_rate, colwise
     end
 
     @testset "UnsafeFastDict" begin
-        d1 = RigidBodyDynamics.UnsafeFastDict{identity}(i => 3 * i for i in 1 : 3)
+        d1 = RigidBodyDynamics.UnsafeFastDict{identity}(i => 3. * i for i in 1 : 3)
         show(DevNull, d1)
+        @test eltype(d1) == Pair{Int64, Float64}
         @test all(keys(d1) .== 1 : 3)
-        @test all(values(d1) .== 3 * (1 : 3))
+        @test all(values(d1) .== 3. * (1 : 3))
 
         d2 = RigidBodyDynamics.UnsafeFastDict{x -> round(Int64, x), Number}(i => 3 * i for i in 1 : 3)
         @test all(keys(d2) .== 1 : 3)

--- a/test/test_util.jl
+++ b/test/test_util.jl
@@ -44,9 +44,14 @@ import RigidBodyDynamics: hat, rotation_vector_rate, colwise
     end
 
     @testset "UnsafeFastDict" begin
-        d = RigidBodyDynamics.UnsafeFastDict((i => 3 * i for i in 1 : 3), identity)
-        show(DevNull, d)
-        @test all(keys(d) .== 1 : 3)
+        d1 = RigidBodyDynamics.UnsafeFastDict{identity}(i => 3 * i for i in 1 : 3)
+        show(DevNull, d1)
+        @test all(keys(d1) .== 1 : 3)
+        @test all(values(d1) .== 3 * (1 : 3))
+
+        d2 = RigidBodyDynamics.UnsafeFastDict{x -> round(Int64, x), Number}(i => 3 * i for i in 1 : 3)
+        @test all(keys(d2) .== 1 : 3)
+        @test all(values(d2) .== 3 * (1 : 3))
     end
 
     @testset "TypeSortedCollection" begin


### PR DESCRIPTION
This allows the user to specify the key type; useful if the key type cannot be inferred from the iterator (as will soon be the case). Also provides nicer syntax for specifying the indexing function.