### PR TITLE
TypeSortedCollection updates.

### DIFF
--- a/test/test_util.jl
+++ b/test/test_util.jl
@@ -57,7 +57,7 @@ import RigidBodyDynamics: hat, rotation_vector_rate, colwise
 
     @testset "TypeSortedCollection" begin
         x = Pair[3. => 1; 4 => 2; 5 => 3]
-        sorted = RigidBodyDynamics.TypeSortedCollection{last}(x)
+        sorted = RigidBodyDynamics.TypeSortedCollection(last, x)
         index = RigidBodyDynamics.indexfun(sorted)
         @test index == last
         @test length(sorted) == length(x)


### PR DESCRIPTION
Store index function in `TypeSortedCollection` to allow closures over mutable types (as discussed with @rdeits).

Generalize `map!` to the multi-argument case.