### PR TITLE
Add `joint_spatial_acceleration`, use it in `spatial_accelerations!`

### DIFF
--- a/src/joint.jl
+++ b/src/joint.jl
@@ -259,6 +259,19 @@ end
 """
 $(SIGNATURES)
 
+Return the spatial acceleration of `joint`'s  successor with respect to its predecessor,
+expressed in the frame after the joint.
+"""
+function joint_spatial_acceleration(joint::Joint, q::AbstractVector, v::AbstractVector, vd::AbstractVector)
+    @boundscheck check_num_positions(joint, q)
+    @boundscheck check_num_velocities(joint, v)
+    @boundscheck check_num_velocities(joint, vd)
+    joint_spatial_acceleration(joint.jointType, frame_after(joint), frame_before(joint), q, v, vd)
+end
+
+"""
+$(SIGNATURES)
+
 Given the wrench exerted across the joint on the joint's successor, compute the
 vector of joint torques ``\\tau`` (in place), in configuration `q`.
 """


### PR DESCRIPTION
Part of an effort to get rid of all references to `state.motion_subspaces` and `state.motion_subspaces_in_world` so that there will be no need for fixed-maximum size matrices. Also improves performance of `inverse_dynamics`.