### PR TITLE
Add fast path for mechanisms without loops

### DIFF
--- a/src/mechanism.jl
+++ b/src/mechanism.jl
@@ -79,6 +79,8 @@ kinematic tree.
 """
 RigidBodyDynamics.path(mechanism::Mechanism, from::RigidBody, to::RigidBody) = TreePath(from, to, mechanism.tree)
 
+has_loops(mechanism::Mechanism) = num_edges(mechanism.graph) > num_edges(mechanism.tree)
+
 function Base.show(io::IO, mechanism::Mechanism)
     println(io, "Spanning tree:")
     print(io, mechanism.tree)

--- a/src/mechanism_algorithms.jl
+++ b/src/mechanism_algorithms.jl
@@ -488,6 +488,7 @@ function inverse_dynamics(
 end
 
 function constraint_jacobian_and_bias!(state::MechanismState, constraintjacobian::AbstractMatrix, constraintbias::AbstractVector)
+    has_loops(state.mechanism) || return # nothing to be done
     update_twists_wrt_world!(state)
     update_bias_accelerations_wrt_world!(state)
     update_motion_subspaces_in_world!(state)


### PR DESCRIPTION
Mostly to avoid the `Ref{Int}` allocation in `constraint_jacobian_and_bias!`.