### PR TITLE
Remove GenericJoint, TreePath updates

### DIFF
--- a/src/RigidBodyDynamics.jl
+++ b/src/RigidBodyDynamics.jl
@@ -16,7 +16,6 @@ import Base.Iterators: filter, flatten
 export
     RigidBody,
     Joint,
-    GenericJoint,
     JointType,
     Mechanism,
     MechanismState,

--- a/src/graphs/Graphs.jl
+++ b/src/graphs/Graphs.jl
@@ -38,7 +38,6 @@ export
     lowest_common_ancestor,
     direction
 
-using RigidBodyDynamics.CustomCollections: UnsafeFastDict
 using Base.Iterators: flatten
 
 include("abstract.jl")

--- a/src/graphs/Graphs.jl
+++ b/src/graphs/Graphs.jl
@@ -36,7 +36,8 @@ export
     tree_index,
     ancestors,
     lowest_common_ancestor,
-    direction
+    direction,
+    directions
 
 using Base.Iterators: flatten
 

--- a/src/graphs/tree_path.jl
+++ b/src/graphs/tree_path.jl
@@ -9,9 +9,10 @@ end
 source(path::TreePath) = path.source
 target(path::TreePath) = path.target
 
-path_edge_index(edge::E, path::TreePath{<:Any, E}) where {E} = path.indexmap[edge_index(edge)]
-Base.in(edge::E, path::TreePath{<:Any, E}) where {E} = path_edge_index(edge, path) != 0
-direction(edge::E, path::TreePath{<:Any, E}) where {E} = path.directions[path_edge_index(edge, path)]
+@inline Base.findfirst(edge::E, path::TreePath{<:Any, E}) where {E} = path.indexmap[edge_index(edge)]
+@inline Base.in(edge::E, path::TreePath{<:Any, E}) where {E} = findfirst(edge, path) != 0
+@inline directions(path::TreePath) = path.directions
+@inline direction(edge::E, path::TreePath{<:Any, E}) where {E} = path.directions[findfirst(edge, path)]
 
 Base.start(path::TreePath) = start(path.edges)
 Base.next(path::TreePath, state) = next(path.edges, state)

--- a/src/graphs/tree_path.jl
+++ b/src/graphs/tree_path.jl
@@ -48,7 +48,7 @@ function TreePath(src::V, target::V, tree::SpanningTree{V, E}) where {V, E}
     reverse!(lca_to_target)
 
     edges = collect(flatten((source_to_lca, lca_to_target)))
-    directions = UnsafeFastDict{edge_index}(flatten(((e => :up for e in source_to_lca), (e => :down for e in lca_to_target))))
+    directions = UnsafeFastDict{edge_index, E, Symbol}(flatten(((e => :up for e in source_to_lca), (e => :down for e in lca_to_target))))
     indices = IntSet(edge_index.(edges))
-    TreePath(src, target, edges, directions, indices)
+    TreePath{V, E}(src, target, edges, directions, indices)
 end

--- a/src/mechanism.jl
+++ b/src/mechanism.jl
@@ -6,8 +6,8 @@ A `Mechanism` represents an interconnection of rigid bodies and joints.
 state-dependent information.
 """
 mutable struct Mechanism{T}
-    graph::DirectedGraph{RigidBody{T}, GenericJoint{T}}
-    tree::SpanningTree{RigidBody{T}, GenericJoint{T}}
+    graph::DirectedGraph{RigidBody{T}, Joint{T}}
+    tree::SpanningTree{RigidBody{T}, Joint{T}}
     environment::ContactEnvironment{T}
     gravitational_acceleration::FreeVector3D{SVector{3, T}} # TODO: consider removing
     modcount::Int
@@ -19,7 +19,7 @@ mutable struct Mechanism{T}
     be attached with joints.
     """
     function Mechanism(root_body::RigidBody{T}; gravity::SVector{3, T} = SVector(zero(T), zero(T), T(-9.81))) where {T}
-        graph = DirectedGraph{RigidBody{T}, GenericJoint{T}}()
+        graph = DirectedGraph{RigidBody{T}, Joint{T}}()
         add_vertex!(graph, root_body)
         tree = SpanningTree(graph, root_body)
         gravitational_acceleration = FreeVector3D(default_frame(root_body), gravity)

--- a/src/mechanism_algorithms.jl
+++ b/src/mechanism_algorithms.jl
@@ -83,9 +83,10 @@ function geometric_jacobian!(out::GeometricJacobian, state::MechanismState, path
     update_motion_subspaces!(state)
     foreach_with_extra_args(out, state, path, state.type_sorted_tree_joints, state.motion_subspaces.data) do out, state, path, joint, motion_subspace # TODO: use closure once it doesn't allocate
         vrange = velocity_range(state, joint)
-        if joint in path
+        pathindex = findfirst(joint, path)
+        if pathindex > 0
             part = transformfun(motion_subspace)
-            direction(joint, path) == :up && (part = -part)
+            directions(path)[pathindex] == :up && (part = -part)
             set_cols!(out, vrange, part)
         else
             zero_cols!(out, vrange)
@@ -522,9 +523,10 @@ function constraint_jacobian_and_bias!(state::MechanismState, constraintjacobian
         # Jacobian.
         foreach_with_extra_args(constraintjacobian, state, path, T, rowrange, state.type_sorted_tree_joints, state.motion_subspaces.data) do constraintjacobian, state, path, T, rowrange, treejoint, J # TODO: use closure once it doesn't allocate
             vrange = velocity_range(state, treejoint)
-            if treejoint in path
+            pathindex = findfirst(treejoint, path)
+            if pathindex > 0
                 part = angular(T)' * angular(J) + linear(T)' * linear(J) # TODO: At_mul_B
-                direction(treejoint, path) == :up && (part = -part)
+                directions(path)[pathindex] == :up && (part = -part)
                 set_matrix_block!(constraintjacobian, rowrange, vrange, part)
             else
                 zero_matrix_block!(constraintjacobian, rowrange, vrange)

--- a/src/mechanism_algorithms.jl
+++ b/src/mechanism_algorithms.jl
@@ -136,7 +136,7 @@ The Jacobian is computed in the `Mechanism`'s root frame.
 
 See [`geometric_jacobian!(out, state, path)`](@ref).
 """
-function geometric_jacobian(state::MechanismState{X, M, C}, path::TreePath{RigidBody{M}, GenericJoint{M}}) where {X, M, C}
+function geometric_jacobian(state::MechanismState{X, M, C}, path::TreePath{RigidBody{M}, Joint{M}}) where {X, M, C}
     nv = num_velocities(state)
     angular = Matrix{C}(3, nv)
     linear = Matrix{C}(3, nv)

--- a/src/mechanism_algorithms.jl
+++ b/src/mechanism_algorithms.jl
@@ -83,7 +83,7 @@ function geometric_jacobian!(out::GeometricJacobian, state::MechanismState, path
     update_motion_subspaces!(state)
     foreach_with_extra_args(out, state, path, state.type_sorted_tree_joints, state.motion_subspaces.data) do out, state, path, joint, motion_subspace # TODO: use closure once it doesn't allocate
         vrange = velocity_range(state, joint)
-        if Graphs.edge_index(joint) in path.indices
+        if joint in path
             part = transformfun(motion_subspace)
             direction(joint, path) == :up && (part = -part)
             set_cols!(out, vrange, part)
@@ -522,7 +522,7 @@ function constraint_jacobian_and_bias!(state::MechanismState, constraintjacobian
         # Jacobian.
         foreach_with_extra_args(constraintjacobian, state, path, T, rowrange, state.type_sorted_tree_joints, state.motion_subspaces.data) do constraintjacobian, state, path, T, rowrange, treejoint, J # TODO: use closure once it doesn't allocate
             vrange = velocity_range(state, treejoint)
-            if Graphs.edge_index(treejoint) in path.indices
+            if treejoint in path
                 part = angular(T)' * angular(J) + linear(T)' * linear(J) # TODO: At_mul_B
                 direction(treejoint, path) == :up && (part = -part)
                 set_matrix_block!(constraintjacobian, rowrange, vrange, part)

--- a/src/state_cache.jl
+++ b/src/state_cache.jl
@@ -34,7 +34,7 @@ end
 Base.show(io::IO, ::StateCache) = print(io, "StateCache{…}(…)")
 
 function StateCache(mechanism::Mechanism{M}) where M
-    JointCollection = typeof(TypeSortedCollection(typedjoint.(joints(mechanism))))
+    JointCollection = typeof(TypeSortedCollection(joints(mechanism)))
     StateCache{M, JointCollection}(mechanism, [], [])
 end
 

--- a/test/test_custom_collections.jl
+++ b/test/test_custom_collections.jl
@@ -9,18 +9,6 @@
         end
     end
 
-    @testset "UnsafeFastDict" begin
-        d1 = RigidBodyDynamics.UnsafeFastDict{identity}(i => 3. * i for i in 1 : 3)
-        show(DevNull, d1)
-        @test eltype(d1) == Pair{Int64, Float64}
-        @test all(keys(d1) .== 1 : 3)
-        @test all(values(d1) .== 3. * (1 : 3))
-
-        d2 = RigidBodyDynamics.UnsafeFastDict{x -> round(Int64, x), Number}(i => 3 * i for i in 1 : 3)
-        @test all(keys(d2) .== 1 : 3)
-        @test all(values(d2) .== 3 * (1 : 3))
-    end
-
     @testset "nulldict" begin
         nd = RigidBodyDynamics.NullDict{Int, Int}()
         @test isempty(nd)


### PR DESCRIPTION
* remove `GenericJoint`, `typedjoint`, just store non-concretely-typed joints in a `Mechanism`'s graph and tree. Stop making concretely typed copy of the joints in `MechanismState`.
* change `TreePath` to use a `SparseVector`, so that `UnsafeFastDict` could be removed.