### PR TITLE
implement length() and iteration for NullDict to fix display

### DIFF
--- a/src/custom_collections.jl
+++ b/src/custom_collections.jl
@@ -67,6 +67,9 @@ allocate any memory.
 struct NullDict{K, V} <: Associative{K, V}
 end
 Base.haskey(::NullDict, k) = false
+Base.length(::NullDict) = 0
+Base.start(::NullDict) = nothing
+Base.done(::NullDict, state) = true
 
 
 ## UnsafeVectorView

--- a/test/test_custom_collections.jl
+++ b/test/test_custom_collections.jl
@@ -20,4 +20,14 @@
         @test all(keys(d2) .== 1 : 3)
         @test all(values(d2) .== 3 * (1 : 3))
     end
+
+    @testset "nulldict" begin
+        nd = RigidBodyDynamics.NullDict{Int, Int}()
+        @test isempty(nd)
+        @test length(nd) == 0
+        for element in nd
+            @test false # should never be reached, since the nulldict is always empty
+        end
+        show(IOBuffer(), nd)
+    end
 end


### PR DESCRIPTION
Without these methods, trying to display a `NullDict` fails due to the fallback `show()` methods for `Associative` trying to print its length and/or elements. 