### PR TITLE
Redo geometric_jacobian using state.type_sorted_tree_joints

### DIFF
--- a/perf/runbenchmarks.jl
+++ b/perf/runbenchmarks.jl
@@ -28,8 +28,7 @@ function create_benchmark_suite()
     rfoot = findbody(mechanism, "r_foot")
     lhand = findbody(mechanism, "l_hand")
     p = path(mechanism, rfoot, lhand)
-    nvpath = num_velocities(p)
-    jac = GeometricJacobian(default_frame(lhand), default_frame(rfoot), root_frame(mechanism), Matrix{ScalarType}(3, nvpath), Matrix{ScalarType}(3, nvpath))
+    jac = GeometricJacobian(default_frame(lhand), default_frame(rfoot), root_frame(mechanism), Matrix{ScalarType}(3, nv), Matrix{ScalarType}(3, nv))
 
     suite["mass_matrix"] = @benchmarkable(begin
         setdirty!($state)

--- a/src/mechanism.jl
+++ b/src/mechanism.jl
@@ -77,7 +77,7 @@ $(SIGNATURES)
 Return the path from rigid body `from` to `to` along edges of the `Mechanism`'s
 kinematic tree.
 """
-RigidBodyDynamics.path(mechanism::Mechanism, from::RigidBody, to::RigidBody) = Graphs.path(from, to, mechanism.tree)
+RigidBodyDynamics.path(mechanism::Mechanism, from::RigidBody, to::RigidBody) = TreePath(from, to, mechanism.tree)
 
 function Base.show(io::IO, mechanism::Mechanism)
     println(io, "Spanning tree:")

--- a/src/mechanism_algorithms.jl
+++ b/src/mechanism_algorithms.jl
@@ -84,21 +84,16 @@ function geometric_jacobian!(out::GeometricJacobian, state::MechanismState, path
     out.linear[:] = 0
     foreach_with_extra_args(out, state, path, state.type_sorted_tree_joints) do out, state, path, joint
         vrange = velocity_range(state, joint)
-        if !isempty(vrange)
-            ind = edge_index(joint)
-            for j in path # TODO: not a nice way to do this
-                if edge_index(j) == ind
-                    mechanism = state.mechanism
-                    body = successor(joint, mechanism)
-                    qjoint = configuration(state, joint)
-                    @nocachecheck tf = transform_to_root(state, body)
-                    part = transformfun(transform(motion_subspace(joint, qjoint), tf))
-                    direction(joint, path) == :up && (part = -part)
-                    @framecheck out.frame part.frame
-                    copy!(out.angular, CartesianRange((1 : 3, vrange)), part.angular, CartesianRange(indices(part.angular)))
-                    copy!(out.linear, CartesianRange((1 : 3, vrange)), part.linear, CartesianRange(indices(part.linear)))
-                end
-            end
+        if !isempty(vrange) && edge_index(joint) in path.indices
+            mechanism = state.mechanism
+            body = successor(joint, mechanism)
+            qjoint = configuration(state, joint)
+            @nocachecheck tf = transform_to_root(state, body)
+            part = transformfun(transform(motion_subspace(joint, qjoint), tf))
+            direction(joint, path) == :up && (part = -part)
+            @framecheck out.frame part.frame
+            copy!(out.angular, CartesianRange((1 : 3, vrange)), part.angular, CartesianRange(indices(part.angular)))
+            copy!(out.linear, CartesianRange((1 : 3, vrange)), part.linear, CartesianRange(indices(part.linear)))
         end
     end
     out

--- a/src/mechanism_state.jl
+++ b/src/mechanism_state.jl
@@ -287,39 +287,6 @@ for fun in (:num_velocities, :num_positions)
     end
 end
 
-function set_path_vector!{X, M, C}(ret::AbstractVector, state::MechanismState{X, M, C}, path::TreePath, fun)
-    setvectorpart! = (out, part, startind) -> begin
-        n = length(part)
-        n > 0 && copy!(out, startind, part, 1, n)
-        startind + n
-    end
-    startind = 1
-    for joint in path
-        startind = setvectorpart!(ret, fun(state, joint), startind)
-    end
-    ret
-end
-
-"""
-$(SIGNATURES)
-
-Return the part of the `Mechanism`'s configuration vector ``q`` associated with
-the joints along `path`.
-"""
-function configuration{X, M, C}(state::MechanismState{X, M, C}, path::TreePath{RigidBody{M}, GenericJoint{M}})
-    set_path_vector!(Vector{X}(num_positions(path)), state, path, configuration)
-end
-
-"""
-$(SIGNATURES)
-
-Return the part of the `Mechanism`'s velocity vector ``v`` associated with
-the joints along `path`.
-"""
-function velocity{X, M, C}(state::MechanismState{X, M, C}, path::TreePath{RigidBody{M}, GenericJoint{M}})
-    set_path_vector!(Vector{X}(num_velocities(path)), state, path, velocity)
-end
-
 """
 $(SIGNATURES)
 

--- a/src/mechanism_state.jl
+++ b/src/mechanism_state.jl
@@ -282,8 +282,8 @@ additional_state(state::MechanismState) = state.s
 state_vector(state::MechanismState) = [configuration(state); velocity(state); additional_state(state)]
 
 for fun in (:num_velocities, :num_positions)
-    @eval function $fun(path::TreePath{RigidBody{T}, GenericJoint{T}} where {T})
-        mapreduce($fun, +, 0, path)
+    @eval function $fun(p::TreePath{RigidBody{T}, GenericJoint{T}} where {T})
+        mapreduce($fun, +, 0, p)
     end
 end
 

--- a/test/test_graph.jl
+++ b/test/test_graph.jl
@@ -225,7 +225,7 @@ Graphs.flip_direction!(edge::Edge{Float64}) = (edge.data = -edge.data)
                 src_ancestors = ancestors(src, tree)
                 dest_ancestors = ancestors(dest, tree)
                 lca = lowest_common_ancestor(src, dest, tree)
-                p = path(src, dest, tree)
+                p = TreePath(src, dest, tree)
 
                 show(DevNull, p)
                 @inferred collect(p)

--- a/test/test_mechanism_algorithms.jl
+++ b/test/test_mechanism_algorithms.jl
@@ -92,7 +92,7 @@
             body = rand([bs...])
             delete!(bs, body)
             base = rand([bs...])
-            p = RigidBodyDynamics.path(mechanism, base, body)
+            p = path(mechanism, base, body)
             v = velocity(x)
 
             J = geometric_jacobian(x, p)


### PR DESCRIPTION
Not the most beautiful way to do it currently (iterating over all joints and checking whether they belong to the path), but another usage of state.motion_subspaces_in_world (and hence the fixed-maximum size stuff I want to get rid of) gone.

Also change the result of `geometric_jacobian` from the 'compact' representation (acting only on `velocity(state, path)`) to the 'full' representation (acting on `velocity(state)`), because I've found this easier to work with in practice (for setting up QPs and such).