### PR TITLE
Introduce `foreach_with_extra_args`

### DIFF
--- a/test/test_util.jl
+++ b/test/test_util.jl
@@ -83,5 +83,13 @@ import RigidBodyDynamics: hat, rotation_vector_rate, colwise
         results = Vector{Int64}(maximum(index.(y)))
         map!(f, results, sortedy)
         @test maptest(f, results, index, y)
+
+        foreach_extra_args_result = Dict{Int64, Int64}()
+        g(extra_arg::Int64, element::Pair) = (foreach_extra_args_result[last(element)] = round(Int64, extra_arg * first(element)))
+        extra_arg = 5
+        RigidBodyDynamics.foreach_with_extra_args(g, extra_arg, sortedx)
+        for element in x
+            @test foreach_extra_args_result[index(element)] == g(extra_arg, element)
+        end
     end
 end


### PR DESCRIPTION
This is a workaround for the fact that creating closures over heap-allocated variables currently allocates. I don't like the name of the function, and I don't like that it has to exist in the first place, but it's effective as a temporary solution and it allows me to move forward.