### PR TITLE
Remove upper bound on ForwardDiff test dependency.

### DIFF
--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,4 +1,4 @@
-ForwardDiff 0.5.0 0.6.0
+ForwardDiff 0.5.0
 BenchmarkTools 0.2.0
 SymPy 0.5.1
 NBInclude 1.1.0


### PR DESCRIPTION
Enabled by new ForwardDiff tag.