### PR TITLE
Fix #209

### DIFF
--- a/src/cache_element.jl
+++ b/src/cache_element.jl
@@ -12,5 +12,5 @@ end
         f!(element.data, args...)
         element.dirty = false
     end
-    element.data
+    nothing
 end

--- a/src/joint.jl
+++ b/src/joint.jl
@@ -99,7 +99,7 @@ after the joint to the frame before the joint for joint configuration vector ``q
 """
 function joint_transform(joint::Joint, q::AbstractVector)
     @boundscheck check_num_positions(joint, q)
-    _joint_transform(joint.jointType, frame_after(joint), frame_before(joint), q)
+    joint_transform(joint.jointType, frame_after(joint), frame_before(joint), q)
 end
 
 """
@@ -114,7 +114,7 @@ the frame after the joint, which is attached to the joint's successor.
 """
 function motion_subspace(joint::Joint, q::AbstractVector)
     @boundscheck check_num_positions(joint, q)
-    _motion_subspace(joint.jointType, frame_after(joint), frame_before(joint), q)
+    motion_subspace(joint.jointType, frame_after(joint), frame_before(joint), q)
 end
 
 """
@@ -134,7 +134,7 @@ The constraint wrench subspace is orthogonal to the motion subspace.
 function constraint_wrench_subspace(joint::Joint, jointTransform::Transform3D)
     @framecheck jointTransform.from frame_after(joint)
     @framecheck jointTransform.to frame_before(joint)
-    _constraint_wrench_subspace(joint.jointType, jointTransform)
+    constraint_wrench_subspace(joint.jointType, jointTransform)
 end
 
 """
@@ -147,7 +147,7 @@ in configuration ``q`` and at velocity ``v``, when the joint acceleration
 function bias_acceleration(joint::Joint, q::AbstractVector, v::AbstractVector)
     @boundscheck check_num_positions(joint, q)
     @boundscheck check_num_velocities(joint, v)
-    _bias_acceleration(joint.jointType, frame_after(joint), frame_before(joint), q, v)
+    bias_acceleration(joint.jointType, frame_after(joint), frame_before(joint), q, v)
 end
 
 """
@@ -156,7 +156,7 @@ $(SIGNATURES)
 Whether the joint's motion subspace and constraint wrench subspace depend on
 ``q``.
 """
-has_fixed_subspaces(joint::Joint) = _has_fixed_subspaces(joint.jointType)
+has_fixed_subspaces(joint::Joint) = has_fixed_subspaces(joint.jointType)
 
 """
 $(SIGNATURES)
@@ -172,7 +172,7 @@ function configuration_derivative_to_velocity!(joint::Joint, v::AbstractVector, 
     @boundscheck check_num_velocities(joint, v)
     @boundscheck check_num_positions(joint, q)
     @boundscheck check_num_positions(joint, q̇)
-    _configuration_derivative_to_velocity!(joint.jointType, v, q, q̇)
+    configuration_derivative_to_velocity!(joint.jointType, v, q, q̇)
 end
 
 """
@@ -189,7 +189,7 @@ function velocity_to_configuration_derivative!(joint::Joint, q̇::AbstractVector
     @boundscheck check_num_positions(joint, q̇)
     @boundscheck check_num_positions(joint, q)
     @boundscheck check_num_velocities(joint, v)
-    _velocity_to_configuration_derivative!(joint.jointType, q̇, q, v)
+    velocity_to_configuration_derivative!(joint.jointType, q̇, q, v)
 end
 
 """
@@ -200,7 +200,7 @@ transform.
 """
 function zero_configuration!(joint::Joint, q::AbstractVector)
     @boundscheck check_num_positions(joint, q)
-    _zero_configuration!(joint.jointType, q)
+    zero_configuration!(joint.jointType, q)
 end
 
 """
@@ -211,7 +211,7 @@ joint type.
 """
 function rand_configuration!(joint::Joint, q::AbstractVector)
     @boundscheck check_num_positions(joint, q)
-    _rand_configuration!(joint.jointType, q)
+    rand_configuration!(joint.jointType, q)
 end
 
 """
@@ -225,7 +225,7 @@ Note that this is the same as `Twist(motion_subspace(joint, q), v)`.
 function joint_twist(joint::Joint, q::AbstractVector, v::AbstractVector)
     @boundscheck check_num_positions(joint, q)
     @boundscheck check_num_velocities(joint, v)
-    _joint_twist(joint.jointType, frame_after(joint), frame_before(joint), q, v)
+    joint_twist(joint.jointType, frame_after(joint), frame_before(joint), q, v)
 end
 
 """
@@ -238,7 +238,7 @@ function joint_torque!(joint::Joint, τ::AbstractVector, q::AbstractVector, join
     @boundscheck check_num_velocities(joint, τ)
     @boundscheck check_num_positions(joint, q)
     @framecheck(joint_wrench.frame, frame_after(joint))
-    _joint_torque!(joint.jointType, τ, q, joint_wrench)
+    joint_torque!(joint.jointType, τ, q, joint_wrench)
 end
 
 """
@@ -266,7 +266,7 @@ function local_coordinates!(joint::Joint,
     @boundscheck check_num_positions(joint, q0)
     @boundscheck check_num_positions(joint, q)
     @boundscheck check_num_velocities(joint, v)
-    _local_coordinates!(joint.jointType, ϕ, ϕ̇, q0, q, v)
+    local_coordinates!(joint.jointType, ϕ, ϕ̇, q0, q, v)
 end
 
 """
@@ -282,5 +282,5 @@ function global_coordinates!(joint::Joint, q::AbstractVector, q0::AbstractVector
     @boundscheck check_num_positions(joint, q)
     @boundscheck check_num_positions(joint, q0)
     @boundscheck check_num_velocities(joint, ϕ)
-    _global_coordinates!(joint.jointType, q, q0, ϕ)
+    global_coordinates!(joint.jointType, q, q0, ϕ)
 end

--- a/src/joint.jl
+++ b/src/joint.jl
@@ -24,19 +24,18 @@ See also:
 * Definition 2.9 in Duindam, "Port-Based Modeling and Control for Efficient Bipedal Walking Robots", 2006.
 * Section 4.4 of Featherstone, "Rigid Body Dynamics Algorithms", 2008.
 """
-type Joint{T<:Number}
+type Joint{T<:Number, JT<:JointType{T}}
     name::String
     frameBefore::CartesianFrame3D
     frameAfter::CartesianFrame3D
-    jointType::JointType{T}
+    jointType::JT
     id::Int64
 
-    function (::Type{Joint{T}}){T}(name::String, frameBefore::CartesianFrame3D, frameAfter::CartesianFrame3D, jointType::JointType{T})
-        new{T}(name, frameBefore, frameAfter, jointType, -1)
+    function Joint(name::String, frameBefore::CartesianFrame3D, frameAfter::CartesianFrame3D, jointType::JT) where {T<:Number, JT<:JointType{T}}
+        new{T, JT}(name, frameBefore, frameAfter, jointType, -1)
     end
 end
 
-Joint{T}(name::String, frameBefore::CartesianFrame3D, frameAfter::CartesianFrame3D, jointType::JointType{T}) = Joint{T}(name, frameBefore, frameAfter, jointType)
 Joint(name::String, jointType::JointType) = Joint(name, CartesianFrame3D(string("before_", name)), CartesianFrame3D(string("after_", name)), jointType)
 
 frame_before(joint::Joint) = joint.frameBefore
@@ -71,22 +70,19 @@ end
 end
 
 
-# 'RTTI'-style dispatch inspired by https://groups.google.com/d/msg/julia-users/ude2-MUiFLM/z-MuQ9nhAAAJ, hopefully a short-term solution.
-# See https://github.com/tkoolen/RigidBodyDynamics.jl/issues/93.
-
 """
 $(SIGNATURES)
 
 Return the length of the configuration vector of `joint`.
 """
-num_positions{M}(joint::Joint{M})::Int64 = @rtti_dispatch (QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}) num_positions(joint.jointType)
+num_positions(joint::Joint) = num_positions(joint.jointType)
 
 """
 $(SIGNATURES)
 
 Return the length of the velocity vector of `joint`.
 """
-num_velocities{M}(joint::Joint{M})::Int64 = @rtti_dispatch (QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}) num_velocities(joint.jointType)
+num_velocities(joint::Joint) = num_velocities(joint.jointType)
 
 """
 $(SIGNATURES)
@@ -101,9 +97,9 @@ $(SIGNATURES)
 Return a `Transform3D` representing the homogeneous transform from the frame
 after the joint to the frame before the joint for joint configuration vector ``q``.
 """
-function joint_transform{M, X}(joint::Joint{M}, q::AbstractVector{X})::Transform3DS{promote_type(M, X)}
+function joint_transform(joint::Joint, q::AbstractVector)
     @boundscheck check_num_positions(joint, q)
-    @rtti_dispatch (QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}) _joint_transform(joint.jointType, frame_after(joint), frame_before(joint), q)
+    _joint_transform(joint.jointType, frame_after(joint), frame_before(joint), q)
 end
 
 """
@@ -116,9 +112,9 @@ the velocity vector ``v``, that maps ``v`` to the twist of the joint's successor
 with respect to its predecessor. The returned motion subspace is expressed in
 the frame after the joint, which is attached to the joint's successor.
 """
-function motion_subspace{M, X}(joint::Joint{M}, q::AbstractVector{X})::MotionSubspace{promote_type(M, X)}
+function motion_subspace(joint::Joint, q::AbstractVector)
     @boundscheck check_num_positions(joint, q)
-    @rtti_dispatch (QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}) _motion_subspace(joint.jointType, frame_after(joint), frame_before(joint), q)
+    _motion_subspace(joint.jointType, frame_after(joint), frame_before(joint), q)
 end
 
 """
@@ -135,10 +131,10 @@ its successor.
 
 The constraint wrench subspace is orthogonal to the motion subspace.
 """
-function constraint_wrench_subspace{M, A}(joint::Joint{M}, jointTransform::Transform3D{A})#::WrenchSubspace{promote_type(M, X)} # FIXME: type assertion causes segfault! see https://github.com/JuliaLang/julia/issues/20034. should be fixed in 0.6
+function constraint_wrench_subspace(joint::Joint, jointTransform::Transform3D)
     @framecheck jointTransform.from frame_after(joint)
     @framecheck jointTransform.to frame_before(joint)
-    @rtti_dispatch (QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}) _constraint_wrench_subspace(joint.jointType, jointTransform)
+    _constraint_wrench_subspace(joint.jointType, jointTransform)
 end
 
 """
@@ -148,10 +144,10 @@ Return the acceleration of the joint's successor with respect to its predecessor
 in configuration ``q`` and at velocity ``v``, when the joint acceleration
 ``\\dot{v}`` is zero.
 """
-function bias_acceleration{M, X}(joint::Joint{M}, q::AbstractVector{X}, v::AbstractVector{X})::SpatialAcceleration{promote_type(M, X)}
+function bias_acceleration(joint::Joint, q::AbstractVector, v::AbstractVector)
     @boundscheck check_num_positions(joint, q)
     @boundscheck check_num_velocities(joint, v)
-    @rtti_dispatch (QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}) _bias_acceleration(joint.jointType, frame_after(joint), frame_before(joint), q, v)
+    _bias_acceleration(joint.jointType, frame_after(joint), frame_before(joint), q, v)
 end
 
 """
@@ -160,9 +156,7 @@ $(SIGNATURES)
 Whether the joint's motion subspace and constraint wrench subspace depend on
 ``q``.
 """
-function has_fixed_subspaces{M}(joint::Joint{M})
-    @rtti_dispatch (QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}) _has_fixed_subspaces(joint.jointType)
-end
+has_fixed_subspaces(joint::Joint) = _has_fixed_subspaces(joint.jointType)
 
 """
 $(SIGNATURES)
@@ -174,11 +168,11 @@ Note that this mapping is linear.
 
 See also [`velocity_to_configuration_derivative!`](@ref), the inverse mapping.
 """
-function configuration_derivative_to_velocity!{M}(joint::Joint{M}, v::AbstractVector, q::AbstractVector, q̇::AbstractVector)::Void
+function configuration_derivative_to_velocity!(joint::Joint, v::AbstractVector, q::AbstractVector, q̇::AbstractVector)
     @boundscheck check_num_velocities(joint, v)
     @boundscheck check_num_positions(joint, q)
     @boundscheck check_num_positions(joint, q̇)
-    @rtti_dispatch (QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}) _configuration_derivative_to_velocity!(joint.jointType, v, q, q̇)
+    _configuration_derivative_to_velocity!(joint.jointType, v, q, q̇)
 end
 
 """
@@ -191,11 +185,11 @@ Note that this mapping is linear.
 
 See also [`configuration_derivative_to_velocity!`](@ref), the inverse mapping.
 """
-function velocity_to_configuration_derivative!{M}(joint::Joint{M}, q̇::AbstractVector, q::AbstractVector, v::AbstractVector)::Void
+function velocity_to_configuration_derivative!(joint::Joint, q̇::AbstractVector, q::AbstractVector, v::AbstractVector)
     @boundscheck check_num_positions(joint, q̇)
     @boundscheck check_num_positions(joint, q)
     @boundscheck check_num_velocities(joint, v)
-    @rtti_dispatch (QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}) _velocity_to_configuration_derivative!(joint.jointType, q̇, q, v)
+    _velocity_to_configuration_derivative!(joint.jointType, q̇, q, v)
 end
 
 """
@@ -204,9 +198,9 @@ $(SIGNATURES)
 Set ``q`` to the 'zero' configuration, corresponding to an identity joint
 transform.
 """
-function zero_configuration!{M}(joint::Joint{M}, q::AbstractVector)::Void
+function zero_configuration!(joint::Joint, q::AbstractVector)
     @boundscheck check_num_positions(joint, q)
-    @rtti_dispatch (QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}) _zero_configuration!(joint.jointType, q)
+    _zero_configuration!(joint.jointType, q)
 end
 
 """
@@ -215,9 +209,9 @@ $(SIGNATURES)
 Set ``q`` to a random configuration. The distribution used depends on the
 joint type.
 """
-function rand_configuration!{M}(joint::Joint{M}, q::AbstractVector)::Void
+function rand_configuration!(joint::Joint, q::AbstractVector)
     @boundscheck check_num_positions(joint, q)
-    @rtti_dispatch (QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}) _rand_configuration!(joint.jointType, q)
+    _rand_configuration!(joint.jointType, q)
 end
 
 """
@@ -228,10 +222,10 @@ expressed in the frame after the joint.
 
 Note that this is the same as `Twist(motion_subspace(joint, q), v)`.
 """
-function joint_twist{M, X}(joint::Joint{M}, q::AbstractVector{X}, v::AbstractVector{X})::Twist{promote_type(M, X)}
+function joint_twist(joint::Joint, q::AbstractVector, v::AbstractVector)
     @boundscheck check_num_positions(joint, q)
     @boundscheck check_num_velocities(joint, v)
-    @rtti_dispatch (QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}) _joint_twist(joint.jointType, frame_after(joint), frame_before(joint), q, v)
+    _joint_twist(joint.jointType, frame_after(joint), frame_before(joint), q, v)
 end
 
 """
@@ -240,11 +234,11 @@ $(SIGNATURES)
 Given the wrench exerted across the joint on the joint's successor, compute the
 vector of joint torques ``\\tau`` (in place), in configuration `q`.
 """
-function joint_torque!{M}(joint::Joint{M}, τ::AbstractVector, q::AbstractVector, joint_wrench::Wrench)::Void
+function joint_torque!(joint::Joint, τ::AbstractVector, q::AbstractVector, joint_wrench::Wrench)
     @boundscheck check_num_velocities(joint, τ)
     @boundscheck check_num_positions(joint, q)
     @framecheck(joint_wrench.frame, frame_after(joint))
-    @rtti_dispatch (QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}) _joint_torque!(joint.jointType, τ, q, joint_wrench)
+    _joint_torque!(joint.jointType, τ, q, joint_wrench)
 end
 
 """
@@ -264,7 +258,7 @@ exponential coordinates could be used as the local coordinate vector ``\\phi``.
 
 See also [`global_coordinates!`](@ref).
 """
-function local_coordinates!{M}(joint::Joint{M},
+function local_coordinates!(joint::Joint,
         ϕ::AbstractVector, ϕ̇::AbstractVector,
         q0::AbstractVector, q::AbstractVector, v::AbstractVector)
     @boundscheck check_num_velocities(joint, ϕ)
@@ -272,7 +266,7 @@ function local_coordinates!{M}(joint::Joint{M},
     @boundscheck check_num_positions(joint, q0)
     @boundscheck check_num_positions(joint, q)
     @boundscheck check_num_velocities(joint, v)
-    @rtti_dispatch (QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}) _local_coordinates!(joint.jointType, ϕ, ϕ̇, q0, q, v)
+    _local_coordinates!(joint.jointType, ϕ, ϕ̇, q0, q, v)
 end
 
 """
@@ -284,9 +278,9 @@ around ``q_0``.
 
 See also [`local_coordinates!`](@ref).
 """
-function global_coordinates!{M}(joint::Joint{M}, q::AbstractVector, q0::AbstractVector, ϕ::AbstractVector)
+function global_coordinates!(joint::Joint, q::AbstractVector, q0::AbstractVector, ϕ::AbstractVector)
     @boundscheck check_num_positions(joint, q)
     @boundscheck check_num_positions(joint, q0)
     @boundscheck check_num_velocities(joint, ϕ)
-    @rtti_dispatch (QuaternionFloating{M}, Revolute{M}, Prismatic{M}, Fixed{M}) _global_coordinates!(joint.jointType, q, q0, ϕ)
+    _global_coordinates!(joint.jointType, q, q0, ϕ)
 end

--- a/src/joint.jl
+++ b/src/joint.jl
@@ -226,9 +226,9 @@ $(SIGNATURES)
 Set ``q`` to the 'zero' configuration, corresponding to an identity joint
 transform.
 """
-function zero_configuration!(joint::Joint, q::AbstractVector)
+function zero_configuration!(q::AbstractVector, joint::Joint)
     @boundscheck check_num_positions(joint, q)
-    zero_configuration!(joint.jointType, q)
+    zero_configuration!(q, joint.jointType)
 end
 
 """
@@ -237,9 +237,9 @@ $(SIGNATURES)
 Set ``q`` to a random configuration. The distribution used depends on the
 joint type.
 """
-function rand_configuration!(joint::Joint, q::AbstractVector)
+function rand_configuration!(q::AbstractVector, joint::Joint)
     @boundscheck check_num_positions(joint, q)
-    rand_configuration!(joint.jointType, q)
+    rand_configuration!(q, joint.jointType)
 end
 
 """

--- a/src/joint_types.jl
+++ b/src/joint_types.jl
@@ -6,14 +6,14 @@ Base.eltype{T}(::Type{JointType{T}}) = T
 # Default implementations
 flip_direction{T}(jt::JointType{T}) = deepcopy(jt)
 
-function _local_coordinates!(jt::JointType,
+function local_coordinates!(jt::JointType,
         ϕ::AbstractVector, ϕ̇::AbstractVector,
         q0::AbstractVector, q::AbstractVector, v::AbstractVector)
     sub!(ϕ, q, q0)
     copy!(ϕ̇, v)
 end
 
-function _global_coordinates!(jt::JointType, q::AbstractVector, q0::AbstractVector, ϕ::AbstractVector)
+function global_coordinates!(jt::JointType, q::AbstractVector, q0::AbstractVector, ϕ::AbstractVector)
     @simd for i = 1 : length(q)
         q[i] = q0[i] + ϕ[i]
     end
@@ -70,12 +70,12 @@ end
 @inline linear_velocity(jt::QuaternionFloating, v::AbstractVector) = @inbounds return SVector(v[4], v[5], v[6])
 @inline linear_velocity!(jt::QuaternionFloating, v::AbstractVector, ν::AbstractVector) = @inbounds copy!(v, 4, ν, 1, 3)
 
-function _joint_transform(
+function joint_transform(
         jt::QuaternionFloating, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector)
     Transform3D(frameAfter, frameBefore, rotation(jt, q), translation(jt, q))
 end
 
-function _motion_subspace{T<:Number, X<:Number}(
+function motion_subspace{T<:Number, X<:Number}(
         jt::QuaternionFloating{T}, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector{X})
     S = promote_type(T, X)
     angular = hcat(eye(SMatrix{3, 3, S}), zeros(SMatrix{3, 3, S}))
@@ -83,20 +83,20 @@ function _motion_subspace{T<:Number, X<:Number}(
     MotionSubspace(frameAfter, frameBefore, frameAfter, angular, linear)
 end
 
-function _constraint_wrench_subspace{T<:Number, A<:AbstractMatrix}(jt::QuaternionFloating{T}, jointTransform::Transform3D{A})
+function constraint_wrench_subspace{T<:Number, A<:AbstractMatrix}(jt::QuaternionFloating{T}, jointTransform::Transform3D{A})
     S = promote_type(eltype(typeof((jt))), eltype(typeof(jointTransform)))
     WrenchSubspace(jointTransform.from, zeros(SMatrix{3, 0, S}), zeros(SMatrix{3, 0, S}))
 end
 
-function _bias_acceleration{T<:Number, X<:Number}(
+function bias_acceleration{T<:Number, X<:Number}(
         jt::QuaternionFloating{T}, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector{X}, v::AbstractVector{X})
     S = promote_type(T, X)
     zero(SpatialAcceleration{S}, frameAfter, frameBefore, frameAfter)
 end
 
-_has_fixed_subspaces(jt::QuaternionFloating) = true
+has_fixed_subspaces(jt::QuaternionFloating) = true
 
-function _configuration_derivative_to_velocity!(jt::QuaternionFloating, v::AbstractVector, q::AbstractVector, q̇::AbstractVector)
+function configuration_derivative_to_velocity!(jt::QuaternionFloating, v::AbstractVector, q::AbstractVector, q̇::AbstractVector)
     quat = rotation(jt, q)
     @inbounds quatdot = SVector(q̇[1], q̇[2], q̇[3], q̇[4])
     ω = angular_velocity_in_body(quat, quatdot)
@@ -107,7 +107,7 @@ function _configuration_derivative_to_velocity!(jt::QuaternionFloating, v::Abstr
     nothing
 end
 
-function _velocity_to_configuration_derivative!(jt::QuaternionFloating, q̇::AbstractVector, q::AbstractVector, v::AbstractVector)
+function velocity_to_configuration_derivative!(jt::QuaternionFloating, q̇::AbstractVector, q::AbstractVector, v::AbstractVector)
     quat = rotation(jt, q)
     ω = angular_velocity(jt, v)
     linear = linear_velocity(jt, v)
@@ -121,21 +121,21 @@ function _velocity_to_configuration_derivative!(jt::QuaternionFloating, q̇::Abs
     nothing
 end
 
-function _zero_configuration!(jt::QuaternionFloating, q::AbstractVector)
+function zero_configuration!(jt::QuaternionFloating, q::AbstractVector)
     T = eltype(q)
     rotation!(jt, q, eye(Quat{T}))
     translation!(jt, q, zeros(SVector{3, T}))
     nothing
 end
 
-function _rand_configuration!(jt::QuaternionFloating, q::AbstractVector)
+function rand_configuration!(jt::QuaternionFloating, q::AbstractVector)
     T = eltype(q)
     rotation!(jt, q, rand(Quat{T}))
     translation!(jt, q, randn(SVector{3, T}))
     nothing
 end
 
-function _joint_twist{T<:Number, X<:Number}(
+function joint_twist{T<:Number, X<:Number}(
         jt::QuaternionFloating{T}, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector{X}, v::AbstractVector{X})
     S = promote_type(T, X)
     angular = convert(SVector{3, S}, angular_velocity(jt, v))
@@ -143,14 +143,14 @@ function _joint_twist{T<:Number, X<:Number}(
     Twist(frameAfter, frameBefore, frameAfter, angular, linear)
 end
 
-function _joint_torque!(jt::QuaternionFloating, τ::AbstractVector, q::AbstractVector, joint_wrench::Wrench)
+function joint_torque!(jt::QuaternionFloating, τ::AbstractVector, q::AbstractVector, joint_wrench::Wrench)
     angular_velocity!(jt, τ, joint_wrench.angular)
     linear_velocity!(jt, τ, joint_wrench.linear)
     nothing
 end
 
 # uses exponential coordinates centered around q0
-function _local_coordinates!(jt::QuaternionFloating,
+function local_coordinates!(jt::QuaternionFloating,
         ϕ::AbstractVector, ϕ̇::AbstractVector,
         q0::AbstractVector, q::AbstractVector, v::AbstractVector)
     # anonymous helper frames
@@ -158,10 +158,10 @@ function _local_coordinates!(jt::QuaternionFloating,
     frame0 = CartesianFrame3D()
     frameAfter = CartesianFrame3D()
 
-    t0 = _joint_transform(jt, frame0, frameBefore, q0) # 0 to before
-    t = _joint_transform(jt, frameAfter, frameBefore, q) # after to before
+    t0 = joint_transform(jt, frame0, frameBefore, q0) # 0 to before
+    t = joint_transform(jt, frameAfter, frameBefore, q) # after to before
     relative_transform = inv(t0) * t # relative to q0
-    twist = _joint_twist(jt, frameAfter, frame0, q, v) # (q_0 is assumed not to change)
+    twist = joint_twist(jt, frameAfter, frame0, q, v) # (q_0 is assumed not to change)
     ξ, ξ̇ = log_with_time_derivative(relative_transform, twist)
 
     @inbounds copy!(ϕ, 1, ξ.angular, 1, 3)
@@ -173,13 +173,13 @@ function _local_coordinates!(jt::QuaternionFloating,
     nothing
 end
 
-function _global_coordinates!(jt::QuaternionFloating, q::AbstractVector, q0::AbstractVector, ϕ::AbstractVector)
+function global_coordinates!(jt::QuaternionFloating, q::AbstractVector, q0::AbstractVector, ϕ::AbstractVector)
     # anonymous helper frames
     frameBefore = CartesianFrame3D()
     frame0 = CartesianFrame3D()
     frameAfter = CartesianFrame3D()
 
-    t0 = _joint_transform(jt, frame0, frameBefore, q0)
+    t0 = joint_transform(jt, frame0, frameBefore, q0)
     @inbounds ξrot = SVector(ϕ[1], ϕ[2], ϕ[3])
     @inbounds ξtrans = SVector(ϕ[4], ϕ[5], ϕ[6])
     ξ = Twist(frameAfter, frame0, frame0, ξrot, ξtrans)
@@ -200,29 +200,29 @@ abstract type OneDegreeOfFreedomFixedAxis{T<:Number} <: JointType{T} end
 num_positions(::OneDegreeOfFreedomFixedAxis) = 1
 num_velocities(::OneDegreeOfFreedomFixedAxis) = 1
 
-function _zero_configuration!(::OneDegreeOfFreedomFixedAxis, q::AbstractVector)
+function zero_configuration!(::OneDegreeOfFreedomFixedAxis, q::AbstractVector)
     fill!(q, zero(eltype(q)))
     nothing
 end
 
-function _rand_configuration!(::OneDegreeOfFreedomFixedAxis, q::AbstractVector)
+function rand_configuration!(::OneDegreeOfFreedomFixedAxis, q::AbstractVector)
     randn!(q)
     nothing
  end
 
-function _bias_acceleration{T<:Number, X<:Number}(
+function bias_acceleration{T<:Number, X<:Number}(
         jt::OneDegreeOfFreedomFixedAxis{T}, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector{X}, v::AbstractVector{X})
     zero(SpatialAcceleration{promote_type(T, X)}, frameAfter, frameBefore, frameAfter)
 end
 
-_has_fixed_subspaces(jt::OneDegreeOfFreedomFixedAxis) = true
+has_fixed_subspaces(jt::OneDegreeOfFreedomFixedAxis) = true
 
-function _configuration_derivative_to_velocity!(::OneDegreeOfFreedomFixedAxis, v::AbstractVector, q::AbstractVector, q̇::AbstractVector)
+function configuration_derivative_to_velocity!(::OneDegreeOfFreedomFixedAxis, v::AbstractVector, q::AbstractVector, q̇::AbstractVector)
     copy!(v, q̇)
     nothing
 end
 
-function _velocity_to_configuration_derivative!(::OneDegreeOfFreedomFixedAxis, q̇::AbstractVector, q::AbstractVector, v::AbstractVector)
+function velocity_to_configuration_derivative!(::OneDegreeOfFreedomFixedAxis, q̇::AbstractVector, q::AbstractVector, v::AbstractVector)
     copy!(q̇, v)
     nothing
 end
@@ -256,19 +256,19 @@ end
 
 flip_direction(jt::Prismatic) = Prismatic(-jt.axis)
 
-function _joint_transform(
+function joint_transform(
         jt::Prismatic, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector)
     @inbounds translation = q[1] * jt.axis
     Transform3D(frameAfter, frameBefore, translation)
 end
 
-function _joint_twist(
+function joint_twist(
         jt::Prismatic, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector, v::AbstractVector)
     @inbounds linear = jt.axis * v[1]
     Twist(frameAfter, frameBefore, frameAfter, zeros(linear), linear)
 end
 
-function _motion_subspace{T<:Number, X<:Number}(
+function motion_subspace{T<:Number, X<:Number}(
         jt::Prismatic{T}, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector{X})
     S = promote_type(T, X)
     angular = zeros(SMatrix{3, 1, X})
@@ -276,7 +276,7 @@ function _motion_subspace{T<:Number, X<:Number}(
     MotionSubspace(frameAfter, frameBefore, frameAfter, angular, linear)
 end
 
-function _constraint_wrench_subspace{T<:Number, A<:AbstractMatrix}(jt::Prismatic{T}, jointTransform::Transform3D{A})
+function constraint_wrench_subspace{T<:Number, A<:AbstractMatrix}(jt::Prismatic{T}, jointTransform::Transform3D{A})
     S = promote_type(eltype(typeof((jt))), eltype(typeof(jointTransform)))
     R = convert(RotMatrix{3, S}, jt.rotationFromZAligned)
     Rcols12 = hcat(R[:, 1], R[:, 2]) # TODO: index using SVector once StaticArrays 0.5 is required on all Julia versions
@@ -285,7 +285,7 @@ function _constraint_wrench_subspace{T<:Number, A<:AbstractMatrix}(jt::Prismatic
     WrenchSubspace(jointTransform.from, angular, linear)
 end
 
-function _joint_torque!(jt::Prismatic, τ::AbstractVector, q::AbstractVector, joint_wrench::Wrench)
+function joint_torque!(jt::Prismatic, τ::AbstractVector, q::AbstractVector, joint_wrench::Wrench)
     @inbounds τ[1] = dot(joint_wrench.linear, jt.axis)
     nothing
 end
@@ -319,17 +319,17 @@ end
 
 flip_direction(jt::Revolute) = Revolute(-jt.axis)
 
-function _joint_transform(jt::Revolute, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector)
+function joint_transform(jt::Revolute, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector)
     @inbounds aa = AngleAxis(q[1], jt.axis[1], jt.axis[2], jt.axis[3])
     Transform3D(frameAfter, frameBefore, convert(RotMatrix{3, eltype(aa)}, aa))
 end
 
-function _joint_twist(jt::Revolute, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector, v::AbstractVector)
+function joint_twist(jt::Revolute, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector, v::AbstractVector)
     @inbounds angular_velocity = jt.axis * v[1]
     Twist(frameAfter, frameBefore, frameAfter, angular_velocity, zeros(angular_velocity))
 end
 
-function _motion_subspace{T<:Number, X<:Number}(
+function motion_subspace{T<:Number, X<:Number}(
         jt::Revolute{T}, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector{X})
     S = promote_type(T, X)
     angular = SMatrix{3, 1, S}(jt.axis)
@@ -337,7 +337,7 @@ function _motion_subspace{T<:Number, X<:Number}(
     MotionSubspace(frameAfter, frameBefore, frameAfter, angular, linear)
 end
 
-function _constraint_wrench_subspace{T<:Number, A<:AbstractMatrix}(jt::Revolute{T}, jointTransform::Transform3D{A})
+function constraint_wrench_subspace{T<:Number, A<:AbstractMatrix}(jt::Revolute{T}, jointTransform::Transform3D{A})
     S = promote_type(eltype(typeof((jt))), eltype(typeof(jointTransform)))
     R = convert(RotMatrix{3, S}, jt.rotationFromZAligned)
     Rcols12 = hcat(R[:, 1], R[:, 2]) # TODO: index using SVector once StaticArrays 0.5 is required on all Julia versions
@@ -346,7 +346,7 @@ function _constraint_wrench_subspace{T<:Number, A<:AbstractMatrix}(jt::Revolute{
     WrenchSubspace(jointTransform.from, angular, linear)
 end
 
-function _joint_torque!(jt::Revolute, τ::AbstractVector, q::AbstractVector, joint_wrench::Wrench)
+function joint_torque!(jt::Revolute, τ::AbstractVector, q::AbstractVector, joint_wrench::Wrench)
     @inbounds τ[1] = dot(joint_wrench.angular, jt.axis)
     nothing
 end
@@ -366,38 +366,38 @@ Random.rand{T}(::Type{Fixed{T}}) = Fixed{T}()
 num_positions(::Fixed) = 0
 num_velocities(::Fixed) = 0
 
-function _joint_transform{T<:Number, X<:Number}(
+function joint_transform{T<:Number, X<:Number}(
         jt::Fixed{T}, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector{X})
     eye(Transform3DS{promote_type(T, X)}, frameAfter, frameBefore)
 end
 
-function _joint_twist{T<:Number, X<:Number}(
+function joint_twist{T<:Number, X<:Number}(
         jt::Fixed{T}, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector{X}, v::AbstractVector{X})
     zero(Twist{promote_type(T, X)}, frameAfter, frameBefore, frameAfter)
 end
 
-function _motion_subspace{T<:Number, X<:Number}(
+function motion_subspace{T<:Number, X<:Number}(
         jt::Fixed{T}, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector{X})
     S = promote_type(T, X)
     MotionSubspace(frameAfter, frameBefore, frameAfter, zeros(SMatrix{3, 0, S}), zeros(SMatrix{3, 0, S}))
 end
 
-function _constraint_wrench_subspace{T<:Number, A<:AbstractMatrix}(jt::Fixed{T}, jointTransform::Transform3D{A})
+function constraint_wrench_subspace{T<:Number, A<:AbstractMatrix}(jt::Fixed{T}, jointTransform::Transform3D{A})
     S = promote_type(eltype(typeof((jt))), eltype(typeof(jointTransform)))
     angular = hcat(eye(SMatrix{3, 3, S}), zeros(SMatrix{3, 3, S}))
     linear = hcat(zeros(SMatrix{3, 3, S}), eye(SMatrix{3, 3, S}))
     WrenchSubspace(jointTransform.from, angular, linear)
 end
 
-_zero_configuration!(::Fixed, q::AbstractVector) = nothing
-_rand_configuration!(::Fixed, q::AbstractVector) = nothing
+zero_configuration!(::Fixed, q::AbstractVector) = nothing
+rand_configuration!(::Fixed, q::AbstractVector) = nothing
 
-function _bias_acceleration{T<:Number, X<:Number}(
+function bias_acceleration{T<:Number, X<:Number}(
         jt::Fixed{T}, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector{X}, v::AbstractVector{X})
     zero(SpatialAcceleration{promote_type(T, X)}, frameAfter, frameBefore, frameAfter)
 end
 
-_has_fixed_subspaces(jt::Fixed) = true
-_configuration_derivative_to_velocity!(::Fixed, v::AbstractVector, q::AbstractVector, q̇::AbstractVector) = nothing
-_velocity_to_configuration_derivative!(::Fixed, q̇::AbstractVector, q::AbstractVector, v::AbstractVector) = nothing
-_joint_torque!(jt::Fixed, τ::AbstractVector, q::AbstractVector, joint_wrench::Wrench) = nothing
+has_fixed_subspaces(jt::Fixed) = true
+configuration_derivative_to_velocity!(::Fixed, v::AbstractVector, q::AbstractVector, q̇::AbstractVector) = nothing
+velocity_to_configuration_derivative!(::Fixed, q̇::AbstractVector, q::AbstractVector, v::AbstractVector) = nothing
+joint_torque!(jt::Fixed, τ::AbstractVector, q::AbstractVector, joint_wrench::Wrench) = nothing

--- a/src/joint_types.jl
+++ b/src/joint_types.jl
@@ -121,14 +121,14 @@ function velocity_to_configuration_derivative!(jt::QuaternionFloating, q̇::Abst
     nothing
 end
 
-function zero_configuration!(jt::QuaternionFloating, q::AbstractVector)
+function zero_configuration!(q::AbstractVector, jt::QuaternionFloating)
     T = eltype(q)
     rotation!(jt, q, eye(Quat{T}))
     translation!(jt, q, zeros(SVector{3, T}))
     nothing
 end
 
-function rand_configuration!(jt::QuaternionFloating, q::AbstractVector)
+function rand_configuration!(q::AbstractVector, jt::QuaternionFloating)
     T = eltype(q)
     rotation!(jt, q, rand(Quat{T}))
     translation!(jt, q, randn(SVector{3, T}))
@@ -200,12 +200,12 @@ abstract type OneDegreeOfFreedomFixedAxis{T<:Number} <: JointType{T} end
 num_positions(::OneDegreeOfFreedomFixedAxis) = 1
 num_velocities(::OneDegreeOfFreedomFixedAxis) = 1
 
-function zero_configuration!(::OneDegreeOfFreedomFixedAxis, q::AbstractVector)
+function zero_configuration!(q::AbstractVector, ::OneDegreeOfFreedomFixedAxis)
     fill!(q, zero(eltype(q)))
     nothing
 end
 
-function rand_configuration!(::OneDegreeOfFreedomFixedAxis, q::AbstractVector)
+function rand_configuration!(q::AbstractVector, ::OneDegreeOfFreedomFixedAxis)
     randn!(q)
     nothing
  end
@@ -389,8 +389,8 @@ function constraint_wrench_subspace{T<:Number, A<:AbstractMatrix}(jt::Fixed{T}, 
     WrenchSubspace(jointTransform.from, angular, linear)
 end
 
-zero_configuration!(::Fixed, q::AbstractVector) = nothing
-rand_configuration!(::Fixed, q::AbstractVector) = nothing
+zero_configuration!(q::AbstractVector, ::Fixed) = nothing
+rand_configuration!(q::AbstractVector, ::Fixed) = nothing
 
 function bias_acceleration{T<:Number, X<:Number}(
         jt::Fixed{T}, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector{X}, v::AbstractVector{X})

--- a/src/mechanism.jl
+++ b/src/mechanism.jl
@@ -56,7 +56,7 @@ $(SIGNATURES)
 
 Return the `RigidBody`s that are part of the `Mechanism` as an iterable collection.
 """
-bodies{T}(mechanism::Mechanism{T}) = vertices(mechanism.graph)
+bodies(mechanism::Mechanism) = vertices(mechanism.graph)
 
 """
 $(SIGNATURES)

--- a/src/mechanism.jl
+++ b/src/mechanism.jl
@@ -6,13 +6,13 @@ A `Mechanism` represents an interconnection of rigid bodies and joints.
 state-dependent information.
 """
 type Mechanism{T<:Number}
-    graph::DirectedGraph{RigidBody{T}, Joint{T}}
-    tree::SpanningTree{RigidBody{T}, Joint{T}}
+    graph::DirectedGraph{RigidBody{T}, GenericJoint{T}}
+    tree::SpanningTree{RigidBody{T}, GenericJoint{T}}
     environment::ContactEnvironment{T}
     gravitationalAcceleration::FreeVector3D{SVector{3, T}} # TODO: consider removing
 
     function (::Type{Mechanism{T}}){T<:Number}(rootBody::RigidBody{T}; gravity::SVector{3, T} = SVector(zero(T), zero(T), T(-9.81)))
-        graph = DirectedGraph{RigidBody{T}, Joint{T}}()
+        graph = DirectedGraph{RigidBody{T}, GenericJoint{T}}()
         add_vertex!(graph, rootBody)
         tree = SpanningTree(graph, rootBody)
         gravitationalAcceleration = FreeVector3D(default_frame(rootBody), gravity)

--- a/src/mechanism_algorithms.jl
+++ b/src/mechanism_algorithms.jl
@@ -552,8 +552,7 @@ function constraint_jacobian_and_bias!(state::MechanismState, constraintjacobian
         range = rowstart : nextrowstart - 1
 
         # Constraint wrench subspace.
-        jointtransform = relative_transform(state, frame_after(nontreejoint), frame_before(nontreejoint)) # TODO: expensive
-        T = constraint_wrench_subspace(nontreejoint, jointtransform)
+        T = constraint_wrench_subspace(state, nontreejoint)
         T = transform(T, transform_to_root(state, T.frame)) # TODO: expensive
 
         # Jacobian rows.
@@ -565,7 +564,7 @@ function constraint_jacobian_and_bias!(state::MechanismState, constraintjacobian
         end
 
         # Constraint bias.
-        has_fixed_subspaces(nontreejoint) || error("Only joints with fixed motion subspace (Ṡ = 0) supported at this point.")
+        has_fixed_subspaces(nontreejoint) || error("Only joints with fixed motion subspace (Ṡ = 0) supported at this point.") # TODO: call to joint-type-specific function
         kjoint = fastview(constraintbias, range)
         pred = predecessor(nontreejoint, mechanism)
         succ = successor(nontreejoint, mechanism)

--- a/src/mechanism_algorithms.jl
+++ b/src/mechanism_algorithms.jl
@@ -142,7 +142,7 @@ The Jacobian is computed in the `Mechanism`'s root frame.
 
 See [`geometric_jacobian!(out, state, path)`](@ref).
 """
-function geometric_jacobian{X, M, C}(state::MechanismState{X, M, C}, path::TreePath{RigidBody{M}, Joint{M}})
+function geometric_jacobian{X, M, C}(state::MechanismState{X, M, C}, path::TreePath{RigidBody{M}, GenericJoint{M}})
     nv = num_velocities(path)
     angular = Matrix{C}(3, nv)
     linear = Matrix{C}(3, nv)

--- a/src/mechanism_algorithms.jl
+++ b/src/mechanism_algorithms.jl
@@ -449,9 +449,9 @@ function joint_wrenches_and_torques!{T, X, M}(
             # TODO: consider also doing this for the root:
             net_wrenches_in_joint_wrenches_out[parentbody] += jointwrench # action = -reaction
         end
-        jointwrench = transform(jointwrench, inv(transform_to_root(state, body))) # TODO: stay in world frame?
         @inbounds τjoint = fastview(torquesout, velocity_range(state, joint))
-        joint_torque!(joint, τjoint, configuration(state, joint), jointwrench)
+        S = motion_subspace_in_world(state, joint)
+        torque!(τjoint, S, jointwrench)
     end
 end
 

--- a/src/mechanism_manipulation.jl
+++ b/src/mechanism_manipulation.jl
@@ -18,7 +18,7 @@ If `successor` is not yet a part of the `Mechanism`, it will be added to the
 `Mechanism`, effectively creating a loop constraint that will be enforced
 using Lagrange multipliers (as opposed to using recursive algorithms).
 """
-function attach!{T}(mechanism::Mechanism{T}, predecessor::RigidBody{T}, joint::Joint{T}, jointToPredecessor::Transform3D,
+function attach!{T}(mechanism::Mechanism{T}, predecessor::RigidBody{T}, joint::GenericJoint{T}, jointToPredecessor::Transform3D,
         successor::RigidBody{T}, successorToJoint::Transform3D = eye(Transform3DS{T}, default_frame(successor), frame_after(joint)))
     @assert jointToPredecessor.from == frame_before(joint)
     @assert successorToJoint.to == frame_after(joint)
@@ -38,7 +38,7 @@ function attach!{T}(mechanism::Mechanism{T}, predecessor::RigidBody{T}, joint::J
     mechanism
 end
 
-function _copyjoint!{T}(dest::Mechanism{T}, src::Mechanism{T}, srcjoint::Joint{T}, bodymap::Dict{RigidBody{T}, RigidBody{T}}, jointmap::Dict{Joint{T}, Joint{T}})
+function _copyjoint!{T}(dest::Mechanism{T}, src::Mechanism{T}, srcjoint::GenericJoint{T}, bodymap::Dict{RigidBody{T}, RigidBody{T}}, jointmap::Dict{GenericJoint{T}, GenericJoint{T}})
     srcpredecessor = source(srcjoint, src.graph)
     srcsuccessor = target(srcjoint, src.graph)
 
@@ -70,7 +70,7 @@ function attach!{T}(mechanism::Mechanism{T}, parentbody::RigidBody{T}, childmech
     @assert mechanism != childmechanism # infinite loop otherwise
 
     bodymap = Dict{RigidBody{T}, RigidBody{T}}()
-    jointmap = Dict{Joint{T}, Joint{T}}()
+    jointmap = Dict{GenericJoint{T}, GenericJoint{T}}()
 
     # Define where child root body is located w.r.t parent body and add frames that were attached to childroot to parentbody.
     childroot = root_body(childmechanism)
@@ -104,7 +104,7 @@ function submechanism{T}(mechanism::Mechanism{T}, submechanismroot::RigidBody{T}
     # FIXME: test with cycles
 
     bodymap = Dict{RigidBody{T}, RigidBody{T}}()
-    jointmap = Dict{Joint{T}, Joint{T}}()
+    jointmap = Dict{GenericJoint{T}, GenericJoint{T}}()
 
     # Create Mechanism
     root = bodymap[submechanismroot] = deepcopy(submechanismroot)
@@ -249,14 +249,14 @@ function maximal_coordinates(mechanism::Mechanism)
 
     # Body and joint mapping.
     bodymap = Dict{RigidBody{T}, RigidBody{T}}()
-    jointmap = Dict{Joint{T}, Joint{T}}()
+    jointmap = Dict{GenericJoint{T}, GenericJoint{T}}()
 
     # Copy root.
     root = bodymap[root_body(mechanism)] = deepcopy(root_body(mechanism))
     ret = Mechanism(root, gravity = mechanism.gravitationalAcceleration.v)
 
     # Copy non-root bodies and attach them to the root with a floating joint.
-    newfloatingjoints = Dict{RigidBody{T}, Joint{T}}()
+    newfloatingjoints = Dict{RigidBody{T}, GenericJoint{T}}()
     for srcbody in non_root_bodies(mechanism)
         framebefore = default_frame(root)
         frameafter = default_frame(srcbody)

--- a/src/mechanism_state.jl
+++ b/src/mechanism_state.jl
@@ -56,7 +56,7 @@ immutable MechanismState{X<:Number, M<:Number, C<:Number, TSJ}
         qstart = 1
         qs = JointDict{M, VectorSegment{X}}(joint => begin
             qjoint = view(q, qstart : qstart + num_positions(joint) - 1)
-            zero_configuration!(joint, qjoint)
+            zero_configuration!(qjoint, joint)
             qstart += num_positions(joint)
             qjoint
         end for joint in tree_joints(mechanism))
@@ -195,10 +195,7 @@ configuration vector would be set to identity. The contract is that each of the
 joint transforms should be an identity transform.
 """
 function zero_configuration!(state::MechanismState)
-    map!
-    for joint in tree_joints(state.mechanism)
-        zero_configuration!(joint, configuration(state, joint))
-    end
+    map_in_place!(zero_configuration!, values(state.qs), state.type_sorted_tree_joints)
     reset_contact_state!(state)
     setdirty!(state)
 end
@@ -209,8 +206,7 @@ $(SIGNATURES)
 Zero the velocity vector ``v``. Invalidates cache variables.
 """
 function zero_velocity!(state::MechanismState)
-    X = eltype(state.v)
-    fill!(state.v,  zero(X))
+    state.v[:] = 0
     reset_contact_state!(state)
     setdirty!(state)
 end
@@ -233,9 +229,7 @@ the particular joint types present in the associated `Mechanism`. The resulting
 Invalidates cache variables.
 """
 function rand_configuration!(state::MechanismState)
-    for joint in tree_joints(state.mechanism)
-        rand_configuration!(joint, configuration(state, joint))
-    end
+    map_in_place!(rand_configuration!, values(state.qs), state.type_sorted_tree_joints)
     reset_contact_state!(state)
     setdirty!(state)
 end

--- a/src/mechanism_state.jl
+++ b/src/mechanism_state.jl
@@ -132,14 +132,6 @@ for stateful contact models).
 """
 num_additional_states(state::MechanismState) = length(state.s)
 
-
-"""
-$(SIGNATURES)
-
-Return the `Joint`s that are not part of the underlying `Mechanism`'s spanning tree as an iterable collection.
-"""
-non_tree_joints(state::MechanismState) = state.nontreejoints
-
 state_vector_eltype{X, M, C}(state::MechanismState{X, M, C}) = X
 mechanism_eltype{X, M, C}(state::MechanismState{X, M, C}) = M
 cache_eltype{X, M, C}(state::MechanismState{X, M, C}) = C

--- a/src/mechanism_state.jl
+++ b/src/mechanism_state.jl
@@ -1,5 +1,5 @@
 const BodyDict{T} = UnsafeFastDict{Graphs.vertex_index, RigidBody{T}}
-const JointDict{T} = UnsafeFastDict{Graphs.edge_index, Joint{T}}
+const JointDict{T} = UnsafeFastDict{Graphs.edge_index, GenericJoint{T}}
 
 """
 $(TYPEDEF)
@@ -16,7 +16,7 @@ Type parameters:
 """
 immutable MechanismState{X<:Number, M<:Number, C<:Number}
     mechanism::Mechanism{M}
-    constraint_jacobian_structure::Vector{Tuple{Joint{M}, TreePath{RigidBody{M}, Joint{M}}}}
+    constraint_jacobian_structure::Vector{Tuple{GenericJoint{M}, TreePath{RigidBody{M}, GenericJoint{M}}}}
 
     # configurations, velocities
     q::Vector{X}
@@ -297,7 +297,7 @@ additional_state(state::MechanismState) = state.s
 state_vector(state::MechanismState) = [configuration(state); velocity(state); additional_state(state)]
 
 for fun in (:num_velocities, :num_positions)
-    @eval function $fun{T}(path::TreePath{RigidBody{T}, Joint{T}})
+    @eval function $fun{T}(path::TreePath{RigidBody{T}, GenericJoint{T}})
         mapreduce(it -> $fun(first(it)), +, 0, path)
     end
 end
@@ -321,7 +321,7 @@ $(SIGNATURES)
 Return the part of the `Mechanism`'s configuration vector ``q`` associated with
 the joints along `path`.
 """
-function configuration{X, M, C}(state::MechanismState{X, M, C}, path::TreePath{RigidBody{M}, Joint{M}})
+function configuration{X, M, C}(state::MechanismState{X, M, C}, path::TreePath{RigidBody{M}, GenericJoint{M}})
     set_path_vector!(Vector{X}(num_positions(path)), state, path, configuration)
 end
 
@@ -331,7 +331,7 @@ $(SIGNATURES)
 Return the part of the `Mechanism`'s velocity vector ``v`` associated with
 the joints along `path`.
 """
-function velocity{X, M, C}(state::MechanismState{X, M, C}, path::TreePath{RigidBody{M}, Joint{M}})
+function velocity{X, M, C}(state::MechanismState{X, M, C}, path::TreePath{RigidBody{M}, GenericJoint{M}})
     set_path_vector!(Vector{X}(num_velocities(path)), state, path, velocity)
 end
 

--- a/src/spatial.jl
+++ b/src/spatial.jl
@@ -741,10 +741,12 @@ function newton_euler(I::SpatialInertia, Ṫ::SpatialAcceleration, T::Twist)
     Wrench(frame, angular, linear)
 end
 
+torque!(τ::AbstractVector, jac::GeometricJacobian, wrench::Wrench) = At_mul_B!(τ, jac, wrench)
+
 function torque(jac::GeometricJacobian, wrench::Wrench)
-    ret = Vector{promote_type(eltype(jac), eltype(wrench))}(num_cols(jac))
-    At_mul_B!(ret, jac, wrench)
-    ret
+    τ = Vector{promote_type(eltype(jac), eltype(wrench))}(num_cols(jac))
+    torque!(τ, jac, wrench)
+    τ
 end
 
 for (MatrixType, VectorType) in (:WrenchMatrix => :(Union{Twist, SpatialAcceleration}), :GeometricJacobian => :(Union{Momentum, Wrench}))

--- a/src/type_sorted_collection.jl
+++ b/src/type_sorted_collection.jl
@@ -22,15 +22,32 @@ end
 Base.length(x::TypeSortedCollection) = sum(length, x.data)
 indexfun(x::TypeSortedCollection) = x.indexfun
 
-@generated function Base.map!(f, dest::AbstractVector, tv::TypeSortedCollection{I, D}, As...) where {I, D}
+@generated function Base.map!(f, dest::AbstractVector, tsc::TypeSortedCollection{I, D}, As...) where {I, D}
     expr = Expr(:block)
     push!(expr.args, :(Base.@_inline_meta))
     for i = 1 : nfields(D)
         push!(expr.args, quote
-            vec = tv.data[$i]
+            vec = tsc.data[$i]
             for element in vec
-                index = tv.indexfun(element)
+                index = tsc.indexfun(element)
                 dest[index] = f(element, getindex.(As, index)...)
+            end
+        end)
+    end
+    push!(expr.args, :(return nothing))
+    expr
+end
+
+# like map!, but f! takes the destination element as the first argument and modifies it
+@generated function map_in_place!(f!, dest::AbstractVector, tsc::TypeSortedCollection{I, D}, As...) where {I, D}
+    expr = Expr(:block)
+    push!(expr.args, :(Base.@_inline_meta))
+    for i = 1 : nfields(D)
+        push!(expr.args, quote
+            vec = tsc.data[$i]
+            for element in vec
+                index = tsc.indexfun(element)
+                f!(dest[index], element, getindex.(As, index)...)
             end
         end)
     end

--- a/src/util.jl
+++ b/src/util.jl
@@ -85,24 +85,6 @@ function cached_download(url::String, localFileName::String, cacheDir::String = 
     fullCachePath
 end
 
-macro rtti_dispatch(typeTuple, signature)
-    @assert signature.head == :call
-    @assert length(signature.args) > 1
-    @assert typeTuple.head == :tuple
-
-    f = signature.args[1]
-    args = signature.args[2 : end]
-    dispatchArg = args[1]
-    otherArgs = args[2 : end]
-    types = typeTuple.args
-
-    ret = :(error("type not recognized"))
-    for T in reverse(types)
-        ret = Expr(:if, :(isa($dispatchArg, $T)), :(return $(f)($(dispatchArg)::$T, $(otherArgs...))), ret)
-    end
-    :($(esc(ret)))
-end
-
 const ContiguousSMatrixColumnView{S1, S2, T, L} = SubArray{T,2,SMatrix{S1, S2, T, L},Tuple{Base.Slice{Base.OneTo{Int}},UnitRange{Int}},true}
 
 const RotMatrix3{T} = RotMatrix{3, T, 9}

--- a/test/test_mechanism_algorithms.jl
+++ b/test/test_mechanism_algorithms.jl
@@ -434,7 +434,7 @@
             q0 = Vector{Float64}(num_positions(joint))
             q = configuration(state, joint)
             v = velocity(state, joint)
-            rand_configuration!(joint, q0)
+            rand_configuration!(q0, joint)
             local_coordinates!(joint, ϕ, ϕ̇, q0, q, v)
             q_back = Vector{Float64}(num_positions(joint))
             global_coordinates!(joint, q_back, q0, ϕ)


### PR DESCRIPTION
Replaces uses of the `@rtti_dispatch` macro with simple function calls. This was made possible by the use of `TypeSortedContainer`, without which the function calls would have involved abstract types, resulting in runtime dispatch.

This reduces overhead a bit, simplifies the code, and most importantly allows users to define new joint types in code that lives outside of `RigidBodyDynamics.jl`.

`Joint`s are now parameterized not only on their scalar type, but also on a `JointType` subtype. Inside `Mechanism`, joints are stored as `GenericJoint{T}`s (an alias for `Joint{T, JointType{T}}`), which is equivalent to the `Joint` type before this change. This allows functions like `Graphs.edge_index`, `frame_before`, and `frame_after` to be called in a type-stable fashion, but calls to `JointType`-dependent functions will still be type-unstable for these joints. However, upon construction of a `MechanismState`, a `TypeSortedContainer` of joints will be constructed that contains specifically-typed joints in separate vectors, one for each `JointType` subtype. Calls to `JointType`-dependent functions will be type-stable for these joints.

Still to do:
- [x] `constraint_jacobian_and_bias!`
- [x] `zero_configuration!` / `zero_velocity!` / `rand_configuration!`
- [x] `configuration_derivative!`, `local_coordinates!`, `global_coordinates!`