### PR TITLE
More permissive constructors

### DIFF
--- a/src/joint_types.jl
+++ b/src/joint_types.jl
@@ -271,7 +271,7 @@ struct Prismatic{T} <: OneDegreeOfFreedomFixedAxis{T}
     Construct a new `Prismatic` joint type, allowing translation along `axis`
     (expressed in the frame before the joint).
     """
-    Prismatic(axis::AbstractVector{T}) where {T} = new{T}(axis, rotation_between(SVector(zero(T), zero(T), one(T)), SVector(axis)))
+    Prismatic(axis::AbstractVector{T}) where {T} = new{T}(axis, rotation_between(SVector(zero(T), zero(T), one(T)), SVector{3, T}(axis)))
 end
 
 Base.show(io::IO, jt::Prismatic) = print(io, "Prismatic joint with axis $(jt.axis)")

--- a/src/joint_types.jl
+++ b/src/joint_types.jl
@@ -338,7 +338,7 @@ struct Revolute{T} <: OneDegreeOfFreedomFixedAxis{T}
     Construct a new `Revolute` joint type, allowing rotation about `axis`
     (expressed in the frame before the joint).
     """
-    Revolute(axis::AbstractVector{T}) where {T} = new{T}(axis, rotation_between(SVector(zero(T), zero(T), one(T)), SVector(axis)))
+    Revolute(axis::AbstractVector{T}) where {T} = new{T}(axis, rotation_between(SVector(zero(T), zero(T), one(T)), SVector{3, T}(axis)))
 end
 
 Base.show(io::IO, jt::Revolute) = print(io, "Revolute joint with axis $(jt.axis)")

--- a/src/spatial.jl
+++ b/src/spatial.jl
@@ -27,6 +27,12 @@ struct SpatialInertia{T}
     moment::SMatrix{3, 3, T, 9}
     crossPart::SVector{3, T} # mass times center of mass
     mass::T
+
+    @inline function SpatialInertia(frame::CartesianFrame3D, moment::AbstractMatrix{T}, crossPart::AbstractVector{T}, mass::T) where T
+        @boundscheck size(moment) == (3, 3) || error("size mismatch")
+        @boundscheck size(crossPart) == (3,) || error("size mismatch")
+        new{T}(frame, moment, crossPart, mass)
+    end
 end
 
 for MotionSpaceElement in (:Twist, :SpatialAcceleration)

--- a/test/test_spatial.jl
+++ b/test/test_spatial.jl
@@ -33,6 +33,10 @@ end
         @test isapprox(Array(I2) + Array(I3), Array(I2 + I3); atol = 1e-12)
         @inferred transform(zero(SpatialInertia{Float32}, f1), eye(Transform3D, f1))
         @test I2 + zero(I2) == I2
+
+        # Test that the constructor works with dynamic arrays (which are
+        # converted to static arrays internally)
+        I4 = @inferred(SpatialInertia(f2, eye(3), zeros(3), 1.0))
     end
 
     @testset "twist" begin


### PR DESCRIPTION
Modify the `Prismatic`, `Revolute`, and `SpatialInertia` constructors to work when given non-static array inputs. This makes it a little easier for users to define mechanisms without using StaticArrays directly (but their input is converted to static arrays internally for storage). 