### PR TITLE
Fix #310 by making Joint immutable.

### DIFF
--- a/src/joint_types.jl
+++ b/src/joint_types.jl
@@ -281,7 +281,7 @@ function Random.rand(::Type{Prismatic{T}}) where {T}
     Prismatic(axis)
 end
 
-flip_direction(jt::Prismatic) = Prismatic(-jt.axis)
+RigidBodyDynamics.flip_direction(jt::Prismatic) = Prismatic(-jt.axis)
 
 function joint_transform(jt::Prismatic, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector)
     translation = q[1] * jt.axis
@@ -350,7 +350,7 @@ function Random.rand(::Type{Revolute{T}}) where {T}
     Revolute(axis)
 end
 
-flip_direction(jt::Revolute) = Revolute(-jt.axis)
+RigidBodyDynamics.flip_direction(jt::Revolute) = Revolute(-jt.axis)
 
 function joint_transform(jt::Revolute, frameAfter::CartesianFrame3D, frameBefore::CartesianFrame3D, q::AbstractVector)
     @inbounds aa = AngleAxis(q[1], jt.axis[1], jt.axis[2], jt.axis[3], false)
@@ -403,7 +403,7 @@ struct Fixed{T} <: JointType{T}
 end
 Base.show(io::IO, jt::Fixed) = print(io, "Fixed joint")
 Random.rand(::Type{Fixed{T}}) where {T} = Fixed{T}()
-flip_direction(jt::Fixed) = deepcopy(jt)
+RigidBodyDynamics.flip_direction(jt::Fixed) = deepcopy(jt)
 
 num_positions(::Type{<:Fixed}) = 0
 num_velocities(::Type{<:Fixed}) = 0

--- a/src/mechanism_algorithms.jl
+++ b/src/mechanism_algorithms.jl
@@ -81,7 +81,7 @@ function geometric_jacobian!(out::GeometricJacobian, state::MechanismState, path
     update_motion_subspaces_in_world!(state)
     foreach_with_extra_args(out, state, path, state.type_sorted_tree_joints) do out, state, path, joint # TODO: use closure once it doesn't allocate
         vrange = velocity_range(state, joint)
-        if edge_index(joint) in path.indices
+        if Graphs.edge_index(joint) in path.indices
             part = transformfun(motion_subspace_in_world(state, joint))
             direction(joint, path) == :up && (part = -part)
             set_cols!(out, vrange, part)
@@ -528,7 +528,7 @@ function constraint_jacobian_and_bias!(state::MechanismState, constraintjacobian
         # Jacobian.
         foreach_with_extra_args(constraintjacobian, state, path, T, rowrange, state.type_sorted_tree_joints) do constraintjacobian, state, path, T, rowrange, treejoint # TODO: use closure once it doesn't allocate
             vrange = velocity_range(state, treejoint)
-            if edge_index(treejoint) in path.indices
+            if Graphs.edge_index(treejoint) in path.indices
                 J = motion_subspace_in_world(state, treejoint)
                 part = T.angular' * J.angular + T.linear' * J.linear # TODO: At_mul_B
                 direction(treejoint, path) == :up && (part = -part)


### PR DESCRIPTION
Required turning Graphs.flip_edge! into Graphs.flip_edge.

Also added functionality for getting a mapping from original joint to flipped joint, now that flipping is not in-place anymore.