### PR TITLE
Change fields of TreePath

### DIFF
--- a/src/RigidBodyDynamics.jl
+++ b/src/RigidBodyDynamics.jl
@@ -149,8 +149,8 @@ export
 
 const noalloc_doc = """This method does its computation in place, performing no dynamic memory allocation."""
 
-include("graphs.jl")
 include("custom_collections.jl")
+include("graphs.jl")
 include("util.jl")
 include("cache_element.jl")
 

--- a/src/mechanism_algorithms.jl
+++ b/src/mechanism_algorithms.jl
@@ -96,9 +96,9 @@ function geometric_jacobian!(out::GeometricJacobian, state::MechanismState, path
         nextbaseframe = out.base
         startind = 1
         lastjoint = last(path)
-        for (joint, direction) in path
+        for joint in path
             S = transformfun(motion_subspace_in_world(state, joint))
-            direction == :up && (S = -S)
+            direction(joint, path) == :up && (S = -S)
             startind, nextbaseframe = _set_jacobian_part!(out, S, nextbaseframe, startind)
             joint == lastjoint && (@framecheck S.body out.body)
         end
@@ -574,10 +574,10 @@ function constraint_jacobian_and_bias!(state::MechanismState, constraintjacobian
             T = transform(T, transform_to_root(state, succ) * frame_definition(succ, T.frame)) # TODO: somewhat expensive
 
             # Jacobian rows.
-            for (treejoint, direction) in path
+            for treejoint in path
                 J = motion_subspace_in_world(state, treejoint)
                 colstart = first(velocity_range(state, treejoint))
-                sign = ifelse(direction == :up, -1, 1)
+                sign = ifelse(direction(treejoint, path) == :up, -1, 1)
                 force_space_matrix_transpose_mul_jacobian!(constraintjacobian, rowstart, colstart, T, J, sign)
             end
 

--- a/test/test_graph.jl
+++ b/test/test_graph.jl
@@ -233,8 +233,8 @@ Graphs.flip_direction!(edge::Edge{Float64}) = (edge.data = -edge.data)
                 @test source(p) == src
                 @test target(p) == dest
 
-                source_to_lca = collect(edge for (edge, direction) in p if direction == :up)
-                target_to_lca = reverse!(collect(edge for (edge, direction) in p if direction == :down))
+                source_to_lca = collect(edge for edge in p if direction(edge, p) == :up)
+                target_to_lca = reverse!(collect(edge for edge in p if direction(edge, p) == :down))
 
                 for (v, v_ancestors, pathsegment) in [(src, src_ancestors, source_to_lca); (dest, dest_ancestors, target_to_lca)]
                     if v == root(tree)


### PR DESCRIPTION
Instead of having a `Vector{Pair{E, Symbol}}`, store a `Vector` of edges and a dict that maps edges to directions. This will be useful for an upcoming change to `geometric_jacobian`.