### PR TITLE
Always use StaticArrays as the backing array type of a Transform3D.

### DIFF
--- a/notebooks/Symbolic double pendulum.ipynb
+++ b/notebooks/Symbolic double pendulum.ipynb
@@ -103,7 +103,7 @@
     "inertia1 = SpatialInertia(CartesianFrame3D(\"upper_link\"), I_1 * axis * axis.', m_1 * SVector(zero(T), zero(T), c_1), m_1)\n",
     "body1 = RigidBody(inertia1)\n",
     "joint1 = Joint(\"shoulder\", Revolute(axis))\n",
-    "joint1_to_world = eye(RigidBodyDynamics.Transform3DS{T}, frame_before(joint1), default_frame(world))\n",
+    "joint1_to_world = eye(Transform3D{T}, frame_before(joint1), default_frame(world))\n",
     "attach!(double_pendulum, world, body1, joint1, joint_pose = joint1_to_world)\n",
     "\n",
     "# Attach the second (lower) link to the world via a revolute joint named 'elbow'\n",

--- a/src/joint_types.jl
+++ b/src/joint_types.jl
@@ -115,7 +115,7 @@ function motion_subspace(jt::QuaternionFloating{T}, frame_after::CartesianFrame3
     GeometricJacobian(frame_after, frame_before, frame_after, angular, linear)
 end
 
-function constraint_wrench_subspace(jt::QuaternionFloating{T}, joint_transform::Transform3D{<:AbstractMatrix{X}}) where {T, X}
+function constraint_wrench_subspace(jt::QuaternionFloating{T}, joint_transform::Transform3D{X}) where {T, X}
     S = promote_type(T, X)
     WrenchMatrix(joint_transform.from, zeros(SMatrix{3, 0, S}), zeros(SMatrix{3, 0, S}))
 end
@@ -316,7 +316,7 @@ function motion_subspace(jt::Prismatic{T}, frame_after::CartesianFrame3D, frame_
     GeometricJacobian(frame_after, frame_before, frame_after, angular, linear)
 end
 
-function constraint_wrench_subspace(jt::Prismatic{T}, joint_transform::Transform3D{<:AbstractMatrix{X}}) where {T, X}
+function constraint_wrench_subspace(jt::Prismatic{T}, joint_transform::Transform3D{X}) where {T, X}
     S = promote_type(T, X)
     R = convert(RotMatrix3{S}, jt.rotation_from_z_aligned)
     Rcols12 = R[:, SVector(1, 2)]
@@ -386,7 +386,7 @@ function motion_subspace(jt::Revolute{T}, frame_after::CartesianFrame3D, frame_b
     GeometricJacobian(frame_after, frame_before, frame_after, angular, linear)
 end
 
-function constraint_wrench_subspace(jt::Revolute{T}, joint_transform::Transform3D{<:AbstractMatrix{X}}) where {T, X}
+function constraint_wrench_subspace(jt::Revolute{T}, joint_transform::Transform3D{X}) where {T, X}
     S = promote_type(T, X)
     R = convert(RotMatrix3{S}, jt.rotation_from_z_aligned)
     Rcols12 = R[:, SVector(1, 2)]
@@ -420,7 +420,7 @@ has_fixed_subspaces(jt::Fixed) = true
 function joint_transform(jt::Fixed{T}, frame_after::CartesianFrame3D, frame_before::CartesianFrame3D,
         q::AbstractVector{X}) where {T, X}
     S = promote_type(T, X)
-    eye(Transform3DS{S}, frame_after, frame_before)
+    eye(Transform3D{S}, frame_after, frame_before)
 end
 
 function joint_twist(jt::Fixed{T}, frame_after::CartesianFrame3D, frame_before::CartesianFrame3D,
@@ -441,7 +441,7 @@ function motion_subspace(jt::Fixed{T}, frame_after::CartesianFrame3D, frame_befo
     GeometricJacobian(frame_after, frame_before, frame_after, zeros(SMatrix{3, 0, S}), zeros(SMatrix{3, 0, S}))
 end
 
-function constraint_wrench_subspace(jt::Fixed{T}, joint_transform::Transform3D{<:AbstractMatrix{X}}) where {T, X}
+function constraint_wrench_subspace(jt::Fixed{T}, joint_transform::Transform3D{X}) where {T, X}
     S = promote_type(T, X)
     angular = hcat(eye(SMatrix{3, 3, S}), zeros(SMatrix{3, 3, S}))
     linear = hcat(zeros(SMatrix{3, 3, S}), eye(SMatrix{3, 3, S}))
@@ -555,7 +555,7 @@ function motion_subspace(jt::Planar{T}, frame_after::CartesianFrame3D, frame_bef
     GeometricJacobian(frame_after, frame_before, frame_after, angular, linear)
 end
 
-function constraint_wrench_subspace(jt::Planar{T}, joint_transform::Transform3D{<:AbstractMatrix{X}}) where {T, X}
+function constraint_wrench_subspace(jt::Planar{T}, joint_transform::Transform3D{X}) where {T, X}
     S = promote_type(T, X)
     angular = hcat(zeros(SVector{3, S}), jt.x_axis, jt.y_axis)
     linear = hcat(jt.rot_axis, zeros(SMatrix{3, 2, S}))
@@ -650,7 +650,7 @@ function motion_subspace(jt::QuaternionSpherical{T}, frame_after::CartesianFrame
     GeometricJacobian(frame_after, frame_before, frame_after, angular, linear)
 end
 
-function constraint_wrench_subspace(jt::QuaternionSpherical{T}, joint_transform::Transform3D{<:AbstractMatrix{X}}) where {T, X}
+function constraint_wrench_subspace(jt::QuaternionSpherical{T}, joint_transform::Transform3D{X}) where {T, X}
     S = promote_type(T, X)
     angular = zeros(SMatrix{3, 3, S})
     linear = eye(SMatrix{3, 3, S})

--- a/src/mechanism_modification.jl
+++ b/src/mechanism_modification.jl
@@ -20,8 +20,8 @@ If `successor` is not yet a part of the `Mechanism`, it will be added to the
 using Lagrange multipliers (as opposed to using recursive algorithms).
 """
 function attach!(mechanism::Mechanism{T}, predecessor::RigidBody{T}, successor::RigidBody{T}, joint::GenericJoint{T};
-        joint_pose::Transform3D = eye(Transform3DS{T}, frame_before(joint), default_frame(predecessor)),
-        successor_pose::Transform3D = eye(Transform3DS{T}, default_frame(successor), frame_after(joint))) where {T}
+        joint_pose::Transform3D = eye(Transform3D{T}, frame_before(joint), default_frame(predecessor)),
+        successor_pose::Transform3D = eye(Transform3D{T}, default_frame(successor), frame_after(joint))) where {T}
     @assert joint_pose.from == frame_before(joint)
     @assert successor_pose.to == frame_after(joint)
     @assert predecessor ∈ bodies(mechanism)
@@ -45,7 +45,7 @@ end
 Base.@deprecate(
         attach!(mechanism::Mechanism{T}, predecessor::RigidBody{T}, joint::GenericJoint{T},
             joint_to_predecessor::Transform3D, successor::RigidBody{T},
-            successor_to_joint::Transform3D = eye(Transform3DS{T}, default_frame(successor), frame_after(joint))) where {T},
+            successor_to_joint::Transform3D = eye(Transform3D{T}, default_frame(successor), frame_after(joint))) where {T},
         attach!(mechanism, predecessor, successor, joint;
             joint_pose = joint_to_predecessor, successor_pose = successor_to_joint))
 
@@ -77,7 +77,7 @@ belongs to `mechanism`).
 Note: gravitational acceleration for childmechanism is ignored.
 """
 function attach!(mechanism::Mechanism{T}, parentbody::RigidBody{T}, childmechanism::Mechanism{T};
-        child_root_pose = eye(Transform3DS{T}, default_frame(root_body(childmechanism)), default_frame(parentbody))) where {T}
+        child_root_pose = eye(Transform3D{T}, default_frame(root_body(childmechanism)), default_frame(parentbody))) where {T}
     # FIXME: test with cycles
 
     @assert mechanism != childmechanism # infinite loop otherwise
@@ -212,7 +212,7 @@ function remove_fixed_tree_joints!(mechanism::Mechanism)
         succ = target(fixedjoint, graph)
 
         # Add identity joint transform as a body-fixed frame definition.
-        jointtransform = eye(Transform3DS{T}, frame_after(fixedjoint), frame_before(fixedjoint))
+        jointtransform = eye(Transform3D{T}, frame_after(fixedjoint), frame_before(fixedjoint))
         add_frame!(pred, jointtransform)
 
         # Migrate body fixed frames to parent body.
@@ -283,7 +283,7 @@ function maximal_coordinates(mechanism::Mechanism)
         frameafter = default_frame(srcbody)
         body = bodymap[srcbody] = deepcopy(srcbody)
         floatingjoint = newfloatingjoints[body] = Joint(string(body), framebefore, frameafter, QuaternionFloating{T}())
-        attach!(ret, root, body, floatingjoint, joint_pose = eye(Transform3DS{T}, framebefore), successor_pose = eye(Transform3DS{T}, frameafter))
+        attach!(ret, root, body, floatingjoint, joint_pose = eye(Transform3D{T}, framebefore), successor_pose = eye(Transform3D{T}, frameafter))
     end
 
     # Copy input Mechanism's joints.
@@ -315,9 +315,9 @@ function rand_tree_mechanism(::Type{T}, parentselector::Function, jointtypes::Va
     mechanism = Mechanism(parentbody)
     for (i, jointtype) in enumerate(jointtypes)
         joint = Joint("joint$i", rand(jointtype))
-        joint_to_parent_body = rand(Transform3DS{T}, frame_before(joint), default_frame(parentbody))
+        joint_to_parent_body = rand(Transform3D{T}, frame_before(joint), default_frame(parentbody))
         body = RigidBody(rand(SpatialInertia{T}, CartesianFrame3D("body$i")))
-        body_to_joint = eye(Transform3DS{T}, default_frame(body), frame_after(joint))
+        body_to_joint = eye(Transform3D{T}, default_frame(body), frame_after(joint))
         attach!(mechanism, parentbody, body, joint, joint_pose = joint_to_parent_body, successor_pose = body_to_joint)
         parentbody = parentselector(mechanism)
     end

--- a/src/mechanism_state.jl
+++ b/src/mechanism_state.jl
@@ -28,15 +28,15 @@ struct MechanismState{X, M, C, JointCollection}
     # joint-specific
     qs::JointDict{M, VectorSegment{X}}
     vs::JointDict{M, VectorSegment{X}}
-    joint_poses::JointDict{M, Transform3DS{M}} # TODO: remove, just use data in Joints
-    joint_transforms::CacheElement{JointDict{M, Transform3DS{C}}}
+    joint_poses::JointDict{M, Transform3D{M}} # TODO: remove, just use data in Joints
+    joint_transforms::CacheElement{JointDict{M, Transform3D{C}}}
     joint_twists::CacheElement{JointDict{M, Twist{C}}}
     joint_bias_accelerations::CacheElement{JointDict{M, SpatialAcceleration{C}}}
     motion_subspaces_in_world::CacheElement{JointDict{M, MotionSubspace{C}}}
     constraint_wrench_subspaces::CacheElement{JointDict{M, WrenchSubspace{C}}}
 
     # body-specific
-    transforms_to_root::CacheElement{BodyDict{M, Transform3DS{C}}}
+    transforms_to_root::CacheElement{BodyDict{M, Transform3D{C}}}
     twists_wrt_world::CacheElement{BodyDict{M, Twist{C}}}
     bias_accelerations_wrt_world::CacheElement{BodyDict{M, SpatialAcceleration{C}}}
     inertias::CacheElement{BodyDict{M, SpatialInertia{C}}}
@@ -61,15 +61,15 @@ struct MechanismState{X, M, C, JointCollection}
         qstart, vstart = 1, 1
         qs = JointDict{M, VectorSegment{X}}(j => view(q, qstart : (qstart += num_positions(j)) - 1) for j in tree_joints(mechanism))
         vs = JointDict{M, VectorSegment{X}}(j => view(v, vstart : (vstart += num_velocities(j)) - 1) for j in tree_joints(mechanism))
-        joint_poses = JointDict{M, Transform3DS{M}}(j => body_fixed_frame_definition(mechanism, frame_before(j)) for j in joints(mechanism))
-        joint_transforms = CacheElement(JointDict{M, Transform3DS{C}}(joints(mechanism)))
+        joint_poses = JointDict{M, Transform3D{M}}(j => body_fixed_frame_definition(mechanism, frame_before(j)) for j in joints(mechanism))
+        joint_transforms = CacheElement(JointDict{M, Transform3D{C}}(joints(mechanism)))
         joint_twists = CacheElement(JointDict{M, Twist{C}}(tree_joints(mechanism)))
         joint_bias_accelerations = CacheElement(JointDict{M, SpatialAcceleration{C}}(tree_joints(mechanism)))
         motion_subspaces_in_world = CacheElement(JointDict{M, MotionSubspace{C}}(tree_joints(mechanism)))
         constraint_wrench_subspaces = CacheElement(JointDict{M, WrenchSubspace{C}}(non_tree_joints(mechanism)))
 
         # body-specific
-        transforms_to_root = CacheElement(BodyDict{M, Transform3DS{C}}(bodies(mechanism)))
+        transforms_to_root = CacheElement(BodyDict{M, Transform3D{C}}(bodies(mechanism)))
         twists_wrt_world = CacheElement(BodyDict{M, Twist{C}}(bodies(mechanism)))
         bias_accelerations_wrt_world = CacheElement(BodyDict{M, SpatialAcceleration{C}}(bodies(mechanism)))
         inertias = CacheElement(BodyDict{M, SpatialInertia{C}}(bodies(mechanism)))
@@ -541,7 +541,7 @@ end
     map!(joint_transform, tree_joint_transforms, state.type_sorted_tree_joints, values(state.qs))
 
     # update transforms to root
-    transforms_to_root[root_body(mechanism)] = eye(Transform3DS{cache_eltype(state)}, root_frame(mechanism))
+    transforms_to_root[root_body(mechanism)] = eye(Transform3D{cache_eltype(state)}, root_frame(mechanism))
     for joint in tree_joints(mechanism)
         parentbody = predecessor(joint, mechanism)
         body = successor(joint, mechanism)

--- a/src/parse_urdf.jl
+++ b/src/parse_urdf.jl
@@ -102,7 +102,7 @@ function parse_root_link(mechanism::Mechanism{T}, xml_link::XMLElement) where {T
     parent = root_body(mechanism)
     body = parse_body(T, xml_link)
     joint = Joint("$(string(body))_to_world", Fixed{T}())
-    joint_to_parent = eye(Transform3DS{T}, frame_before(joint), default_frame(parent))
+    joint_to_parent = eye(Transform3D{T}, frame_before(joint), default_frame(parent))
     attach!(mechanism, parent, body, joint, joint_pose = joint_to_parent)
 end
 

--- a/src/rigid_body.jl
+++ b/src/rigid_body.jl
@@ -10,19 +10,19 @@ a list of definitions of coordinate systems that are rigidly attached to it.
 mutable struct RigidBody{T}
     name::String
     inertia::Nullable{SpatialInertia{T}}
-    frame_definitions::Vector{Transform3DS{T}}
+    frame_definitions::Vector{Transform3D{T}}
     contact_points::Vector{DefaultContactPoint{T}} # TODO: allow different contact models
     id::Int64
 
     # inertia undefined; can be used for the root of a kinematic tree
     function RigidBody{T}(name::String) where {T}
         frame = CartesianFrame3D(name)
-        new{T}(name, Nullable{SpatialInertia{T}}(), [eye(Transform3DS{T}, frame)], DefaultContactPoint{T}[], -1)
+        new{T}(name, Nullable{SpatialInertia{T}}(), [eye(Transform3D{T}, frame)], DefaultContactPoint{T}[], -1)
     end
 
     # other bodies
     function RigidBody(name::String, inertia::SpatialInertia{T}) where {T}
-        new{T}(name, Nullable(inertia), [eye(Transform3DS{T}, inertia.frame)], DefaultContactPoint{T}[], -1)
+        new{T}(name, Nullable(inertia), [eye(Transform3D{T}, inertia.frame)], DefaultContactPoint{T}[], -1)
     end
 end
 

--- a/src/spatial/Spatial.jl
+++ b/src/spatial/Spatial.jl
@@ -22,7 +22,6 @@ export
 
 # aliases
 export
-    Transform3DS, # TODO: remove
     MotionSubspace, # TODO: remove
     WrenchSubspace # TODO: remove
 

--- a/test/test_mechanism_modification.jl
+++ b/test/test_mechanism_modification.jl
@@ -20,10 +20,10 @@ end
         body0 = RigidBody{Float64}("root")
         mechanism = Mechanism(body0)
         joint1 = Joint("joint1", rand(Revolute{Float64}))
-        joint1_pose = rand(RigidBodyDynamics.Transform3DS{Float64}, frame_before(joint1), default_frame(body0))
+        joint1_pose = rand(Transform3D{Float64}, frame_before(joint1), default_frame(body0))
         body1 = RigidBody(rand(SpatialInertia{Float64}, frame_after(joint1)))
         joint2 = Joint("joint2", QuaternionFloating{Float64}())
-        joint2_pose = rand(RigidBodyDynamics.Transform3DS{Float64}, frame_before(joint2), default_frame(body1))
+        joint2_pose = rand(Transform3D{Float64}, frame_before(joint2), default_frame(body1))
         body2 = RigidBody(rand(SpatialInertia{Float64}, CartesianFrame3D("2")))
 
         # can't attach if predecessor is not among bodies of mechanism


### PR DESCRIPTION
Reasons:
* This is just easier to use.
* Unlike with e.g. `GeometricJacobian`, the size of a `Transform3D` is *always* fixed.
* I haven't yet come across a compelling use case where the underlying array type should not be an `SMatrix{4, 4}`, other than the ReverseDiff use case, see https://github.com/JuliaDiff/ReverseDiff.jl/issues/64#issuecomment-293097200. But I'm now of the opinion that supporting ReverseDiff in its current form (with a categorical lack of support for immutable array types) is not worth the trouble, especially since most use cases related to rigid body dynamics are such that ForwardDiff would likely be faster than ReverseDiff anyway. Still, hopefully a future Cassette-based version of ReverseDiff will be easier to work with.

Close #207.