### PR TITLE
Canonicalize body and joint indices in MechanismState constructor

### DIFF
--- a/src/graphs.jl
+++ b/src/graphs.jl
@@ -31,6 +31,7 @@ export
     rewire!,
     flip_direction!,
     replace_edge!,
+    reindex!,
     root,
     edge_to_parent,
     edges_to_children,
@@ -94,6 +95,16 @@ in_edges(vertex::V, g::DirectedGraph{V, E}) where {V, E} = g.inedges[vertex_inde
 out_edges(vertex::V, g::DirectedGraph{V, E}) where {V, E} = g.outedges[vertex_index(vertex)]
 
 Base.show(io::IO, ::DirectedGraph{V, E}) where {V, E} = print(io, "DirectedGraph{$V, $E}(…)")
+
+function Base.empty!(g::DirectedGraph)
+    empty!(g.vertices)
+    empty!(g.edges)
+    empty!(g.sources)
+    empty!(g.targets)
+    empty!(g.inedges)
+    empty!(g.outedges)
+    g
+end
 
 function add_vertex!(g::DirectedGraph{V, E}, vertex::V) where {V, E}
     @assert vertex ∉ vertices(g)
@@ -183,6 +194,21 @@ function replace_edge!(g::DirectedGraph{V, E}, old_edge::E, new_edge::E) where {
     in_edge_index = findfirst(in_edges(dest, g), old_edge)
     in_edges(dest, g)[in_edge_index] = new_edge
     edge_index!(old_edge, -1)
+    g
+end
+
+function reindex!(g::DirectedGraph{V, E}, vertices_in_order, edges_in_order) where {V, E}
+    @assert isempty(setdiff(vertices(g), vertices_in_order))
+    @assert isempty(setdiff(edges(g), edges_in_order))
+    sources = source.(edges_in_order, g)
+    targets = target.(edges_in_order, g)
+    empty!(g)
+    for v in vertices_in_order
+        add_vertex!(g, v)
+    end
+    for (source, target, e) in zip(sources, targets, edges_in_order)
+        add_edge!(g, source, target, e)
+    end
     g
 end
 

--- a/src/mechanism_modification.jl
+++ b/src/mechanism_modification.jl
@@ -264,6 +264,15 @@ function maximal_coordinates(mechanism::Mechanism)
     ret, newfloatingjoints, bodymap, jointmap
 end
 
+function canonicalize_graph!(mechanism::Mechanism)
+    root = root_body(mechanism)
+    treejoints = copy(tree_joints(mechanism))
+    vertices = append!([root], successor(joint, mechanism) for joint in treejoints)
+    edges = vcat(treejoints, non_tree_joints(mechanism))
+    reindex!(mechanism.graph, vertices, edges)
+    mechanism.tree = SpanningTree(mechanism.graph, root, treejoints)
+end
+
 add_environment_primitive!(mechanism::Mechanism, halfspace::HalfSpace3D) = push!(mechanism.environment, halfspace)
 """
 $(SIGNATURES)

--- a/src/mechanism_state.jl
+++ b/src/mechanism_state.jl
@@ -45,7 +45,7 @@ struct MechanismState{X, M, C, JointCollection}
 
     function MechanismState{X}(mechanism::Mechanism{M}) where {X, M}
         C = promote_type(X, M)
-
+        canonicalize_graph!(mechanism)
         type_sorted_joints = TypeSortedCollection(typedjoint.(joints(mechanism)), Graphs.edge_index) # TODO: really only needed to get type
         JointCollection = typeof(type_sorted_joints)
         type_sorted_tree_joints = JointCollection(typedjoint.(tree_joints(mechanism)), Graphs.edge_index)

--- a/test/test_graph.jl
+++ b/test/test_graph.jl
@@ -285,4 +285,21 @@ Graphs.flip_direction!(edge::Edge{Float64}) = (edge.data = -edge.data)
             @test new_edge ∈ edges_to_children(src, tree)
         end
     end
+
+    @testset "reindex!" begin
+        graph = DirectedGraph{Vertex{Int64}, Edge{Float64}}()
+        for i = 1 : 100
+            add_vertex!(graph, Vertex(i))
+        end
+        for i = 1 : num_vertices(graph) - 1
+            add_edge!(graph, rand(vertices(graph)), rand(vertices(graph)), Edge(Float64(i)))
+        end
+        newvertices = shuffle(vertices(graph))
+        newedges = shuffle(edges(graph))
+        reindex!(graph, newvertices, newedges)
+        @test all(vertices(graph) .== newvertices)
+        @test all(edges(graph) .== newedges)
+        @test all(vertex_index.(vertices(graph)) .== 1 : num_vertices(graph))
+        @test all(edge_index.(edges(graph)) .== 1 : num_edges(graph))
+    end
 end


### PR DESCRIPTION
Reindex to put all the tree joints in one contiguous block, followed by the non-tree joints.
Also make the order of the bodies match the order of the tree joints.
Reasons:
* needed to use TypeSortedCollections.TypeSortedCollection
* potentially better cache locality
* good to have performance not depend on the exact way the Mechanism was constructed (apart from selection of tree joints)