### PR TITLE
Introduce Spatial.velocity_jacobian.

### DIFF
--- a/src/joint_types.jl
+++ b/src/joint_types.jl
@@ -140,7 +140,7 @@ end
 function configuration_derivative_to_velocity_adjoint!(fq, jt::QuaternionFloating, q::AbstractVector, fv)
     quatnorm = sqrt(q[1]^2 + q[2]^2 + q[3]^2 + q[4]^2) # TODO: make this nicer
     quat = Quat(q[1] / quatnorm, q[2] / quatnorm, q[3] / quatnorm, q[4] / quatnorm, false)
-    rot = (quat_derivative_to_body_angular_velocity_jacobian(quat)' * angular_velocity(jt, fv)) ./ quatnorm
+    rot = (velocity_jacobian(angular_velocity_in_body, quat)' * angular_velocity(jt, fv)) ./ quatnorm
     trans = quat * linear_velocity(jt, fv)
     rotation!(fq, jt, rot)
     translation!(fq, jt, trans)
@@ -680,7 +680,7 @@ end
 function configuration_derivative_to_velocity_adjoint!(fq, jt::QuaternionSpherical, q::AbstractVector, fv)
     quatnorm = sqrt(q[1]^2 + q[2]^2 + q[3]^2 + q[4]^2) # TODO: make this nicer
     quat = Quat(q[1] / quatnorm, q[2] / quatnorm, q[3] / quatnorm, q[4] / quatnorm, false)
-    fq .= (quat_derivative_to_body_angular_velocity_jacobian(quat)' * fv) ./ quatnorm
+    fq .= (velocity_jacobian(angular_velocity_in_body, quat)' * fv) ./ quatnorm
     nothing
 end
 

--- a/src/spatial/Spatial.jl
+++ b/src/spatial/Spatial.jl
@@ -43,8 +43,7 @@ export
     rotation_vector_rate,
     quaternion_derivative,
     angular_velocity_in_body,
-    body_angular_velocity_to_quat_derivative_jacobian,
-    quat_derivative_to_body_angular_velocity_jacobian,
+    velocity_jacobian,
     linearized_rodrigues_vec
 
 # macros

--- a/src/spatial/util.jl
+++ b/src/spatial/util.jl
@@ -135,16 +135,18 @@ end
     angular, linear
 end
 
-@inline function body_angular_velocity_to_quat_derivative_jacobian(q::Quat)
-    mat = @SMatrix [
+function quaternion_derivative end
+function angular_velocity_in_body end
+
+@inline function velocity_jacobian(::typeof(quaternion_derivative), q::Quat)
+    (@SMatrix [
         -q.x -q.y -q.z;
         q.w -q.z  q.y;
         q.z  q.w -q.x;
-        -q.y  q.x  q.w]
-    mat / 2
+        -q.y  q.x  q.w]) / 2
 end
 
-@inline function quat_derivative_to_body_angular_velocity_jacobian(q::Quat)
+@inline function velocity_jacobian(::typeof(angular_velocity_in_body), q::Quat)
     2 * @SMatrix [
     -q.x  q.w  q.z -q.y;
     -q.y -q.z  q.w  q.x;
@@ -153,12 +155,12 @@ end
 
 @inline function quaternion_derivative(q::Quat, angular_velocity_in_body::AbstractVector)
     @boundscheck length(angular_velocity_in_body) == 3 || error("size mismatch")
-    body_angular_velocity_to_quat_derivative_jacobian(q) * angular_velocity_in_body
+    velocity_jacobian(quaternion_derivative, q) * angular_velocity_in_body
 end
 
 @inline function angular_velocity_in_body(q::Quat, quat_derivative::AbstractVector)
     @boundscheck length(quat_derivative) == 4 || error("size mismatch")
-    quat_derivative_to_body_angular_velocity_jacobian(q) * quat_derivative
+    velocity_jacobian(angular_velocity_in_body, q) * quat_derivative
 end
 
 function linearized_rodrigues_vec(r::RotMatrix) # TODO: consider moving to Rotations


### PR DESCRIPTION
Simplifies naming of functions that had awkwardly long names.