### PR TITLE
Make `relative_acceleration` operate on precomputed body accelerations w.r.t. root

### DIFF
--- a/src/RigidBodyDynamics.jl
+++ b/src/RigidBodyDynamics.jl
@@ -130,6 +130,7 @@ export
     relative_acceleration,
     kinetic_energy,
     gravitational_potential_energy,
+    spatial_accelerations!,
     mass_matrix!,
     mass_matrix,
     momentum,

--- a/src/mechanism.jl
+++ b/src/mechanism.jl
@@ -247,8 +247,5 @@ function gravitational_spatial_acceleration(mechanism::Mechanism)
     SpatialAcceleration(frame, frame, frame, zeros(SVector{3, eltype(mechanism)}), mechanism.gravitationalAcceleration.v)
 end
 
-tree_index(joint::Joint, mechanism::Mechanism) = Graphs.tree_index(joint, mechanism.tree)
-tree_index(body::RigidBody, mechanism::Mechanism) = Graphs.tree_index(body, mechanism.tree)
-
 findbody(mechanism::Mechanism, name::String) = findunique(b -> b.name == name, bodies(mechanism))
 findjoint(mechanism::Mechanism, name::String) = findunique(j -> j.name == name, joints(mechanism))

--- a/test/test_mechanism_algorithms.jl
+++ b/test/test_mechanism_algorithms.jl
@@ -145,10 +145,12 @@
     # end
 
     @testset "relative_acceleration" begin
+        result = DynamicsResult{Float64}(mechanism)
         for body in bodies(mechanism)
             for base in bodies(mechanism)
                 v̇ = rand(num_velocities(mechanism))
-                Ṫ = relative_acceleration(x, body, base, v̇)
+                spatial_accelerations!(result.accelerations, x, v̇)
+                Ṫ = relative_acceleration(result, body, base)
                 q = configuration(x)
                 v = velocity(x)
                 q̇ = configuration_derivative(x)
@@ -163,8 +165,8 @@
 
                 root = root_body(mechanism)
                 f = default_frame(body)
-                Ṫbody = transform(x, relative_acceleration(x, body, root, v̇), f)
-                Ṫbase = transform(x, relative_acceleration(x, base, root, v̇), f)
+                Ṫbody = transform(x, relative_acceleration(result, body, root), f)
+                Ṫbase = transform(x, relative_acceleration(result, base, root), f)
                 @test isapprox(transform(x, -Ṫbase + Ṫbody, Ṫ.frame), Ṫ; atol = 1e-12)
             end
         end


### PR DESCRIPTION
Also export `spatial_accelerations!`. It's likely that you'll want more than one relative spatial acceleration anyway, and this gets rid of some code duplication and usages of `state.motion_subspaces_in_world`.