### PR TITLE
Fix #330 by explicitly specifying the value type of the UnsafeFastDict

### DIFF
--- a/src/dynamics_result.jl
+++ b/src/dynamics_result.jl
@@ -48,11 +48,11 @@ mutable struct DynamicsResult{T, M}
         ṡ = Vector{T}(num_additional_states(mechanism))
 
         rootframe = root_frame(mechanism)
-        contactwrenches = BodyDict{M}(b => zero(Wrench{T}, rootframe) for b in bodies(mechanism))
-        totalwrenches = BodyDict{M}(b => zero(Wrench{T}, rootframe) for b in bodies(mechanism))
-        accelerations = BodyDict{M}(b => zero(SpatialAcceleration{T}, rootframe, rootframe, rootframe) for b in bodies(mechanism))
-        jointwrenches = BodyDict{M}(b => zero(Wrench{T}, rootframe) for b in bodies(mechanism))
-        contact_state_derivs = BodyDict{M}(b => Vector{Vector{DefaultSoftContactStateDeriv{T}}}() for b in bodies(mechanism))
+        contactwrenches = BodyDict{M, Wrench{T}}(b => zero(Wrench{T}, rootframe) for b in bodies(mechanism))
+        totalwrenches = BodyDict{M, Wrench{T}}(b => zero(Wrench{T}, rootframe) for b in bodies(mechanism))
+        accelerations = BodyDict{M, SpatialAcceleration{T}}(b => zero(SpatialAcceleration{T}, rootframe, rootframe, rootframe) for b in bodies(mechanism))
+        jointwrenches = BodyDict{M, Wrench{T}}(b => zero(Wrench{T}, rootframe) for b in bodies(mechanism))
+        contact_state_derivs = BodyDict{M, Vector{Vector{DefaultSoftContactStateDeriv{T}}}}(b => Vector{Vector{DefaultSoftContactStateDeriv{T}}}() for b in bodies(mechanism))
         startind = 1
         for body in bodies(mechanism), point in contact_points(body)
             model = contact_model(point)

--- a/test/test_mechanism_algorithms.jl
+++ b/test/test_mechanism_algorithms.jl
@@ -574,4 +574,13 @@ end
         @test @inferred(clamp(0, RigidBodyDynamics.Bounds(-1, 1))) == 0
         @test @inferred(intersect(RigidBodyDynamics.Bounds(-1, 1), RigidBodyDynamics.Bounds(-0.5, 2.0))) == RigidBodyDynamics.Bounds(-0.5, 1.0)
     end
+
+    @testset "issue #330" begin
+        mechanism = rand_tree_mechanism(Revolute{Float64})
+        f330(x::AbstractArray{T}) where {T} = begin
+            result = DynamicsResult{T}(mechanism)
+            1.
+        end
+        @test ForwardDiff.hessian(f330, [1.]) == 0 * eye(1)
+    end
 end


### PR DESCRIPTION
instead of relying on `Core.Inference.return_type`, which unfortunately can't handle the case described in the issue (also on Julia nightly, 3 day old master). Might be worth investigating further why it can't handle this and possibly opening an issue with Julia.