### PR TITLE
Add PDControl submodule

### DIFF
--- a/src/RigidBodyDynamics.jl
+++ b/src/RigidBodyDynamics.jl
@@ -154,6 +154,7 @@ include("graphs/Graphs.jl")
 include("spatial/Spatial.jl")
 include("contact.jl")
 include("cache_element.jl")
+include("pdcontrol.jl")
 
 using .Spatial # contains additional functions that are reexported
 using .CustomCollections

--- a/src/pdcontrol.jl
+++ b/src/pdcontrol.jl
@@ -1,0 +1,70 @@
+module PDControl
+
+using RigidBodyDynamics.Spatial
+using StaticArrays
+using Rotations
+using Compat
+
+export
+    PDGains,
+    DoubleGeodesicPDGains,
+    pd
+
+abstract type AbstractPDGains{T} end
+
+struct PDGains{T} <: AbstractPDGains{T}
+    k::T
+    d::T
+end
+Base.eltype(::Type{PDGains{T}}) where {T} = eltype(T)
+Base.convert(::Type{T}, gains::T) where {T<:PDGains} = gains
+Base.convert(::Type{PDGains{S}}, gains::PDGains{T}) where {T, N, S<:SMatrix{N, N, T}} = PDGains(convert(S, eye(S) * gains.k), convert(S, eye(S) * gains.d))
+
+struct DoubleGeodesicPDGains{T<:Number} <: AbstractPDGains{T}
+    frame::CartesianFrame3D
+    angular::PDGains{SMatrix{3, 3, T, 9}}
+    linear::PDGains{SMatrix{3, 3, T, 9}}
+end
+
+function DoubleGeodesicPDGains(frame::CartesianFrame3D, angular::PDGains, linear::PDGains)
+    T = promote_type(eltype(angular), eltype(linear))
+    P = PDGains{SMatrix{3, 3, T, 9}}
+    DoubleGeodesicPDGains(frame, convert(P, angular), convert(P, linear))
+end
+
+function Spatial.transform(gains::DoubleGeodesicPDGains, t::Transform3D)
+    @framecheck t.from gains.frame
+    R = rotation(t)
+    angular = PDGains(R * gains.angular.k * R', R * gains.angular.d * R')
+    linear = PDGains(R * gains.linear.k * R', R * gains.linear.d * R')
+    DoubleGeodesicPDGains(t.to, angular, linear)
+end
+
+group_error(x, xdes) = x - xdes
+group_error(x::Rotation, xdes::Rotation) = inv(xdes) * x
+group_error(x::Transform3D, xdes::Transform3D) = inv(xdes) * x
+
+pd(gains::AbstractPDGains, x, xdes, ẋ, ẋdes) = pd(gains, group_error(x, xdes), -ẋdes + ẋ) # TODO: ẋ - ẋdes, but doesn't work for Twists right now
+pd(gains::PDGains, e, ė) = -gains.k * e - gains.d * ė
+pd(gains::PDGains, e::RodriguesVec, ė::AbstractVector) = pd(gains, SVector(e.sx, e.sy, e.sz), ė)
+pd(gains::PDGains, e::Rotation{3}, ė::AbstractVector) = pd(gains, RodriguesVec(e), ė)
+
+function pd(gains::DoubleGeodesicPDGains, e::Transform3D, ė::Twist)
+    # Theorem 12 in Bullo, Murray, "Proportional derivative (PD) control on the Euclidean group", 1995 (4.6 in the Technical Report).
+    # Note: in Theorem 12, even though the twist and spatial acceleration are expressed in body frame, the gain Kv is expressed in base (or desired) frame,
+    # since it acts on the translation part of the transform from body frame to base frame (i.e. the definition of body frame expressed in base frame),
+    # and force Kv * p needs to be rotated back to body frame to match the spatial acceleration in body frame.
+    # Instead, we express Kv in body frame by performing a similarity transform on Kv: R * Kv * R', where R is the rotation from actual body frame to desired body frame.
+    # This turns the linear and proportional part of the PD law into R' * R * Kv * R' * p = Kv * R' * p
+    # Note also that in Theorem 12, the frame in which the orientation gain Kω must be expressed is ambiguous, since R' * log(R) = log(R).
+    # This explains why the Kω used here is the same as the Kω in Theorem 12.
+    @framecheck ė.body e.from
+    @framecheck ė.base e.to
+    @framecheck ė.frame ė.body
+    @framecheck gains.frame ė.body # gains should be expressed in actual body frame
+    R = rotation(e)
+    p = translation(e)
+    SpatialAcceleration(ė.body, ė.base, ė.frame, pd(gains.angular, R, ė.angular), pd(gains.linear, R' * p, ė.linear))
+end
+
+end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using Base.Test
 using RigidBodyDynamics
 using RigidBodyDynamics.Graphs
 using RigidBodyDynamics.Contact
+using RigidBodyDynamics.PDControl
 using Rotations
 using StaticArrays
 using ForwardDiff
@@ -14,7 +15,6 @@ create_autodiff(x, dx) = [ForwardDiff.Dual(x[i], dx[i]) for i in 1 : length(x)]
 
 # TODO: https://github.com/JuliaDiff/DiffBase.jl/pull/19
 @inline Base.mod2pi(x::ForwardDiff.Dual) = ForwardDiff.Dual(mod2pi(ForwardDiff.value(x)), ForwardDiff.partials(x))
-@inline Base.rem(x::ForwardDiff.Dual, n::Real) = ForwardDiff.Dual(rem(ForwardDiff.value(x), n), ForwardDiff.partials(x))
 @inline Base.rem2pi(x::ForwardDiff.Dual, roundingmode::RoundingMode) = ForwardDiff.Dual(rem2pi(ForwardDiff.value(x), roundingmode), ForwardDiff.partials(x))
 
 include("test_graph.jl")
@@ -27,6 +27,7 @@ include("test_double_pendulum.jl")
 include("test_mechanism_algorithms.jl")
 include("test_simulate.jl")
 include("test_mechanism_modification.jl")
+include("test_pd_control.jl")
 
 # notebooks
 @testset "example notebooks" begin

--- a/test/test_pd_control.jl
+++ b/test/test_pd_control.jl
@@ -1,0 +1,97 @@
+@testset "pd" begin
+    @testset "scalar" begin
+        @test pd(PDGains(1, 2), 3, 4) == -11
+    end
+
+    @testset "vector" begin
+        gains = PDGains(1, 2)
+        e = [3; 4; 5]
+        ė = [6; 7; 8]
+        @test pd(gains, e, ė) == ((e, ė) -> pd(gains, e, ė)).(e, ė)
+    end
+
+    @testset "specifying desireds" begin
+        gains = PDGains(5, 6)
+        x = SVector(1, 2)
+        ẋ = SVector(5, 6)
+        @test pd(gains, x, ẋ) == pd(gains, x, zero(x), ẋ, zero(ẋ))
+    end
+
+    @testset "x-axis rotation" begin
+        gains = PDGains(2, 3)
+        e = RotX(rand())
+        ė = rand() * SVector(1, 0, 0)
+        @test pd(gains, e, ė)[1] ≈ pd(gains, e.theta, ė[1])
+    end
+
+    @testset "orientation control" begin
+        mechanism = rand_floating_tree_mechanism(Float64) # single floating body
+        joint = first(tree_joints(mechanism))
+        body = successor(joint, mechanism)
+        base = root_body(mechanism)
+
+        state = MechanismState(mechanism)
+        rand!(state)
+
+        Rdes = rand(RotMatrix{3})
+        ωdes = zeros(SVector{3})
+        gains = PDGains(100, 20)
+
+        control_dynamics_result = DynamicsResult(mechanism)
+        function control!(torques::AbstractVector, t, state::MechanismState)
+            H = transform_to_root(state, body)
+            T = transform(twist_wrt_world(state, body), inv(H))
+            R = rotation(H)
+            ω = T.angular
+            ωddes = pd(gains, R, Rdes, ω, ωdes)
+            v̇des = Array([ωddes; zeros(ωddes)])
+            inverse_dynamics!(torques, control_dynamics_result.jointwrenches, control_dynamics_result.accelerations, state, v̇des)
+        end
+
+        final_time = 3.
+        simulate(state, final_time, control!; Δt = 1e-3)
+
+        H = transform_to_root(state, body)
+        T = transform(twist_wrt_world(state, body), inv(H))
+        R = rotation(H)
+        ω = T.angular
+
+        @test isapprox(R * Rdes', eye(Rdes); atol = 1e-8)
+        @test isapprox(ω, zero(ω); atol = 1e-8)
+    end
+
+    @testset "pose control" begin
+        mechanism = rand_floating_tree_mechanism(Float64) # single floating body
+        joint = first(tree_joints(mechanism))
+        body = successor(joint, mechanism)
+        base = root_body(mechanism)
+
+        baseframe = default_frame(base)
+        desiredframe = CartesianFrame3D("desired")
+        actualframe = frame_after(joint)
+
+        state = MechanismState(mechanism)
+        rand!(state)
+
+        xdes = rand(Transform3D, desiredframe, baseframe)
+        vdes = zero(Twist{Float64}, desiredframe, baseframe, actualframe)
+        gains = DoubleGeodesicPDGains(baseframe, PDGains(100, 20), PDGains(100, 20)) # world-fixed gains
+
+        control_dynamics_result = DynamicsResult(mechanism)
+        function control!(torques::AbstractVector, t, state::MechanismState)
+            x = transform_to_root(state, body)
+            invx = inv(x)
+            v = transform(twist_wrt_world(state, body), invx)
+            v̇des = pd(transform(gains, invx), x, xdes, v, vdes)
+            inverse_dynamics!(torques, control_dynamics_result.jointwrenches, control_dynamics_result.accelerations, state, Array(v̇des))
+        end
+
+        final_time = 3.
+        simulate(state, final_time, control!; Δt = 1e-3)
+
+        x = transform_to_root(state, body)
+        v = transform(twist_wrt_world(state, body), inv(x))
+        @test isapprox(x, xdes * eye(Transform3D, actualframe, desiredframe), atol = 1e-6)
+        @test isapprox(v, vdes + zero(Twist{Float64}, actualframe, desiredframe, actualframe), atol = 1e-6)
+    end
+end


### PR DESCRIPTION
Originally part of https://github.com/tkoolen/MomentumBasedControl.jl.

PD control functionality, including SO(3) and SE(3) PD control. I initially thought it would be better to have this live in its own repo, but I think it will be useful inside RigidBodyDynamics for a (near-) future Baumgarte stabilization implementation.

Currently unexported.