### PR TITLE
Store MotionSubspaces in a TypeSortedCollection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ notifications:
 before_install:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
 script:
-  - julia -e 'ENV["PYTHON"]=""; Pkg.clone(pwd()); Pkg.build("RigidBodyDynamics"); Pkg.test("RigidBodyDynamics"; coverage=true)'
+  - julia -e 'ENV["PYTHON"]=""; Pkg.clone(pwd()); Pkg.checkout("TypeSortedCollections"); Pkg.build("RigidBodyDynamics"); Pkg.test("RigidBodyDynamics"; coverage=true)'
   # Note: PYTHON env is to ensure that PyCall uses the Conda.jl package's Miniconda distribution within Julia. Otherwise the sympy Python module won't be installed/imported properly.
 after_success:
   - julia -e 'cd(Pkg.dir("RigidBodyDynamics")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/src/RigidBodyDynamics.jl
+++ b/src/RigidBodyDynamics.jl
@@ -108,7 +108,6 @@ export
     additional_state,
     joint_transform,
     motion_subspace,
-    motion_subspace_in_world, # TODO: remove, just call it motion_subspace
     constraint_wrench_subspace,
     bias_acceleration,
     spatial_inertia,

--- a/src/mechanism_algorithms.jl
+++ b/src/mechanism_algorithms.jl
@@ -183,7 +183,7 @@ function mass_matrix!(out::Symmetric{C, Matrix{C}}, state::MechanismState{X, M, 
         foreach_with_extra_args(out, state, irange, F, ancestor_joint_ids, state.type_sorted_tree_joints) do out, state, irange, F, ancestor_joint_ids, jointj # TODO: use closure once it doesn't allocate
             Base.@_inline_meta
             jrange = velocity_range(state, jointj)
-            if Graphs.edge_id(jointj) ∈ ancestor_joint_ids
+            if Int(Graphs.edge_id(jointj)) ∈ ancestor_joint_ids
                 Sj = motion_subspace_in_world(state, jointj)
                 block = angular(F)' * angular(Sj) + linear(F)' * linear(Sj)
                 set_matrix_block!(out.data, irange, jrange, block)

--- a/src/mechanism_algorithms.jl
+++ b/src/mechanism_algorithms.jl
@@ -179,10 +179,10 @@ function mass_matrix!(out::Symmetric{C, Matrix{C}}, state::MechanismState{X, M, 
         Si = motion_subspace_in_world(state, jointi)
         Ici = crb_inertia(state, successor(jointi, state.mechanism))
         F = Ici * Si
-        ancestor_joint_ids = state.ancestor_joint_ids[jointi]
-        foreach_with_extra_args(out, state, irange, F, ancestor_joint_ids, state.type_sorted_tree_joints) do out, state, irange, F, ancestor_joint_ids, jointj # TODO: use closure once it doesn't allocate
+        ancestor_joint_mask = state.ancestor_joint_masks[jointi]
+        foreach_with_extra_args(out, state, irange, F, ancestor_joint_mask, state.type_sorted_tree_joints) do out, state, irange, F, mask, jointj # TODO: use closure once it doesn't allocate
             Base.@_inline_meta # currently required; try removing with 1.0
-            if ancestor_joint_ids[Int(Graphs.edge_id(jointj))]
+            if mask[jointj]
                 jrange = velocity_range(state, jointj)
                 Sj = motion_subspace_in_world(state, jointj)
                 block = angular(F)' * angular(Sj) + linear(F)' * linear(Sj)

--- a/src/mechanism_state.jl
+++ b/src/mechanism_state.jl
@@ -19,7 +19,7 @@ struct MechanismState{X, M, C, JointCollection}
     modcount::Int
     type_sorted_tree_joints::JointCollection
     type_sorted_non_tree_joints::JointCollection
-    ancestor_joint_ids::JointDict{M, Vector{JointID}}
+    ancestor_joint_ids::JointDict{M, IntSet}
     constraint_jacobian_structure::JointDict{M, TreePath{RigidBody{M}, GenericJoint{M}}}
 
     q::Vector{X} # configurations
@@ -55,8 +55,8 @@ struct MechanismState{X, M, C, JointCollection}
         JointCollection = typeof(type_sorted_joints)
         type_sorted_tree_joints = JointCollection(typedjoint.(tree_joints(mechanism)))
         type_sorted_non_tree_joints = JointCollection(typedjoint.(non_tree_joints(mechanism)))
-        ancestor_joint_id_list = joint -> sort(Graphs.edge_id.(path(mechanism, successor(joint, mechanism), root_body(mechanism)).edges), by = Int)
-        ancestor_joint_ids = JointDict{M, Vector{JointID}}(j => ancestor_joint_id_list(j) for j in tree_joints(mechanism))
+        ancestor_joint_id_set = joint -> IntSet(Int.(Graphs.edge_id.(path(mechanism, successor(joint, mechanism), root_body(mechanism)).edges)))
+        ancestor_joint_ids = JointDict{M, IntSet}(j => ancestor_joint_id_set(j) for j in tree_joints(mechanism))
 
         # joint-specific
         qstart, vstart = 1, 1

--- a/src/mechanism_state.jl
+++ b/src/mechanism_state.jl
@@ -19,7 +19,7 @@ struct MechanismState{X, M, C, JointCollection}
     modcount::Int
     type_sorted_tree_joints::JointCollection
     type_sorted_non_tree_joints::JointCollection
-    ancestor_joint_ids::JointDict{M, IntSet}
+    ancestor_joint_ids::JointDict{M, BitVector}
     constraint_jacobian_structure::JointDict{M, TreePath{RigidBody{M}, GenericJoint{M}}}
 
     q::Vector{X} # configurations
@@ -55,8 +55,8 @@ struct MechanismState{X, M, C, JointCollection}
         JointCollection = typeof(type_sorted_joints)
         type_sorted_tree_joints = JointCollection(typedjoint.(tree_joints(mechanism)))
         type_sorted_non_tree_joints = JointCollection(typedjoint.(non_tree_joints(mechanism)))
-        ancestor_joint_id_set = joint -> IntSet(Int.(Graphs.edge_id.(path(mechanism, successor(joint, mechanism), root_body(mechanism)).edges)))
-        ancestor_joint_ids = JointDict{M, IntSet}(j => ancestor_joint_id_set(j) for j in tree_joints(mechanism))
+        ancestor_joint_id_bitvec = joint -> BitArray(j ∈ path(mechanism, successor(joint, mechanism), root_body(mechanism)) for j in tree_joints(mechanism))
+        ancestor_joint_ids = JointDict{M, BitVector}(j => ancestor_joint_id_bitvec(j) for j in tree_joints(mechanism))
 
         # joint-specific
         qstart, vstart = 1, 1

--- a/src/mechanism_state.jl
+++ b/src/mechanism_state.jl
@@ -19,7 +19,7 @@ struct MechanismState{X, M, C, JointCollection}
     modcount::Int
     type_sorted_tree_joints::JointCollection
     type_sorted_non_tree_joints::JointCollection
-    type_sorted_ancestor_joints::JointDict{M, JointCollection}
+    ancestor_joint_ids::JointDict{M, Vector{JointID}}
     constraint_jacobian_structure::JointDict{M, TreePath{RigidBody{M}, GenericJoint{M}}}
 
     q::Vector{X} # configurations
@@ -55,8 +55,8 @@ struct MechanismState{X, M, C, JointCollection}
         JointCollection = typeof(type_sorted_joints)
         type_sorted_tree_joints = JointCollection(typedjoint.(tree_joints(mechanism)))
         type_sorted_non_tree_joints = JointCollection(typedjoint.(non_tree_joints(mechanism)))
-        ancestor_joints(joint) = path(mechanism, successor(joint, mechanism), root_body(mechanism)).edges
-        type_sorted_ancestor_joints = JointDict{M, JointCollection}(j => JointCollection(typedjoint.(ancestor_joints(j))) for j in tree_joints(mechanism))
+        ancestor_joint_id_list = joint -> sort(Graphs.edge_id.(path(mechanism, successor(joint, mechanism), root_body(mechanism)).edges), by = Int)
+        ancestor_joint_ids = JointDict{M, Vector{JointID}}(j => ancestor_joint_id_list(j) for j in tree_joints(mechanism))
 
         # joint-specific
         qstart, vstart = 1, 1
@@ -91,7 +91,7 @@ struct MechanismState{X, M, C, JointCollection}
         m = mechanism
         constraint_jacobian_structure = JointDict{M, TreePath{RigidBody{M}, GenericJoint{M}}}(j => path(m, predecessor(j, m), successor(j, m)) for j in non_tree_joints(m))
 
-        new{X, M, C, JointCollection}(mechanism, modcount(mechanism), type_sorted_tree_joints, type_sorted_non_tree_joints, type_sorted_ancestor_joints,
+        new{X, M, C, JointCollection}(mechanism, modcount(mechanism), type_sorted_tree_joints, type_sorted_non_tree_joints, ancestor_joint_ids,
             constraint_jacobian_structure, q, v, s, qs, vs, joint_poses,
             joint_transforms, joint_twists, joint_bias_accelerations, motion_subspaces_in_world, constraint_wrench_subspaces,
             transforms_to_root, twists_wrt_world, bias_accelerations_wrt_world, inertias, crb_inertias,


### PR DESCRIPTION
Previously, motion subspaces were converted to a common type (a `GeometricJacobian` backed by 3x6 `SMatrix`es) so that they could be stored type-stably in `MechanismState`. This had some overhead associated with it, but this is just what `TypeSortedCollection`s are made for.

This change required no longer storing ancestor joints for all of the tree joints in a `TypeSortedCollection` (`state.type_sorted_tree_joints`), as the indices of the `TypeSortedCollection` we iterate over in the inner loop of `mass_matrix!` need to match those of the `TypeSortedCollection` of `MotionSubspace`s. Instead, I'm now using a `JointMask`, which is a little wrapper around a `BitVector`.

Decent performance improvements:

* `momentum_matrix!`: 9.146 μs to 7.081 μs
* `dynamics!`: 47.448 μs to 43.964 μs
* `geometric_jacobian!`: 5.669 μs to 4.073 μs
* `mass_matrix!`: 13.727 μs to 12.286 μs

`constraint_jacobian_and_bias!` went from `99.836 μs` to `109.052 μs`, but I haven't put any effort into optimizing that one anyway.

Unfortunately, this means that the `motion_subspace_in_world` function has to go away (or be extremely slow and annoying to implement), but I don't expect any users to be using that function. Please open an issue if you do.