### PR TITLE
Use BodyID/JointID for indexing

### DIFF
--- a/perf/runbenchmarks.jl
+++ b/perf/runbenchmarks.jl
@@ -48,7 +48,7 @@ function create_benchmark_suite()
         inverse_dynamics!($torques, $(result.jointwrenches), $(result.accelerations), $state, v̇, externalwrenches)
     end, setup = begin
         v̇ = rand(ScalarType, num_velocities($mechanism))
-        externalwrenches = RigidBodyDynamics.OldBodyDict{ScalarType}(body => rand(Wrench{ScalarType}, root_frame($mechanism)) for body in bodies($mechanism))
+        externalwrenches = RigidBodyDynamics.BodyDict(RigidBodyDynamics.id(body) => rand(Wrench{ScalarType}, root_frame($mechanism)) for body in bodies($mechanism))
         rand!($state)
     end)
 
@@ -58,7 +58,7 @@ function create_benchmark_suite()
     end, setup = begin
         rand!($state)
         τ = rand(ScalarType, num_velocities($mechanism))
-        externalwrenches = RigidBodyDynamics.OldBodyDict{ScalarType}(body => rand(Wrench{ScalarType}, root_frame($mechanism)) for body in bodies($mechanism))
+        externalwrenches = RigidBodyDynamics.BodyDict(RigidBodyDynamics.id(body) => rand(Wrench{ScalarType}, root_frame($mechanism)) for body in bodies($mechanism))
     end)
 
     suite["momentum_matrix"] = @benchmarkable(begin

--- a/perf/runbenchmarks.jl
+++ b/perf/runbenchmarks.jl
@@ -48,7 +48,7 @@ function create_benchmark_suite()
         inverse_dynamics!($torques, $(result.jointwrenches), $(result.accelerations), $state, v̇, externalwrenches)
     end, setup = begin
         v̇ = rand(ScalarType, num_velocities($mechanism))
-        externalwrenches = RigidBodyDynamics.BodyDict{ScalarType}(body => rand(Wrench{ScalarType}, root_frame($mechanism)) for body in bodies($mechanism))
+        externalwrenches = RigidBodyDynamics.OldBodyDict{ScalarType}(body => rand(Wrench{ScalarType}, root_frame($mechanism)) for body in bodies($mechanism))
         rand!($state)
     end)
 
@@ -58,7 +58,7 @@ function create_benchmark_suite()
     end, setup = begin
         rand!($state)
         τ = rand(ScalarType, num_velocities($mechanism))
-        externalwrenches = RigidBodyDynamics.BodyDict{ScalarType}(body => rand(Wrench{ScalarType}, root_frame($mechanism)) for body in bodies($mechanism))
+        externalwrenches = RigidBodyDynamics.OldBodyDict{ScalarType}(body => rand(Wrench{ScalarType}, root_frame($mechanism)) for body in bodies($mechanism))
     end)
 
     suite["momentum_matrix"] = @benchmarkable(begin

--- a/src/RigidBodyDynamics.jl
+++ b/src/RigidBodyDynamics.jl
@@ -152,7 +152,6 @@ include("custom_collections.jl")
 include("graphs/Graphs.jl")
 include("spatial/Spatial.jl")
 include("contact.jl")
-include("cache_element.jl")
 include("pdcontrol.jl")
 
 using .Spatial # contains additional functions that are reexported

--- a/src/cache_element.jl
+++ b/src/cache_element.jl
@@ -1,8 +1,0 @@
-mutable struct CacheElement{T}
-    data::T
-    dirty::Bool
-    CacheElement(data::T) where {T} = new{T}(data, true)
-end
-
-@inline setdirty!(element::CacheElement) = (element.dirty = true; nothing)
-@inline isdirty(element::CacheElement) = element.dirty

--- a/src/custom_collections.jl
+++ b/src/custom_collections.jl
@@ -274,6 +274,7 @@ isdirty(d::CacheIndexDict) = d.dirty
 @inline Base.done(d::AbstractIndexDict, i) = i == length(d) + 1
 @inline Base.keys(d::AbstractIndexDict{K}) where {K} = (K(i) for i in eachindex(d.values))
 @inline Base.values(d::AbstractIndexDict) = d.values
+@inline Base.haskey(d::AbstractIndexDict, key) = isassigned(d.values, Int(key))
 Base.@propagate_inbounds Base.getindex(d::AbstractIndexDict{K}, key::K) where {K} = d.values[Int(key)]
 Base.@propagate_inbounds Base.setindex!(d::AbstractIndexDict{K}, value, key::K) where {K} = d.values[Int(key)] = value
 

--- a/src/dynamics_result.jl
+++ b/src/dynamics_result.jl
@@ -1,6 +1,3 @@
-#TODO:
-const OldBodyDict{T} = UnsafeFastDict{Graphs.vertex_index, RigidBody{T}}
-
 """
 $(TYPEDEF)
 
@@ -23,11 +20,11 @@ mutable struct DynamicsResult{T, M}
     λ::Vector{T}
     ṡ::Vector{T}
 
-    contactwrenches::OldBodyDict{M, Wrench{T}}
-    totalwrenches::OldBodyDict{M, Wrench{T}}
-    accelerations::OldBodyDict{M, SpatialAcceleration{T}}
-    jointwrenches::OldBodyDict{M, Wrench{T}} # TODO: index by joint tree index?
-    contact_state_derivatives::OldBodyDict{M, Vector{Vector{DefaultSoftContactStateDeriv{T}}}}
+    contactwrenches::BodyDict{Wrench{T}}
+    totalwrenches::BodyDict{Wrench{T}}
+    accelerations::BodyDict{SpatialAcceleration{T}}
+    jointwrenches::BodyDict{Wrench{T}} # TODO: index by joint tree index?
+    contact_state_derivatives::BodyDict{Vector{Vector{DefaultSoftContactStateDeriv{T}}}}
 
     # see solve_dynamics! for meaning of the following variables:
     L::Matrix{T} # lower triangular
@@ -51,11 +48,11 @@ mutable struct DynamicsResult{T, M}
         ṡ = Vector{T}(num_additional_states(mechanism))
 
         rootframe = root_frame(mechanism)
-        contactwrenches = OldBodyDict{M, Wrench{T}}(b => zero(Wrench{T}, rootframe) for b in bodies(mechanism))
-        totalwrenches = OldBodyDict{M, Wrench{T}}(b => zero(Wrench{T}, rootframe) for b in bodies(mechanism))
-        accelerations = OldBodyDict{M, SpatialAcceleration{T}}(b => zero(SpatialAcceleration{T}, rootframe, rootframe, rootframe) for b in bodies(mechanism))
-        jointwrenches = OldBodyDict{M, Wrench{T}}(b => zero(Wrench{T}, rootframe) for b in bodies(mechanism))
-        contact_state_derivs = OldBodyDict{M, Vector{Vector{DefaultSoftContactStateDeriv{T}}}}(b => Vector{Vector{DefaultSoftContactStateDeriv{T}}}() for b in bodies(mechanism))
+        contactwrenches = BodyDict{Wrench{T}}(b => zero(Wrench{T}, rootframe) for b in bodies(mechanism))
+        totalwrenches = BodyDict{Wrench{T}}(b => zero(Wrench{T}, rootframe) for b in bodies(mechanism))
+        accelerations = BodyDict{SpatialAcceleration{T}}(b => zero(SpatialAcceleration{T}, rootframe, rootframe, rootframe) for b in bodies(mechanism))
+        jointwrenches = BodyDict{Wrench{T}}(b => zero(Wrench{T}, rootframe) for b in bodies(mechanism))
+        contact_state_derivs = BodyDict{Vector{Vector{DefaultSoftContactStateDeriv{T}}}}(b => Vector{Vector{DefaultSoftContactStateDeriv{T}}}() for b in bodies(mechanism))
         startind = 1
         for body in bodies(mechanism), point in contact_points(body)
             model = contact_model(point)
@@ -81,10 +78,10 @@ end
 
 DynamicsResult(mechanism::Mechanism{M}) where {M} = DynamicsResult{M}(mechanism)
 
-contact_state_derivatives(result::DynamicsResult, body::RigidBody) = result.contact_state_derivatives[body]
-contact_wrench(result::DynamicsResult, body::RigidBody) = result.contactwrenches[body]
-set_contact_wrench!(result::DynamicsResult, body::RigidBody, wrench::Wrench) = (result.contactwrenches[body] = wrench)
-acceleration(result::DynamicsResult, body::RigidBody) = result.accelerations[body]
-set_acceleration!(result::DynamicsResult, body::RigidBody, accel::SpatialAcceleration) = (result.accelerations[body] = accel)
-joint_wrench(result::DynamicsResult, body::RigidBody) = result.jointwrenches[body]
-set_joint_wrench!(result::DynamicsResult, body::RigidBody, wrench::Wrench) = (result.jointwrenches[body] = wrench)
+contact_state_derivatives(result::DynamicsResult, body::Union{<:RigidBody, BodyID}) = result.contact_state_derivatives[body]
+contact_wrench(result::DynamicsResult, body::Union{<:RigidBody, BodyID}) = result.contactwrenches[body]
+set_contact_wrench!(result::DynamicsResult, body::Union{<:RigidBody, BodyID}, wrench::Wrench) = (result.contactwrenches[body] = wrench)
+acceleration(result::DynamicsResult, body::Union{<:RigidBody, BodyID}) = result.accelerations[body]
+set_acceleration!(result::DynamicsResult, body::Union{<:RigidBody, BodyID}, accel::SpatialAcceleration) = (result.accelerations[body] = accel)
+joint_wrench(result::DynamicsResult, body::Union{<:RigidBody, BodyID}) = result.jointwrenches[body]
+set_joint_wrench!(result::DynamicsResult, body::Union{<:RigidBody, BodyID}, wrench::Wrench) = (result.jointwrenches[body] = wrench)

--- a/src/dynamics_result.jl
+++ b/src/dynamics_result.jl
@@ -1,6 +1,5 @@
 #TODO:
-const BodyDict{T} = UnsafeFastDict{Graphs.vertex_index, RigidBody{T}}
-const JointDict{T} = UnsafeFastDict{Graphs.edge_index, GenericJoint{T}}
+const OldBodyDict{T} = UnsafeFastDict{Graphs.vertex_index, RigidBody{T}}
 
 """
 $(TYPEDEF)
@@ -24,11 +23,11 @@ mutable struct DynamicsResult{T, M}
     λ::Vector{T}
     ṡ::Vector{T}
 
-    contactwrenches::BodyDict{M, Wrench{T}}
-    totalwrenches::BodyDict{M, Wrench{T}}
-    accelerations::BodyDict{M, SpatialAcceleration{T}}
-    jointwrenches::BodyDict{M, Wrench{T}} # TODO: index by joint tree index?
-    contact_state_derivatives::BodyDict{M, Vector{Vector{DefaultSoftContactStateDeriv{T}}}}
+    contactwrenches::OldBodyDict{M, Wrench{T}}
+    totalwrenches::OldBodyDict{M, Wrench{T}}
+    accelerations::OldBodyDict{M, SpatialAcceleration{T}}
+    jointwrenches::OldBodyDict{M, Wrench{T}} # TODO: index by joint tree index?
+    contact_state_derivatives::OldBodyDict{M, Vector{Vector{DefaultSoftContactStateDeriv{T}}}}
 
     # see solve_dynamics! for meaning of the following variables:
     L::Matrix{T} # lower triangular
@@ -52,11 +51,11 @@ mutable struct DynamicsResult{T, M}
         ṡ = Vector{T}(num_additional_states(mechanism))
 
         rootframe = root_frame(mechanism)
-        contactwrenches = BodyDict{M, Wrench{T}}(b => zero(Wrench{T}, rootframe) for b in bodies(mechanism))
-        totalwrenches = BodyDict{M, Wrench{T}}(b => zero(Wrench{T}, rootframe) for b in bodies(mechanism))
-        accelerations = BodyDict{M, SpatialAcceleration{T}}(b => zero(SpatialAcceleration{T}, rootframe, rootframe, rootframe) for b in bodies(mechanism))
-        jointwrenches = BodyDict{M, Wrench{T}}(b => zero(Wrench{T}, rootframe) for b in bodies(mechanism))
-        contact_state_derivs = BodyDict{M, Vector{Vector{DefaultSoftContactStateDeriv{T}}}}(b => Vector{Vector{DefaultSoftContactStateDeriv{T}}}() for b in bodies(mechanism))
+        contactwrenches = OldBodyDict{M, Wrench{T}}(b => zero(Wrench{T}, rootframe) for b in bodies(mechanism))
+        totalwrenches = OldBodyDict{M, Wrench{T}}(b => zero(Wrench{T}, rootframe) for b in bodies(mechanism))
+        accelerations = OldBodyDict{M, SpatialAcceleration{T}}(b => zero(SpatialAcceleration{T}, rootframe, rootframe, rootframe) for b in bodies(mechanism))
+        jointwrenches = OldBodyDict{M, Wrench{T}}(b => zero(Wrench{T}, rootframe) for b in bodies(mechanism))
+        contact_state_derivs = OldBodyDict{M, Vector{Vector{DefaultSoftContactStateDeriv{T}}}}(b => Vector{Vector{DefaultSoftContactStateDeriv{T}}}() for b in bodies(mechanism))
         startind = 1
         for body in bodies(mechanism), point in contact_points(body)
             model = contact_model(point)

--- a/src/dynamics_result.jl
+++ b/src/dynamics_result.jl
@@ -1,3 +1,7 @@
+#TODO:
+const BodyDict{T} = UnsafeFastDict{Graphs.vertex_index, RigidBody{T}}
+const JointDict{T} = UnsafeFastDict{Graphs.edge_index, GenericJoint{T}}
+
 """
 $(TYPEDEF)
 

--- a/src/joint.jl
+++ b/src/joint.jl
@@ -1,8 +1,4 @@
-struct JointID
-    value::Int
-end
-Base.hash(i::JointID, h::UInt) = hash(i.value, h)
-Base.convert(::Type{Int}, i::JointID) = i.value
+@indextype JointID
 
 # The constructor setup for Joint may look strange. The constructors are
 # designed so that e.g. a call to Joint("bla", QuaternionFloating{Float64}())

--- a/src/joint.jl
+++ b/src/joint.jl
@@ -108,9 +108,10 @@ effort for `joint`
 """
 effort_bounds(joint::Joint) = joint.effort_bounds
 
-RigidBodyDynamics.Graphs.edge_id_type(::Type{<:Joint}) = JointID
-RigidBodyDynamics.Graphs.edge_id(joint::Joint) = joint.id[]
-RigidBodyDynamics.Graphs.set_edge_id!(joint::Joint, id::JointID) = (joint.id[] = id)
+@inline id(joint::Joint) = joint.id[]
+@inline RigidBodyDynamics.Graphs.edge_id_type(::Type{<:Joint}) = JointID
+@inline RigidBodyDynamics.Graphs.edge_id(joint::Joint) = id(joint)
+@inline RigidBodyDynamics.Graphs.set_edge_id!(joint::Joint, id::JointID) = (joint.id[] = id)
 function RigidBodyDynamics.Graphs.flip_direction(joint::Joint)
     jtype = RigidBodyDynamics.flip_direction(joint_type(joint))
     Joint(string(joint), frame_after(joint), frame_before(joint), jtype;

--- a/src/joint_types.jl
+++ b/src/joint_types.jl
@@ -504,7 +504,7 @@ struct Planar{T} <: JointType{T}
     """
     function Planar{T}(x_axis::AbstractVector, y_axis::AbstractVector) where {T}
         x, y = map(axis -> normalize(SVector{3}(axis)), (x_axis, y_axis))
-        @assert isapprox(x ⋅ y, 0; atol = 10 * eps(T))
+        @assert isapprox(x ⋅ y, 0; atol = 100 * eps(T))
         z = cross(x, y)
         new{T}(x, y, z)
     end

--- a/src/mechanism_algorithms.jl
+++ b/src/mechanism_algorithms.jl
@@ -292,18 +292,17 @@ function momentum_matrix(state::MechanismState)
     ret
 end
 
-function bias_accelerations!(out::Associative{RigidBody{M}, SpatialAcceleration{T}}, state::MechanismState{X, M}) where {T, X, M}
+function bias_accelerations!(out::Associative{BodyID, SpatialAcceleration{T}}, state::MechanismState{X, M}) where {T, X, M}
     update_bias_accelerations_wrt_world!(state)
-    mechanism = state.mechanism
-    gravitybias = convert(SpatialAcceleration{T}, -gravitational_spatial_acceleration(mechanism))
-    for joint in tree_joints(mechanism)
-        body = successor(joint, mechanism)
-        out[body] = gravitybias + bias_acceleration(state, body)
+    gravitybias = convert(SpatialAcceleration{T}, -gravitational_spatial_acceleration(state.mechanism))
+    for jointid in state.treejointids
+        bodyid = successorid(jointid, state)
+        out[bodyid] = gravitybias + bias_acceleration(state, bodyid)
     end
     nothing
 end
 
-function spatial_accelerations!(out::Associative{RigidBody{M}, SpatialAcceleration{T}},
+function spatial_accelerations!(out::Associative{BodyID, SpatialAcceleration{T}},
         state::MechanismState{X, M}, vd::StridedVector) where {T, X, M}
     update_twists_wrt_world!(state)
     mechanism = state.mechanism
@@ -313,34 +312,32 @@ function spatial_accelerations!(out::Associative{RigidBody{M}, SpatialAccelerati
     vs = values(state.vs)
 
     # Compute joint accelerations
-    foreach_with_extra_args(state, out, vd, joints, qs, vs) do state, accels, vd, joint, qjoint, vjoint # TODO: use closure once it doesn't allocate
-        body = successor(joint, state.mechanism)
-        parentbody = predecessor(joint, state.mechanism)
-        vdjoint = fastview(vd, velocity_range(state, joint))
-        accels[body] = joint_spatial_acceleration(joint, qjoint, vjoint, vdjoint)
+    foreach_with_extra_args(state, out, vd, joints, state.treejointids, qs, vs) do state, accels, vd, joint, jointid, qjoint, vjoint # TODO: use closure once it doesn't allocate
+        parentbodyid, bodyid = predsucc(jointid, state)
+        vdjoint = fastview(vd, velocity_range(state, jointid))
+        accels[bodyid] = joint_spatial_acceleration(joint, qjoint, vjoint, vdjoint)
     end
 
     # Recursive propagation
     # TODO: manual frame changes. Find a way to not avoid the frame checks here.
     out[root] = convert(SpatialAcceleration{T}, -gravitational_spatial_acceleration(mechanism))
-    for joint in tree_joints(mechanism)
-        body = successor(joint, mechanism)
-        parentbody = predecessor(joint, mechanism)
-        toroot = transform_to_root(state, body)
-        parenttwist = twist_wrt_world(state, parentbody)
-        bodytwist = twist_wrt_world(state, body)
-        jointaccel = out[body]
+    for jointid in state.treejointids
+        parentbodyid, bodyid = predsucc(jointid, state)
+        toroot = transform_to_root(state, bodyid)
+        parenttwist = twist_wrt_world(state, parentbodyid)
+        bodytwist = twist_wrt_world(state, bodyid)
+        jointaccel = out[bodyid]
         jointaccel = SpatialAcceleration(jointaccel.body, parenttwist.body, toroot.to,
             Spatial.transform_spatial_motion(jointaccel.angular, jointaccel.linear, rotation(toroot), translation(toroot))...)
-        out[body] = out[parentbody] + (-bodytwist) × parenttwist + jointaccel
+        out[bodyid] = out[parentbodyid] + (-bodytwist) × parenttwist + jointaccel
     end
     nothing
 end
 
 spatial_accelerations!(result::DynamicsResult, state::MechanismState) = spatial_accelerations!(result.accelerations, state, result.v̇)
 
-function relative_acceleration(accels::Associative{RigidBody{M}, SpatialAcceleration{T}}, body::RigidBody{M}, base::RigidBody{M}) where {T, M}
-    -accels[base] + accels[body]
+function relative_acceleration(accels::Associative{BodyID, SpatialAcceleration{T}}, body::RigidBody{M}, base::RigidBody{M}) where {T, M}
+    -accels[id(base)] + accels[id(body)]
 end
 
 # TODO: ensure that accelerations are up-to-date
@@ -354,45 +351,43 @@ function relative_acceleration(state::MechanismState, body::RigidBody, base::Rig
 end
 
 function newton_euler!(
-        out::Associative{RigidBody{M}, Wrench{T}}, state::MechanismState{X, M},
-        accelerations::Associative{RigidBody{M}, SpatialAcceleration{T}},
-        externalwrenches::Associative{RigidBody{M}, Wrench{W}}) where {T, X, M, W}
+        out::Associative{BodyID, Wrench{T}}, state::MechanismState{X, M},
+        accelerations::Associative{BodyID, SpatialAcceleration{T}},
+        externalwrenches::Associative{BodyID, Wrench{W}}) where {T, X, M, W}
     update_twists_wrt_world!(state)
     update_spatial_inertias!(state)
-    mechanism = state.mechanism
-    for joint in tree_joints(mechanism)
-        body = successor(joint, mechanism)
-        wrench = newton_euler(state, body, accelerations[body])
-        out[body] = haskey(externalwrenches, body) ? wrench - externalwrenches[body] : wrench
+    for jointid in state.treejointids
+        bodyid = successorid(jointid, state)
+        wrench = newton_euler(state, bodyid, accelerations[bodyid])
+        out[bodyid] = haskey(externalwrenches, bodyid) ? wrench - externalwrenches[bodyid] : wrench
     end
 end
 
 
 function joint_wrenches_and_torques!(
         torquesout::StridedVector{T},
-        net_wrenches_in_joint_wrenches_out::Associative{RigidBody{M}, Wrench{T}}, # TODO: consider having a separate Associative{Joint{M}, Wrench{T}} for joint wrenches
+        net_wrenches_in_joint_wrenches_out::Associative{BodyID, Wrench{T}}, # TODO: consider having a separate Associative{Joint{M}, Wrench{T}} for joint wrenches
         state::MechanismState{X, M}) where {T, X, M}
     # Note: pass in net wrenches as wrenches argument. wrenches argument is modified to be joint wrenches
     @boundscheck length(torquesout) == num_velocities(state) || error("length of torque vector is wrong")
-    mechanism = state.mechanism
-    joints = tree_joints(mechanism)
-    for i = length(joints) : -1 : 1
-        joint = joints[i]
-        body = successor(joint, mechanism)
-        parentbody = predecessor(joint, mechanism)
-        jointwrench = net_wrenches_in_joint_wrenches_out[body]
-        if !isroot(parentbody, mechanism)
+
+    treejointids = state.treejointids
+    for i = length(treejointids) : -1 : 1
+        jointid = treejointids[i]
+        parentbodyid, bodyid = predsucc(jointid, state)
+        jointwrench = net_wrenches_in_joint_wrenches_out[bodyid]
+        if parentbodyid != BodyID(1) # TODO: ugly
             # TODO: consider also doing this for the root:
-            net_wrenches_in_joint_wrenches_out[parentbody] += jointwrench # action = -reaction
+            net_wrenches_in_joint_wrenches_out[parentbodyid] += jointwrench # action = -reaction
         end
     end
 
-    foreach_with_extra_args(state, torquesout, net_wrenches_in_joint_wrenches_out, state.type_sorted_tree_joints) do state, τ, wrenches, joint # TODO: use closure once it doesn't allocate
-        body = successor(joint, state.mechanism)
-        @inbounds τjoint = fastview(τ, velocity_range(state, joint))
+    foreach_with_extra_args(state, torquesout, net_wrenches_in_joint_wrenches_out, state.type_sorted_tree_joints, treejointids) do state, τ, wrenches, joint, jointid # TODO: use closure once it doesn't allocate
+        bodyid = successorid(jointid, state)
+        @inbounds τjoint = fastview(τ, velocity_range(state, jointid))
         # TODO: awkward to transform back to body frame; consider switching to body-frame implementation
-        tf = inv(transform_to_root(state, body))
-        joint_torque!(τjoint, joint, configuration(state, joint), transform(wrenches[body], tf))
+        tf = inv(transform_to_root(state, bodyid))
+        joint_torque!(τjoint, joint, configuration(state, jointid), transform(wrenches[bodyid], tf)) # TODO: consider using motion subspace
     end
 end
 
@@ -421,10 +416,10 @@ $noalloc_doc
 """
 function dynamics_bias!(
         torques::AbstractVector{T},
-        biasaccelerations::Associative{RigidBody{M}, SpatialAcceleration{T}},
-        wrenches::Associative{RigidBody{M}, Wrench{T}},
+        biasaccelerations::Associative{BodyID, SpatialAcceleration{T}},
+        wrenches::Associative{BodyID, Wrench{T}},
         state::MechanismState{X, M},
-        externalwrenches::Associative{RigidBody{M}, Wrench{W}} = NullDict{RigidBody{M}, Wrench{T}}()) where {T, X, M, W}
+        externalwrenches::Associative{BodyID, Wrench{W}} = NullDict{BodyID, Wrench{T}}()) where {T, X, M, W}
     bias_accelerations!(biasaccelerations, state)
     newton_euler!(wrenches, state, biasaccelerations, externalwrenches)
     joint_wrenches_and_torques!(torques, wrenches, state)
@@ -441,13 +436,13 @@ $dynamics_bias_doc
 """
 function dynamics_bias(
         state::MechanismState{X, M},
-        externalwrenches::Associative{RigidBody{M}, Wrench{W}} = NullDict{RigidBody{M}, Wrench{X}}()) where {X, M, W}
+        externalwrenches::Associative{BodyID, Wrench{W}} = NullDict{BodyID, Wrench{X}}()) where {X, M, W}
     T = promote_type(X, M, W)
     mechanism = state.mechanism
     torques = Vector{T}(num_velocities(state))
     rootframe = root_frame(mechanism)
-    jointwrenches = OldBodyDict{M, Wrench{T}}(b => zero(Wrench{T}, rootframe) for b in bodies(mechanism))
-    accelerations = OldBodyDict{M, SpatialAcceleration{T}}(b => zero(SpatialAcceleration{T}, rootframe, rootframe, rootframe) for b in bodies(mechanism))
+    jointwrenches = BodyDict(id(b) => zero(Wrench{T}, rootframe) for b in bodies(mechanism))
+    accelerations = BodyDict(id(b) => zero(SpatialAcceleration{T}, rootframe, rootframe, rootframe) for b in bodies(mechanism))
     dynamics_bias!(torques, accelerations, jointwrenches, state, externalwrenches)
     torques
 end
@@ -478,12 +473,12 @@ $noalloc_doc
 """
 function inverse_dynamics!(
         torquesout::AbstractVector{T},
-        jointwrenchesout::Associative{RigidBody{M}, Wrench{T}},
-        accelerations::Associative{RigidBody{M}, SpatialAcceleration{T}},
+        jointwrenchesout::Associative{BodyID, Wrench{T}},
+        accelerations::Associative{BodyID, SpatialAcceleration{T}},
         state::MechanismState{X, M},
         v̇::AbstractVector{V},
-        externalwrenches::Associative{RigidBody{M}, Wrench{W}} = NullDict{RigidBody{M}, Wrench{T}}()) where {T, X, M, V, W}
-    length(tree_joints(state.mechanism)) == length(joints(state.mechanism)) || error("This method can currently only handle tree Mechanisms.")
+        externalwrenches::Associative{BodyID, Wrench{W}} = NullDict{BodyID, Wrench{T}}()) where {T, X, M, V, W}
+    @boundscheck length(tree_joints(state.mechanism)) == length(joints(state.mechanism)) || error("This method can currently only handle tree Mechanisms.")
     spatial_accelerations!(accelerations, state, v̇)
     newton_euler!(jointwrenchesout, state, accelerations, externalwrenches)
     joint_wrenches_and_torques!(torquesout, jointwrenchesout, state)
@@ -497,19 +492,18 @@ $inverse_dynamics_doc
 function inverse_dynamics(
         state::MechanismState{X, M},
         v̇::AbstractVector{V},
-        externalwrenches::Associative{RigidBody{M}, Wrench{W}} = NullDict{RigidBody{M}, Wrench{X}}()) where {X, M, V, W}
+        externalwrenches::Associative{BodyID, Wrench{W}} = NullDict{BodyID, Wrench{X}}()) where {X, M, V, W}
     T = promote_type(X, M, V, W)
     mechanism = state.mechanism
     torques = Vector{T}(num_velocities(state))
     rootframe = root_frame(mechanism)
-    jointwrenches = OldBodyDict{M, Wrench{T}}(b => zero(Wrench{T}, rootframe) for b in bodies(mechanism))
-    accelerations = OldBodyDict{M, SpatialAcceleration{T}}(b => zero(SpatialAcceleration{T}, rootframe, rootframe, rootframe) for b in bodies(mechanism))
+    jointwrenches = BodyDict(id(b) => zero(Wrench{T}, rootframe) for b in bodies(mechanism))
+    accelerations = BodyDict(id(b) => zero(SpatialAcceleration{T}, rootframe, rootframe, rootframe) for b in bodies(mechanism))
     inverse_dynamics!(torques, jointwrenches, accelerations, state, v̇, externalwrenches)
     torques
 end
 
 function constraint_jacobian_and_bias!(state::MechanismState, constraintjacobian::AbstractMatrix, constraintbias::AbstractVector)
-    has_loops(state.mechanism) || return # nothing to be done
     update_twists_wrt_world!(state)
     update_bias_accelerations_wrt_world!(state)
     update_motion_subspaces!(state)
@@ -519,12 +513,11 @@ function constraint_jacobian_and_bias!(state::MechanismState, constraintjacobian
     # note: order of rows of Jacobian and bias term is determined by iteration order of state.type_sorted_non_tree_joints
      # TODO: use closure once it doesn't allocate
     foreach_with_extra_args(constraintjacobian, constraintbias, state, mechanism, rowstart, state.type_sorted_non_tree_joints) do constraintjacobian, constraintbias, state, mechanism, rowstart, nontreejoint
-        path = state.constraint_jacobian_structure[nontreejoint]
+        nontreejointid = id(nontreejoint)
+        path = state.constraint_jacobian_structure[nontreejointid]
         nextrowstart = rowstart[] + num_constraints(nontreejoint)
         rowrange = rowstart[] : nextrowstart - 1
-        succ = successor(nontreejoint, mechanism)
-        pred = predecessor(nontreejoint, mechanism)
-        T = constraint_wrench_subspace(state, nontreejoint)
+        T = constraint_wrench_subspace(state, nontreejoint) # TODO: use ID
 
         # Jacobian.
         foreach_with_extra_args(constraintjacobian, state, path, T, rowrange, state.type_sorted_tree_joints, state.motion_subspaces.data) do constraintjacobian, state, path, T, rowrange, treejoint, J # TODO: use closure once it doesn't allocate
@@ -541,8 +534,9 @@ function constraint_jacobian_and_bias!(state::MechanismState, constraintjacobian
         # Constraint bias.
         has_fixed_subspaces(nontreejoint) || error("Only joints with fixed motion subspace (Ṡ = 0) supported at this point.") # TODO: call to joint-type-specific function
         kjoint = fastview(constraintbias, rowrange)
-        crossterm = cross(twist_wrt_world(state, succ), twist_wrt_world(state, pred))
-        biasaccel = crossterm + (-bias_acceleration(state, pred) + bias_acceleration(state, succ)) # 8.47 in Featherstone
+        predid, succid = predsucc(nontreejointid, state)
+        crossterm = cross(twist_wrt_world(state, succid), twist_wrt_world(state, predid))
+        biasaccel = crossterm + (-bias_acceleration(state, predid) + bias_acceleration(state, succid)) # 8.47 in Featherstone
         At_mul_B!(kjoint, T, biasaccel)
         rowstart[] = nextrowstart
     end
@@ -556,14 +550,15 @@ function contact_dynamics!(result::DynamicsResult{T, M}, state::MechanismState{X
     root = root_body(mechanism)
     frame = default_frame(root)
     for body in bodies(mechanism)
+        bodyid = id(body)
         wrench = zero(Wrench{T}, frame)
         points = contact_points(body)
         if !isempty(points)
             # TODO: AABB
-            body_to_root = transform_to_root(state, body)
-            twist = twist_wrt_world(state, body)
-            states_for_body = contact_states(state, body)
-            state_derivs_for_body = contact_state_derivatives(result, body)
+            body_to_root = transform_to_root(state, bodyid)
+            twist = twist_wrt_world(state, bodyid)
+            states_for_body = contact_states(state, bodyid)
+            state_derivs_for_body = contact_state_derivatives(result, bodyid)
             for i = 1 : length(points)
                 @inbounds c = points[i]
                 point = body_to_root * location(c)
@@ -715,15 +710,16 @@ wrenches that act on the `Mechanism`'s bodies.
 """
 function dynamics!(result::DynamicsResult{T, M}, state::MechanismState{X, M},
         torques::AbstractVector{Tau} = ConstVector(zero(T), num_velocities(state)),
-        externalwrenches::Associative{RigidBody{M}, Wrench{W}} = NullDict{RigidBody{M}, Wrench{T}}()) where {T, X, M, Tau, W}
+        externalwrenches::Associative{BodyID, Wrench{W}} = NullDict{BodyID, Wrench{T}}()) where {T, X, M, Tau, W}
     contact_dynamics!(result, state)
-    for body in bodies(state.mechanism)
-        contactwrench = result.contactwrenches[body]
-        result.totalwrenches[body] = haskey(externalwrenches, body) ? externalwrenches[body] + contactwrench : contactwrench
+    for jointid in state.treejointids
+        bodyid = successorid(jointid, state)
+        contactwrench = result.contactwrenches[bodyid]
+        result.totalwrenches[bodyid] = haskey(externalwrenches, bodyid) ? externalwrenches[bodyid] + contactwrench : contactwrench
     end
     dynamics_bias!(result, state)
     mass_matrix!(result, state)
-    constraint_jacobian_and_bias!(result, state)
+    has_loops(state.mechanism) && constraint_jacobian_and_bias!(result, state)
     dynamics_solve!(result, torques)
     nothing
 end
@@ -745,7 +741,7 @@ and returns a `Vector` ``\\dot{x}``.
 function dynamics!(ẋ::StridedVector{X},
         result::DynamicsResult{T, M}, state::MechanismState{X, M}, state_vec::AbstractVector{X},
         torques::AbstractVector{Tau} = ConstVector(zero(T), num_velocities(state)),
-        externalwrenches::Associative{RigidBody{M}, Wrench{W}} = NullDict{RigidBody{M}, Wrench{T}}()) where {T, X, M, Tau, W}
+        externalwrenches::Associative{BodyID, Wrench{W}} = NullDict{BodyID, Wrench{T}}()) where {T, X, M, Tau, W}
     set!(state, state_vec)
     nq = num_positions(state)
     nv = num_velocities(state)

--- a/src/mechanism_algorithms.jl
+++ b/src/mechanism_algorithms.jl
@@ -309,8 +309,8 @@ function spatial_accelerations!(out::Associative{RigidBody{M}, SpatialAccelerati
     mechanism = state.mechanism
     root = root_body(mechanism)
     joints = state.type_sorted_tree_joints
-    qs = values(state.qs)
-    vs = values(state.vs)
+    qs = state.qs.data
+    vs = state.vs.data
 
     # Compute joint accelerations
     foreach_with_extra_args(state, out, vd, joints, qs, vs) do state, accels, vd, joint, qjoint, vjoint # TODO: use closure once it doesn't allocate

--- a/src/mechanism_algorithms.jl
+++ b/src/mechanism_algorithms.jl
@@ -309,8 +309,8 @@ function spatial_accelerations!(out::Associative{RigidBody{M}, SpatialAccelerati
     mechanism = state.mechanism
     root = root_body(mechanism)
     joints = state.type_sorted_tree_joints
-    qs = state.qs.data
-    vs = state.vs.data
+    qs = values(state.qs)
+    vs = values(state.vs)
 
     # Compute joint accelerations
     foreach_with_extra_args(state, out, vd, joints, qs, vs) do state, accels, vd, joint, qjoint, vjoint # TODO: use closure once it doesn't allocate
@@ -446,8 +446,8 @@ function dynamics_bias(
     mechanism = state.mechanism
     torques = Vector{T}(num_velocities(state))
     rootframe = root_frame(mechanism)
-    jointwrenches = BodyDict{M, Wrench{T}}(b => zero(Wrench{T}, rootframe) for b in bodies(mechanism))
-    accelerations = BodyDict{M, SpatialAcceleration{T}}(b => zero(SpatialAcceleration{T}, rootframe, rootframe, rootframe) for b in bodies(mechanism))
+    jointwrenches = OldBodyDict{M, Wrench{T}}(b => zero(Wrench{T}, rootframe) for b in bodies(mechanism))
+    accelerations = OldBodyDict{M, SpatialAcceleration{T}}(b => zero(SpatialAcceleration{T}, rootframe, rootframe, rootframe) for b in bodies(mechanism))
     dynamics_bias!(torques, accelerations, jointwrenches, state, externalwrenches)
     torques
 end
@@ -502,8 +502,8 @@ function inverse_dynamics(
     mechanism = state.mechanism
     torques = Vector{T}(num_velocities(state))
     rootframe = root_frame(mechanism)
-    jointwrenches = BodyDict{M, Wrench{T}}(b => zero(Wrench{T}, rootframe) for b in bodies(mechanism))
-    accelerations = BodyDict{M, SpatialAcceleration{T}}(b => zero(SpatialAcceleration{T}, rootframe, rootframe, rootframe) for b in bodies(mechanism))
+    jointwrenches = OldBodyDict{M, Wrench{T}}(b => zero(Wrench{T}, rootframe) for b in bodies(mechanism))
+    accelerations = OldBodyDict{M, SpatialAcceleration{T}}(b => zero(SpatialAcceleration{T}, rootframe, rootframe, rootframe) for b in bodies(mechanism))
     inverse_dynamics!(torques, jointwrenches, accelerations, state, v̇, externalwrenches)
     torques
 end

--- a/src/mechanism_state.jl
+++ b/src/mechanism_state.jl
@@ -706,7 +706,7 @@ end
     nothing
 end
 
-contact_states(state::MechanismState, body::RigidBody) = state.contact_states[body]
+contact_states(state::MechanismState, body::Union{<:RigidBody, BodyID}) = state.contact_states[body]
 
 function newton_euler(state::MechanismState, body::Union{<:RigidBody, BodyID}, accel::SpatialAcceleration)
     inertia = spatial_inertia(state, body)

--- a/src/rigid_body.jl
+++ b/src/rigid_body.jl
@@ -1,8 +1,4 @@
-struct BodyID
-    value::Int
-end
-Base.hash(i::BodyID, h::UInt) = hash(i.value, h)
-Base.convert(::Type{Int}, i::BodyID) = i.value
+@indextype BodyID
 
 """
 $(TYPEDEF)

--- a/src/rigid_body.jl
+++ b/src/rigid_body.jl
@@ -38,9 +38,10 @@ RigidBody(inertia::SpatialInertia) = RigidBody(string(inertia.frame), inertia)
 Base.string(b::RigidBody) = b.name
 Base.show(io::IO, b::RigidBody) = print(io, "RigidBody: \"$(string(b))\"")
 Base.showcompact(io::IO, b::RigidBody) = print(io, "$(string(b))")
-RigidBodyDynamics.Graphs.vertex_id_type(::Type{<:RigidBody}) = BodyID
-RigidBodyDynamics.Graphs.vertex_id(b::RigidBody) = b.id
-RigidBodyDynamics.Graphs.set_vertex_id!(b::RigidBody, id::BodyID) = (b.id = id)
+@inline id(b::RigidBody) = b.id
+@inline RigidBodyDynamics.Graphs.vertex_id_type(::Type{<:RigidBody}) = BodyID
+@inline RigidBodyDynamics.Graphs.vertex_id(b::RigidBody) = id(b)
+@inline RigidBodyDynamics.Graphs.set_vertex_id!(b::RigidBody, id::BodyID) = (b.id = id)
 
 """
 $(SIGNATURES)

--- a/src/util.jl
+++ b/src/util.jl
@@ -143,6 +143,7 @@ macro indextype(name)
         Base.start(r::$oneto) = start(r.oneto)
         Base.next(r::$oneto, state) = ((i, state) = next(r.oneto, state); ($name(i), state))
         Base.done(r::$oneto, i) = done(r.oneto, i)
+        @inline Base.getindex(r::$oneto, i::Integer) = $name(r.oneto[i])
 
         struct $unitrange <: Base.AbstractUnitRange{$name}
             range::UnitRange{Int}
@@ -154,6 +155,7 @@ macro indextype(name)
         Base.start(r::$unitrange) = start(r.range)
         Base.next(r::$unitrange, state) = ((i, state) = next(r.range, state); ($name(i), state))
         Base.done(r::$unitrange, i) = done(r.range, i)
+        @inline Base.getindex(r::$unitrange, i::Integer) = $name(r.range[i])
         Base.colon(start::$name, stop::$name) = $unitrange(start, stop)
     end)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,7 +11,7 @@ using ForwardDiff
 import Base.Iterators: filter
 
 # useful utility function for computing time derivatives.
-create_autodiff(x, dx) = [ForwardDiff.Dual(x[i], dx[i]) for i in 1 : length(x)]
+create_autodiff(x, dx) = [ForwardDiff.Dual(x[i], dx[i]) for i in 1 : length(x)] # TODO: just use broadcast
 
 include("test_graph.jl")
 include("test_custom_collections.jl")

--- a/test/test_mechanism_algorithms.jl
+++ b/test/test_mechanism_algorithms.jl
@@ -445,7 +445,7 @@ end
         x = MechanismState(mechanism)
         rand!(x)
         v̇ = rand(num_velocities(mechanism))
-        externalwrenches = Dict(body => rand(Wrench{Float64}, root_frame(mechanism)) for body in bodies(mechanism))
+        externalwrenches = Dict(RigidBodyDynamics.id(body) => rand(Wrench{Float64}, root_frame(mechanism)) for body in bodies(mechanism))
         τ = inverse_dynamics(x, v̇, externalwrenches)
         floatingjoint = first(out_joints(root_body(mechanism), mechanism))
         τfloating = τ[velocity_range(x, floatingjoint)]
@@ -455,7 +455,7 @@ end
         gravitational_force = mass(mechanism) * mechanism.gravitational_acceleration
         com = center_of_mass(x)
         gravitational_wrench = Wrench(gravitational_force.frame, cross(com, gravitational_force).v, gravitational_force.v)
-        total_wrench = floatingjointwrench + gravitational_wrench + sum((b) -> transform(x, externalwrenches[b], root_frame(mechanism)), non_root_bodies(mechanism))
+        total_wrench = floatingjointwrench + gravitational_wrench + sum((b) -> transform(x, externalwrenches[RigidBodyDynamics.id(b)], root_frame(mechanism)), non_root_bodies(mechanism))
         @test isapprox(total_wrench, ḣ; atol = 1e-12)
     end
 
@@ -464,7 +464,7 @@ end
         x = MechanismState(mechanism)
         rand!(x)
         external_torques = rand(num_velocities(mechanism))
-        externalwrenches = Dict(body => rand(Wrench{Float64}, root_frame(mechanism)) for body in bodies(mechanism))
+        externalwrenches = Dict(RigidBodyDynamics.id(body) => rand(Wrench{Float64}, root_frame(mechanism)) for body in bodies(mechanism))
         result = DynamicsResult(mechanism)
         dynamics!(result, x, external_torques, externalwrenches)
         τ = inverse_dynamics(x, result.v̇, externalwrenches) - external_torques
@@ -475,7 +475,7 @@ end
         mechanism = rand_tree_mechanism()
         x = MechanismState(mechanism)
         rand!(x)
-        externalwrenches = Dict(body => rand(Wrench{Float64}, root_frame(mechanism)) for body in bodies(mechanism))
+        externalwrenches = Dict(RigidBodyDynamics.id(body) => rand(Wrench{Float64}, root_frame(mechanism)) for body in bodies(mechanism))
         v̇ = zeros(num_velocities(x))
         τ1 = inverse_dynamics(x, v̇, externalwrenches)
         τ2 = dynamics_bias(x, externalwrenches)
@@ -487,7 +487,7 @@ end
         x = MechanismState(mechanism)
         rand!(x)
         torques = rand(num_velocities(mechanism))
-        externalwrenches = Dict(body => rand(Wrench{Float64}, root_frame(mechanism)) for body in bodies(mechanism))
+        externalwrenches = Dict(RigidBodyDynamics.id(body) => rand(Wrench{Float64}, root_frame(mechanism)) for body in bodies(mechanism))
 
         result1 = DynamicsResult(mechanism)
         ẋ = Vector{Float64}(length(state_vector(x)))
@@ -503,7 +503,7 @@ end
         mechanism = rand_tree_mechanism()
         x = MechanismState(mechanism)
         rand!(x)
-        externalwrenches = Dict(body => rand(Wrench{Float64}, root_frame(mechanism)) for body in bodies(mechanism))
+        externalwrenches = Dict(RigidBodyDynamics.id(body) => rand(Wrench{Float64}, root_frame(mechanism)) for body in bodies(mechanism))
         τ = rand(num_velocities(mechanism))
         result = DynamicsResult(mechanism)
         dynamics!(result, x, τ, externalwrenches)
@@ -512,7 +512,7 @@ end
         q̇ = configuration_derivative(x)
         v = velocity(x)
         v̇ = result.v̇
-        power = τ ⋅ v + sum(body -> externalwrenches[body] ⋅ twist_wrt_world(x, body), non_root_bodies(mechanism))
+        power = τ ⋅ v + sum(body -> externalwrenches[RigidBodyDynamics.id(body)] ⋅ twist_wrt_world(x, body), non_root_bodies(mechanism))
 
         q_autodiff = create_autodiff(q, q̇)
         v_autodiff = create_autodiff(v, v̇)

--- a/test/test_mechanism_modification.jl
+++ b/test/test_mechanism_modification.jl
@@ -284,7 +284,7 @@ end
         for (treebody, mcbody) in bodymap
             tree_accel = relative_acceleration(tree_dynamics_result, treebody, root_body(tree_mechanism))
             mc_accel = relative_acceleration(mc_dynamics_result, mcbody, root_body(mc_mechanism))
-            @test isapprox(tree_accel, mc_accel; atol = 1e-12)
+            @test isapprox(tree_accel, mc_accel; atol = 1e-11)
         end
     end # maximal coordinates
 


### PR DESCRIPTION
* add `IndexDict` and `CacheIndexDict`, new `Vector`-backed associative types that don't store the keys (indices) as they are directly constructible from the `Int` used to index into the values.
* make `BodyDict` and `JointDict` aliases for `IndexDict{BodyID}` and `IndexDict{JointID}`, stop using `UnsafeFastDict`. You can still index into e.g. `BodyDict` using a `RigidBody` as a convenience, but the key type is really `BodyID`
* change `Associative{<:RigidBody, T}` arguments in mechanism algorithms to `Associative{BodyID, T}` so that a `BodyDict` can be used.
* store the predecessor and successor ID for each joint ID in MechanismState upon construction; allows faster lookup of body data and parent body data in `BodyDict`s than going through the `Mechanism`'s `SpanningTree`.

A bit faster:
* `momentum_matrix`: 7.339 μs -> 6.545 μs
* `inverse_dynamics` 11.307 μs -> 10.657 μs
* `gravitational_potential_energy`: 2.787 μs -> 2.638 μs
* `dynamics`: 44.906 μs -> 40.151 μs
* `geometric_jacobian`: 4.213 μs -> 3.908 μs
* `mass_matrix`: 12.533 μs -> 9.671 μs

