### PR TITLE
Store predecessor/successor transforms in joint

### DIFF
--- a/src/joint.jl
+++ b/src/joint.jl
@@ -57,8 +57,8 @@ struct Joint{T, JT<:JointType{T}}
             velocity_bounds::Vector{Bounds{T}}=fill(Bounds{T}(), num_velocities(joint_type)),
             effort_bounds::Vector{Bounds{T}}=fill(Bounds{T}(), num_velocities(joint_type))) where {T, JT<:JointType{T}}
         id = Ref(JointID(-1))
-        before_joint_to_predecessor = Ref(eye(Transform3D{Float64}, frame_before))
-        after_joint_to_successor = Ref(eye(Transform3D{Float64}, frame_after))
+        before_joint_to_predecessor = Ref(eye(Transform3D{T}, frame_before))
+        after_joint_to_successor = Ref(eye(Transform3D{T}, frame_after))
         new{T, JointType{T}}(name, frame_before, frame_after, joint_type, id,
             before_joint_to_predecessor, after_joint_to_successor,
             position_bounds, velocity_bounds, effort_bounds)
@@ -200,7 +200,7 @@ the frame after the joint, which is attached to the joint's successor.
 """
 @inline function motion_subspace(joint::Joint, q::AbstractVector)
     @boundscheck check_num_positions(joint, q)
-    motion_subspace(joint.joint_type, frame_after(joint), frame_before(joint), q)
+    motion_subspace(joint.joint_type, frame_after(joint), before_joint_to_predecessor(joint).to, q)
 end
 
 """
@@ -233,7 +233,7 @@ in configuration ``q`` and at velocity ``v``, when the joint acceleration
 function bias_acceleration(joint::Joint, q::AbstractVector, v::AbstractVector)
     @boundscheck check_num_positions(joint, q)
     @boundscheck check_num_velocities(joint, v)
-    bias_acceleration(joint.joint_type, frame_after(joint), frame_before(joint), q, v)
+    bias_acceleration(joint.joint_type, frame_after(joint), before_joint_to_predecessor(joint).to, q, v)
 end
 
 """
@@ -339,7 +339,7 @@ Note that this is the same as `Twist(motion_subspace(joint, q), v)`.
 function joint_twist(joint::Joint, q::AbstractVector, v::AbstractVector)
     @boundscheck check_num_positions(joint, q)
     @boundscheck check_num_velocities(joint, v)
-    joint_twist(joint.joint_type, frame_after(joint), frame_before(joint), q, v)
+    joint_twist(joint.joint_type, frame_after(joint), before_joint_to_predecessor(joint).to, q, v)
 end
 
 """
@@ -352,7 +352,7 @@ function joint_spatial_acceleration(joint::Joint, q::AbstractVector, v::Abstract
     @boundscheck check_num_positions(joint, q)
     @boundscheck check_num_velocities(joint, v)
     @boundscheck check_num_velocities(joint, vd)
-    joint_spatial_acceleration(joint.joint_type, frame_after(joint), frame_before(joint), q, v, vd)
+    joint_spatial_acceleration(joint.joint_type, frame_after(joint), before_joint_to_predecessor(joint).to, q, v, vd)
 end
 
 """

--- a/src/mechanism.jl
+++ b/src/mechanism.jl
@@ -240,10 +240,10 @@ function canonicalize_frame_definitions!(mechanism::Mechanism{T}, body::RigidBod
         change_default_frame!(body, frame_after(joint_to_parent(body, mechanism)))
     end
     for joint in in_joints(body, mechanism)
-        set_after_joint_to_successor!(joint, frame_definition(body, frame_after(joint)))
+        set_joint_to_successor!(joint, frame_definition(body, frame_after(joint)))
     end
     for joint in out_joints(body, mechanism)
-        set_before_joint_to_predecessor!(joint, frame_definition(body, frame_before(joint)))
+        set_joint_to_predecessor!(joint, frame_definition(body, frame_before(joint)))
     end
 end
 

--- a/src/mechanism.jl
+++ b/src/mechanism.jl
@@ -237,8 +237,13 @@ end
 
 function canonicalize_frame_definitions!(mechanism::Mechanism{T}, body::RigidBody{T}) where {T}
     if !isroot(body, mechanism)
-        joint = joint_to_parent(body, mechanism)
-        change_default_frame!(body, frame_after(joint))
+        change_default_frame!(body, frame_after(joint_to_parent(body, mechanism)))
+    end
+    for joint in in_joints(body, mechanism)
+        set_after_joint_to_successor!(joint, frame_definition(body, frame_after(joint)))
+    end
+    for joint in out_joints(body, mechanism)
+        set_before_joint_to_predecessor!(joint, frame_definition(body, frame_before(joint)))
     end
 end
 

--- a/src/mechanism_modification.jl
+++ b/src/mechanism_modification.jl
@@ -86,13 +86,13 @@ function attach!(mechanism::Mechanism{T}, parentbody::RigidBody{T}, childmechani
     for transform in frame_definitions(childroot)
         add_frame!(parentbody, transform)
     end
-    canonicalize_frame_definitions!(mechanism, parentbody)
     bodymap[childroot] = parentbody
 
     # Insert childmechanism's non-root vertices and joints, starting with the tree joints (to preserve order).
     for joint in flatten((tree_joints(childmechanism), non_tree_joints(childmechanism)))
         _copyjoint!(mechanism, childmechanism, joint, bodymap, jointmap)
     end
+    canonicalize_frame_definitions!(mechanism, parentbody)
     bodymap, jointmap
 end
 

--- a/src/mechanism_modification.jl
+++ b/src/mechanism_modification.jl
@@ -27,11 +27,14 @@ function attach!(mechanism::Mechanism{T}, predecessor::RigidBody{T}, successor::
     @assert joint ∉ joints(mechanism)
 
     # define where joint is attached on predecessor
+    joint.before_joint_to_predecessor[] = joint_pose
     add_frame!(predecessor, joint_pose)
 
     # define where child is attached to joint
-    add_frame!(successor, inv(successor_pose))
+    joint.after_joint_to_successor[] = inv(successor_pose)
+    add_frame!(successor, joint.after_joint_to_successor[])
 
+    # update graph
     if successor ∈ bodies(mechanism)
         add_edge!(mechanism.graph, predecessor, successor, joint)
     else
@@ -174,8 +177,11 @@ function remove_joint!(mechanism::Mechanism{M}, joint::GenericJoint{M};
 end
 
 function replace_joint!(mechanism::Mechanism, oldjoint::Joint, newjoint::Joint)
+    # TODO: can hopefully remove this again once Joint is mutable again
     @assert frame_before(newjoint) == frame_before(oldjoint)
     @assert frame_after(newjoint) == frame_after(oldjoint)
+    set_before_joint_to_predecessor!(newjoint, oldjoint.before_joint_to_predecessor[])
+    set_after_joint_to_successor!(newjoint, oldjoint.after_joint_to_successor[])
     if oldjoint ∈ tree_joints(mechanism)
         replace_edge!(mechanism.tree, oldjoint, newjoint)
     else

--- a/src/mechanism_modification.jl
+++ b/src/mechanism_modification.jl
@@ -27,12 +27,12 @@ function attach!(mechanism::Mechanism{T}, predecessor::RigidBody{T}, successor::
     @assert joint ∉ joints(mechanism)
 
     # define where joint is attached on predecessor
-    joint.before_joint_to_predecessor[] = joint_pose
+    joint.joint_to_predecessor[] = joint_pose
     add_frame!(predecessor, joint_pose)
 
     # define where child is attached to joint
-    joint.after_joint_to_successor[] = inv(successor_pose)
-    add_frame!(successor, joint.after_joint_to_successor[])
+    joint.joint_to_successor[] = inv(successor_pose)
+    add_frame!(successor, joint.joint_to_successor[])
 
     # update graph
     if successor ∈ bodies(mechanism)
@@ -180,8 +180,8 @@ function replace_joint!(mechanism::Mechanism, oldjoint::Joint, newjoint::Joint)
     # TODO: can hopefully remove this again once Joint is mutable again
     @assert frame_before(newjoint) == frame_before(oldjoint)
     @assert frame_after(newjoint) == frame_after(oldjoint)
-    set_before_joint_to_predecessor!(newjoint, oldjoint.before_joint_to_predecessor[])
-    set_after_joint_to_successor!(newjoint, oldjoint.after_joint_to_successor[])
+    set_joint_to_predecessor!(newjoint, oldjoint.joint_to_predecessor[])
+    set_joint_to_successor!(newjoint, oldjoint.joint_to_successor[])
     if oldjoint ∈ tree_joints(mechanism)
         replace_edge!(mechanism.tree, oldjoint, newjoint)
     else

--- a/src/mechanism_state.jl
+++ b/src/mechanism_state.jl
@@ -552,7 +552,7 @@ end
     for joint in tree_joints(mechanism)
         jointid = id(joint)
         parentid, bodyid = predsucc(jointid, state)
-        transforms_to_root[bodyid] = transforms_to_root[parentid] * before_joint_to_predecessor(joint) * state.joint_transforms[jointid]
+        transforms_to_root[bodyid] = transforms_to_root[parentid] * joint_to_predecessor(joint) * state.joint_transforms[jointid]
     end
     state.transforms_to_root.dirty = false
 
@@ -561,8 +561,8 @@ end
         foreach_with_extra_args(state.joint_transforms, state, state.type_sorted_non_tree_joints) do joint_transforms, state, joint # TODO: use closure once it's fast
             pred = predecessor(joint, state.mechanism)
             succ = successor(joint, state.mechanism)
-            before_to_root = transform_to_root(state, pred) * before_joint_to_predecessor(joint)
-            after_to_root = transform_to_root(state, succ) * after_joint_to_successor(joint)
+            before_to_root = transform_to_root(state, pred) * joint_to_predecessor(joint)
+            after_to_root = transform_to_root(state, succ) * joint_to_successor(joint)
             joint_transforms[joint] = inv(before_to_root) * after_to_root
         end
     end

--- a/test/test_mechanism_algorithms.jl
+++ b/test/test_mechanism_algorithms.jl
@@ -248,7 +248,6 @@ end
             parent_body = predecessor(joint, mechanism)
             toroot = transform_to_root(x, body)
             S = transform(motion_subspace(joint, configuration(x, joint)), toroot)
-            S = RigidBodyDynamics.change_base(S, default_frame(parent_body)) # to make frames line up
             @test isapprox(relative_twist(x, body, parent_body), Twist(S, velocity(x, joint)); atol = 1e-12)
         end
     end


### PR DESCRIPTION
Enables removal of the awkward `change_base` stuff, and speeds up non-tree joint transform update a bit.