### PR TITLE
Add `replace_joint!`

### DIFF
--- a/perf/runbenchmarks.jl
+++ b/perf/runbenchmarks.jl
@@ -9,7 +9,8 @@ function create_floating_atlas()
     urdf = RigidBodyDynamics.cached_download(url, "atlas.urdf")
     atlas = parse_urdf(ScalarType, urdf)
     for joint in out_joints(root_body(atlas), atlas)
-        joint.jointType = QuaternionFloating{ScalarType}()
+        floatingjoint = Joint(joint.name, frame_before(joint), frame_after(joint), QuaternionFloating{ScalarType}())
+        replace_joint!(atlas, joint, floatingjoint)
     end
     atlas
 end

--- a/src/RigidBodyDynamics.jl
+++ b/src/RigidBodyDynamics.jl
@@ -96,6 +96,7 @@ export
     attach!,
     reattach!, # deprecated
     remove_joint!,
+    replace_joint!,
     maximal_coordinates,
     submechanism,
     remove_fixed_joints!, # deprecated

--- a/src/mechanism_manipulation.jl
+++ b/src/mechanism_manipulation.jl
@@ -149,6 +149,17 @@ function remove_joint!(mechanism::Mechanism, joint::Joint, spanning_tree_next_ed
     istreejoint && rebuild_spanning_tree!(mechanism, spanning_tree_next_edge)
 end
 
+function replace_joint!(mechanism::Mechanism, oldjoint::Joint, newjoint::Joint)
+    @assert frame_before(newjoint) == frame_before(oldjoint)
+    @assert frame_after(newjoint) == frame_after(oldjoint)
+    if oldjoint ∈ tree_joints(mechanism)
+        replace_edge!(mechanism.tree, oldjoint, newjoint)
+    else
+        replace_edge!(mechanism.graph, oldjoint, newjoint)
+    end
+    nothing
+end
+
 Base.@deprecate(
 reattach!{T}(mechanism::Mechanism{T}, oldSubtreeRootBody::RigidBody{T},
     parentBody::RigidBody{T}, joint::Joint, jointToParent::Transform3D,

--- a/test/test_mechanism_manipulation.jl
+++ b/test/test_mechanism_manipulation.jl
@@ -91,6 +91,22 @@ end
         @test isapprox(M_no_fixed_joints, M, atol = 1e-12)
     end
 
+    @testset "replace joint" begin
+        jointtypes = [QuaternionFloating{Float64}; [Revolute{Float64} for i = 1 : 10]]
+        shuffle!(jointtypes)
+        mechanism = rand_tree_mechanism(Float64, jointtypes...)
+
+        for m in [mechanism; maximal_coordinates(mechanism)]
+            for i = 1 : 10
+                oldjoint = rand(joints(mechanism))
+                newjoint = Joint("new", frame_before(oldjoint), frame_after(oldjoint), Fixed{Float64}())
+                replace_joint!(mechanism, oldjoint, newjoint)
+                @test newjoint ∈ joints(mechanism)
+                @test oldjoint ∉ joints(mechanism)
+            end
+        end
+    end
+
     @testset "submechanism" begin
         for testnum = 1 : 100
             jointTypes = [QuaternionFloating{Float64}; [Revolute{Float64} for i = 1 : 10]; [Fixed{Float64} for i = 1 : 10]]


### PR DESCRIPTION
This is in anticipation of changing `Joint`s to also be parameterized on their `JointType`, which would make it impossible to change the type of an existing joint.