### PR TITLE
Cache element update

### DIFF
--- a/notebooks/Four-bar linkage - simulation and visualization.ipynb
+++ b/notebooks/Four-bar linkage - simulation and visualization.ipynb
@@ -261,7 +261,7 @@
    },
    "outputs": [],
    "source": [
-    "state = MechanismState(T, fourbar)\n",
+    "state = MechanismState{T}(fourbar)\n",
     "result = DynamicsResult{T, T}(fourbar);"
    ]
   },

--- a/notebooks/Quickstart - double pendulum.ipynb
+++ b/notebooks/Quickstart - double pendulum.ipynb
@@ -353,7 +353,7 @@
     }
    ],
    "source": [
-    "state = MechanismState(Float64, doublependulum)"
+    "state = MechanismState{Float64}(doublependulum)"
    ]
   },
   {

--- a/notebooks/Symbolic double pendulum.ipynb
+++ b/notebooks/Symbolic double pendulum.ipynb
@@ -154,7 +154,7 @@
    },
    "outputs": [],
    "source": [
-    "x = MechanismState(T, doublePendulum);"
+    "x = MechanismState{T}(doublePendulum);"
    ]
   },
   {

--- a/perf/runbenchmarks.jl
+++ b/perf/runbenchmarks.jl
@@ -20,7 +20,7 @@ function create_benchmark_suite()
     mechanism = create_floating_atlas()
     remove_fixed_tree_joints!(mechanism)
 
-    state = MechanismState(ScalarType, mechanism)
+    state = MechanismState{ScalarType}(mechanism)
     result = DynamicsResult(ScalarType, mechanism)
     nv = num_velocities(state)
     mat = MomentumMatrix(root_frame(mechanism), Matrix{ScalarType}(3, nv), Matrix{ScalarType}(3, nv))

--- a/src/cache_element.jl
+++ b/src/cache_element.jl
@@ -1,35 +1,16 @@
 type CacheElement{T}
-    dirty::Bool
     data::T
-    (::Type{CacheElement{T}}){T}() = new{T}(true)
+    dirty::Bool
+    CacheElement(data::T) where {T} = new{T}(data, true)
 end
 
-@inline function update!{T}(element::CacheElement{T}, data::T)
-    element.data = data
-    element.dirty = false
-end
-
-@inline function Base.get(element::CacheElement)
-    element.dirty && error("Cache dirty.")
-    element.data
-end
-
-@inline function setdirty!(element::CacheElement)
-    element.dirty = true
-end
-
+@inline setdirty!(element::CacheElement) = (element.dirty = true; nothing)
 @inline isdirty(element::CacheElement) = element.dirty
 
-# The reason for doing this using a macro instead of using something like get!(element::CacheElement, callable)
-# is that in all use cases so far, the callable would be a closure over some non-isbits types, meaning that
-# creating the closure allocates.
-# Example showing this allocation behavior: @benchmark (fun = () -> a.x) setup = a = Ref(rand(Int64))
-macro cache_element_get!(element, updateExpr)
-    ret = quote
-        if isdirty($element)
-            update!($element, $updateExpr)
-        end
-        get($element)
+@inline function update!(element::CacheElement, f!, args...)
+    if element.dirty
+        f!(element.data, args...)
+        element.dirty = false
     end
-    :($(esc(ret)))
+    element.data
 end

--- a/src/util.jl
+++ b/src/util.jl
@@ -156,6 +156,20 @@ immutable UnsafeFastDict{I, K, V} <: Associative{K, V}
         V = Core.Inference.return_type(last, Tuple{T})
         UnsafeFastDict{I, K, V}(kv)
     end
+
+    # specify all types, but leave values uninitialized
+    function UnsafeFastDict{I, K, V}(keys::AbstractVector{K}) where {I, K, V}
+        sortedkeys = K[]
+        for k in keys
+            index = I(k)
+            if index > length(sortedkeys)
+                resize!(sortedkeys, index)
+            end
+            sortedkeys[index] = k
+        end
+        values = Vector{V}(length(sortedkeys))
+        new(sortedkeys, values)
+    end
 end
 
 # Iteration

--- a/test/test_double_pendulum.jl
+++ b/test/test_double_pendulum.jl
@@ -46,7 +46,7 @@
     @test findjoint(doublePendulum, joint2.name) == joint2
     @test_throws ErrorException findjoint(doublePendulum, "bla")
 
-    x = MechanismState(Float64, doublePendulum)
+    x = MechanismState{Float64}(doublePendulum)
     rand!(x)
 
     # from http://underactuated.csail.mit.edu/underactuated.html?chapter=3
@@ -87,7 +87,7 @@
     # compare against URDF
     doublePendulumUrdf = parse_urdf(Float64, "urdf/Acrobot.urdf")
     remove_fixed_tree_joints!(doublePendulumUrdf)
-    x_urdf = MechanismState(Float64, doublePendulumUrdf)
+    x_urdf = MechanismState{Float64}(doublePendulumUrdf)
     for (i, j) in enumerate(joints(doublePendulum))
         urdf_joints = collect(joints(doublePendulumUrdf))
         index = findfirst(joint -> joint.name == j.name, urdf_joints)

--- a/test/test_mechanism_algorithms.jl
+++ b/test/test_mechanism_algorithms.jl
@@ -1,6 +1,6 @@
 # @testset "mechanism algorithms" begin
     mechanism = rand_tree_mechanism(Float64, [QuaternionFloating{Float64}; [Revolute{Float64} for i = 1 : 10]; [Fixed{Float64} for i = 1 : 5]; [Prismatic{Float64} for i = 1 : 10]]...)
-    x = MechanismState(Float64, mechanism)
+    x = MechanismState{Float64}(mechanism)
     rand!(x)
 
     @testset "show" begin
@@ -154,7 +154,7 @@
                 q̇ = configuration_derivative(x)
                 q_autodiff = create_autodiff(q, q̇)
                 v_autodiff = create_autodiff(v, v̇)
-                x_autodiff = MechanismState(eltype(q_autodiff), mechanism)
+                x_autodiff = MechanismState{eltype(q_autodiff)}(mechanism)
                 set_configuration!(x_autodiff, q_autodiff)
                 set_velocity!(x_autodiff, v_autodiff)
                 twist_autodiff = relative_twist(x_autodiff, body, base)
@@ -233,7 +233,7 @@
 
         q = configuration(x)
         kinetic_energy_fun = v -> begin
-            local x = MechanismState(eltype(v), mechanism)
+            local x = MechanismState{eltype(v)}(mechanism)
             set_configuration!(x, q)
             set_velocity!(x, v)
             kinetic_energy(x)
@@ -265,11 +265,11 @@
 
     @testset "inverse dynamics / Coriolis term" begin
         mechanism = rand_tree_mechanism(Float64, [[Revolute{Float64} for i = 1 : 10]; [Prismatic{Float64} for i = 1 : 10]]...) # skew symmetry property tested later on doesn't hold when q̇ ≠ v
-        x = MechanismState(Float64, mechanism)
+        x = MechanismState{Float64}(mechanism)
         rand!(x)
 
         function q_to_M(q)
-            local x = MechanismState(eltype(q), mechanism)
+            local x = MechanismState{eltype(q)}(mechanism)
             set_configuration!(x, q)
             zero_velocity!(x)
             vec(mass_matrix(x))
@@ -284,7 +284,7 @@
         q = configuration(x)
         v̇ = zeros(num_velocities(mechanism))
         function v_to_c(v)
-            local x = MechanismState(eltype(v), mechanism)
+            local x = MechanismState{eltype(v)}(mechanism)
             set_configuration!(x, q)
             set_velocity!(x, v)
             inverse_dynamics(x, v̇)
@@ -299,14 +299,14 @@
 
     @testset "inverse dynamics / gravity term" begin
         mechanism = rand_tree_mechanism(Float64, [[Revolute{Float64} for i = 1 : 10]; [Prismatic{Float64} for i = 1 : 10]]...)
-        x = MechanismState(Float64, mechanism)
+        x = MechanismState{Float64}(mechanism)
         rand!(x)
         v̇ = zeros(num_velocities(mechanism))
         zero_velocity!(x)
         g = inverse_dynamics(x, v̇)
 
         function q_to_potential(q)
-            x = MechanismState(eltype(q), mechanism)
+            x = MechanismState{eltype(q)}(mechanism)
             set_configuration!(x, q)
             zero_velocity!(x)
             return [gravitational_potential_energy(x)]
@@ -319,7 +319,7 @@
 
     @testset "momentum matrix" begin
         mechanism = rand_chain_mechanism(Float64, [QuaternionFloating{Float64}; [Revolute{Float64} for i = 1 : 10]; [Prismatic{Float64} for i = 1 : 10]]...)
-        x = MechanismState(Float64, mechanism)
+        x = MechanismState{Float64}(mechanism)
         rand_configuration!(x)
         rand_velocity!(x)
         q = configuration(x)
@@ -333,7 +333,7 @@
         # rate of change of momentum computed using autodiff:
         q_autodiff = create_autodiff(q, q̇)
         v_autodiff = create_autodiff(v, v̇)
-        x_autodiff = MechanismState(eltype(q_autodiff), mechanism)
+        x_autodiff = MechanismState{eltype(q_autodiff)}(mechanism)
         set_configuration!(x_autodiff, q_autodiff)
         set_velocity!(x_autodiff, v_autodiff)
         A_autodiff = Array(momentum_matrix(x_autodiff))
@@ -348,7 +348,7 @@
 
     @testset "inverse dynamics / external wrenches" begin
         mechanism = rand_chain_mechanism(Float64, [QuaternionFloating{Float64}; [Revolute{Float64} for i = 1 : 10]; [Prismatic{Float64} for i = 1 : 10]]...) # what really matters is that there's a floating joint first
-        x = MechanismState(Float64, mechanism)
+        x = MechanismState{Float64}(mechanism)
         rand_configuration!(x)
         rand_velocity!(x)
 
@@ -369,7 +369,7 @@
 
     @testset "dynamics / inverse dynamics" begin
         mechanism = rand_tree_mechanism(Float64, [QuaternionFloating{Float64}; [Revolute{Float64} for i = 1 : 10]; [Prismatic{Float64} for i = 1 : 10]]...)
-        x = MechanismState(Float64, mechanism)
+        x = MechanismState{Float64}(mechanism)
         rand!(x)
         externalTorques = rand(num_velocities(mechanism))
         externalwrenches = Dict(body => rand(Wrench{Float64}, root_frame(mechanism)) for body in bodies(mechanism))
@@ -382,7 +382,7 @@
 
     @testset "dynamics ode method" begin
         mechanism = rand_tree_mechanism(Float64, [QuaternionFloating{Float64}; [Revolute{Float64} for i = 1 : 10]; [Prismatic{Float64} for i = 1 : 10]]...)
-        x = MechanismState(Float64, mechanism)
+        x = MechanismState{Float64}(mechanism)
         rand!(x)
         torques = rand(num_velocities(mechanism))
         externalwrenches = Dict(body => rand(Wrench{Float64}, root_frame(mechanism)) for body in bodies(mechanism))
@@ -399,7 +399,7 @@
 
     @testset "power flow" begin
         mechanism = rand_chain_mechanism(Float64, [QuaternionFloating{Float64}; [Revolute{Float64} for i = 1 : 10]; [Prismatic{Float64} for i = 1 : 10]]...) # what really matters is that there's a floating joint first
-        x = MechanismState(Float64, mechanism)
+        x = MechanismState{Float64}(mechanism)
         rand_configuration!(x)
         rand_velocity!(x)
         externalwrenches = Dict(body => rand(Wrench{Float64}, root_frame(mechanism)) for body in bodies(mechanism))
@@ -415,7 +415,7 @@
 
         q_autodiff = create_autodiff(q, q̇)
         v_autodiff = create_autodiff(v, v̇)
-        x_autodiff = MechanismState(eltype(q_autodiff), mechanism)
+        x_autodiff = MechanismState{eltype(q_autodiff)}(mechanism)
         set_configuration!(x_autodiff, q_autodiff)
         set_velocity!(x_autodiff, v_autodiff)
         energy_autodiff = gravitational_potential_energy(x_autodiff) + kinetic_energy(x_autodiff)
@@ -425,7 +425,7 @@
 
     @testset "local / global coordinates" begin
         mechanism = rand_tree_mechanism(Float64, [QuaternionFloating{Float64}; [Revolute{Float64} for i = 1 : 10]; [Prismatic{Float64} for i = 1 : 10]]...)
-        state = MechanismState(Float64, mechanism)
+        state = MechanismState{Float64}(mechanism)
         rand!(state)
         for joint in joints(mechanism)
             # back and forth between local and global

--- a/test/test_mechanism_manipulation.jl
+++ b/test/test_mechanism_manipulation.jl
@@ -47,7 +47,7 @@ end
             @test RigidBodyDynamics.is_fixed_to_body(body, frame)
         end
 
-        state = MechanismState(Float64, mechanism) # issue 63
+        state = MechanismState{Float64}(mechanism) # issue 63
         rand!(state)
         M = mass_matrix(state)
 
@@ -55,13 +55,13 @@ end
         # make sure mass matrix is block diagonal, and that blocks on diagonal are the same
         doubleAcrobot = parse_urdf(Float64, "urdf/Acrobot.urdf")
         acrobot2 = parse_urdf(Float64, "urdf/Acrobot.urdf")
-        xSingle = MechanismState(Float64, acrobot2)
+        xSingle = MechanismState{Float64}(acrobot2)
         rand!(xSingle)
         qSingle = configuration(xSingle)
         nqSingle = length(qSingle)
         parentBody = root_body(doubleAcrobot)
         attach!(doubleAcrobot, parentBody, acrobot2)
-        x = MechanismState(Float64, doubleAcrobot)
+        x = MechanismState{Float64}(doubleAcrobot)
         set_configuration!(x, [qSingle; qSingle])
         H = mass_matrix(x)
         H11 = H[1 : nqSingle, 1 : nqSingle]
@@ -77,7 +77,7 @@ end
         jointTypes = [QuaternionFloating{Float64}; [Revolute{Float64} for i = 1 : 10]; [Fixed{Float64} for i = 1 : 10]]
         shuffle!(jointTypes)
         mechanism = rand_tree_mechanism(Float64, jointTypes...)
-        state = MechanismState(Float64, mechanism)
+        state = MechanismState{Float64}(mechanism)
         rand!(state)
         q = configuration(state)
         M = mass_matrix(state)
@@ -85,7 +85,7 @@ end
 
         remove_fixed_tree_joints!(mechanism)
         @test tree_joints(mechanism) == nonfixedjoints
-        state_no_fixed_joints = MechanismState(Float64, mechanism)
+        state_no_fixed_joints = MechanismState{Float64}(mechanism)
         set_configuration!(state_no_fixed_joints, q)
         M_no_fixed_joints = mass_matrix(state_no_fixed_joints)
         @test isapprox(M_no_fixed_joints, M, atol = 1e-12)
@@ -113,7 +113,7 @@ end
             jointTypes = [Revolute{Float64} for i = 1 : 4]
             shuffle!(jointTypes)
             mechanism = rand_tree_mechanism(Float64, jointTypes...)
-            state = MechanismState(Float64, mechanism)
+            state = MechanismState{Float64}(mechanism)
             rand!(state)
             M = mass_matrix(state)
 
@@ -122,7 +122,7 @@ end
             @test root_body(mechanismPart) == bodymap[submechanismRoot]
             @test mechanism.gravitationalAcceleration.v == mechanismPart.gravitationalAcceleration.v
 
-            substate = MechanismState(Float64, mechanismPart)
+            substate = MechanismState{Float64}(mechanismPart)
             for (oldjoint, newjoint) in jointmap
                 set_configuration!(substate, newjoint, configuration(state, oldjoint))
                 set_velocity!(substate, newjoint, velocity(state, oldjoint))
@@ -143,7 +143,7 @@ end
             mechanism1 = rand_floating_tree_mechanism(Float64, jointTypes...)
 
             # random state
-            x1 = MechanismState(Float64, mechanism1)
+            x1 = MechanismState{Float64}(mechanism1)
             rand!(x1)
 
             # copy and set up mapping from bodies and joints of mechanism1 to those of mechanism2
@@ -168,7 +168,7 @@ end
 
             # mimic the same state for the rerooted mechanism
             # copy non-floating joint configurations and velocities
-            x2 = MechanismState(Float64, mechanism2)
+            x2 = MechanismState{Float64}(mechanism2)
             for (joint1, joint2) in jointmap
                 if joint1 != floatingjoint
                     joint2Rerooted = joint2 #get(flippedJointMapping, joint2, joint2)
@@ -218,11 +218,11 @@ end
         mcMechanism, newfloatingjoints, bodymap, jointmap = maximal_coordinates(treeMechanism)
 
         # randomize state of tree mechanism
-        treeState = MechanismState(Float64, treeMechanism)
+        treeState = MechanismState{Float64}(treeMechanism)
         rand!(treeState)
 
         # put maximal coordinate system in state that is equivalent to tree mechanism state
-        mcState = MechanismState(Float64, mcMechanism)
+        mcState = MechanismState{Float64}(mcMechanism)
         for oldbody in non_root_bodies(treeMechanism)
             newbody = bodymap[oldbody]
             joint = newfloatingjoints[newbody]
@@ -254,10 +254,10 @@ end
         mechanism = rand_tree_mechanism(Float64, [QuaternionFloating{Float64}; [Revolute{Float64} for i = 1 : 10]; [Fixed{Float64} for i = 1 : 5]; [Prismatic{Float64} for i = 1 : 10]]...);
         mechanism, newfloatingjoints, bodymap, jointmap = maximal_coordinates(mechanism)
 
-        stateFloat64 = MechanismState(Float64, mechanism)
+        stateFloat64 = MechanismState{Float64}(mechanism)
         rand!(stateFloat64)
         NullDual = typeof(ForwardDiff.Dual(0., ()))
-        stateDual = MechanismState(NullDual, mechanism)
+        stateDual = MechanismState{NullDual}(mechanism)
         configuration(stateDual)[:] = configuration(stateFloat64)
         velocity(stateDual)[:] = velocity(stateFloat64)
 

--- a/test/test_simulate.jl
+++ b/test/test_simulate.jl
@@ -2,7 +2,7 @@
     @testset "simulate" begin
         # use simulate function (Munthe-Kaas integrator)
         acrobot = parse_urdf(Float64, "urdf/Acrobot.urdf")
-        x = MechanismState(Float64, acrobot)
+        x = MechanismState{Float64}(acrobot)
         rand!(x)
         total_energy_before = gravitational_potential_energy(x) + kinetic_energy(x)
         times, qs, vs = simulate(x, 0.1; Δt = 1e-2)
@@ -52,7 +52,7 @@
         halfspace = HalfSpace3D(point, normal)
         add_environment_primitive!(mechanism, halfspace)
 
-        state = MechanismState(Float64, mechanism)
+        state = MechanismState{Float64}(mechanism)
         z0 = 0.05
         zero!(state)
         RigidBodyDynamics.translation!(floatingjoint.jointType, configuration(state, floatingjoint), SVector(1., 2., z0 - com.v[3]))
@@ -109,7 +109,7 @@
             frictionmodel = ViscoelasticCoulombModel(μ, 50e3, 1e4)
             m, b = deepcopy((mechanism, body))
             add_contact_point!(b, ContactPoint(contactlocation, SoftContactModel(normalmodel, frictionmodel)))
-            state = MechanismState(Float64, m)
+            state = MechanismState{Float64}(m)
             simulate(state, 1., Δt = 1e-3) # settle into steady state
             x1 = transform(state, contactlocation, worldframe)
             simulate(state, 0.5, Δt = 1e-3)


### PR DESCRIPTION
Update `CacheElement` to perform update in-place. Fixes https://github.com/tkoolen/RigidBodyDynamics.jl/issues/210 (for the most part). Will allow unchecked accesses to cache elements in e.g. `mass_matrix` after computing everything in one go. Will also be useful for upcoming use of `TypeSortedCollection`.

Also change `MechanismState` constructor to use the new inner constructor syntax and deprecates the old outer constructor.
