### PR TITLE
State cache fix

### DIFF
--- a/src/joint.jl
+++ b/src/joint.jl
@@ -63,6 +63,7 @@ frame_after(joint::Joint) = joint.frame_after
 joint_type(joint::Joint) = joint.joint_type
 joint_to_predecessor(joint::Joint) = joint.joint_to_predecessor[]
 joint_to_successor(joint::Joint) = joint.joint_to_successor[]
+motionsubspacetype(::Type{J}, ::Type{X}) where {JT, J<:Joint{<:Any, JT}, X} = motionsubspacetype(JT, X)
 
 """
 $(SIGNATURES)

--- a/src/joint_types.jl
+++ b/src/joint_types.jl
@@ -4,7 +4,17 @@ abstract type JointType{T} end
 Base.eltype(::Type{JointType{T}}) where {T} = T
 num_velocities(::T) where {T<:JointType} = num_velocities(T)
 num_positions(::T) where {T<:JointType} = num_positions(T)
-Base.@pure num_constraints(t::Type{T}) where {T<:JointType} = 6 - num_velocities(t)
+
+num_constraints(::Type{T}) where {T<:JointType} = _num_constraints(num_velocities(T))
+Base.@pure _num_constraints(N::Int) = 6 - N
+
+function motionsubspacetype(::Type{JT}, ::Type{X}) where {T, JT<:JointType{T}, X}
+    N = num_velocities(JT)
+    L = _motionsubspacelength(N)
+    C = promote_type(T, X)
+    GeometricJacobian{SMatrix{3, N, C, L}}
+end
+Base.@pure _motionsubspacelength(N::Int) = 3 * N
 
 # Default implementations
 isfloating(::Type{<:JointType}) = false

--- a/src/mechanism_state.jl
+++ b/src/mechanism_state.jl
@@ -47,7 +47,7 @@ struct MechanismState{X, M, C, JointCollection, MotionSubspaceCollection}
     joint_twists::JointCacheDict{Twist{C}}
     joint_bias_accelerations::JointCacheDict{SpatialAcceleration{C}}
     motion_subspaces::CacheElement{MotionSubspaceCollection} # TODO
-    constraint_wrench_subspaces::JointCacheDict{WrenchSubspace{C}} # note: the ones corresponding to tree joints are never used (or set)
+    constraint_wrench_subspaces::JointCacheDict{WrenchSubspace{C}} # TODO: use a TSC. note: the ones corresponding to tree joints are never used (or set)
 
     # body-related cache
     transforms_to_root::BodyCacheDict{Transform3D{C}}

--- a/src/spatial/Spatial.jl
+++ b/src/spatial/Spatial.jl
@@ -22,7 +22,6 @@ export
 
 # aliases
 export
-    MotionSubspace, # TODO: remove
     WrenchSubspace # TODO: remove
 
 # functions

--- a/src/spatial/spatialmotion.jl
+++ b/src/spatial/spatialmotion.jl
@@ -19,15 +19,6 @@ struct GeometricJacobian{A<:AbstractMatrix}
     end
 end
 
-# MotionSubspace is the return type of motion_subspace(::Joint, ...)
-const MotionSubspace{T} = GeometricJacobian{ContiguousSMatrixColumnView{3, 6, T, 18}}
-
-function MotionSubspace(body::CartesianFrame3D, base::CartesianFrame3D, frame::CartesianFrame3D, angular, linear)
-    GeometricJacobian(body, base, frame, smatrix3x6view(angular), smatrix3x6view(linear))
-end
-
-MotionSubspace(jac::GeometricJacobian) = MotionSubspace(jac.body, jac.base, jac.frame, angular(jac), linear(jac))
-
 # GeometricJacobian-specific functions
 Base.convert(::Type{GeometricJacobian{A}}, jac::GeometricJacobian{A}) where {A} = jac
 

--- a/test/test_mechanism_algorithms.jl
+++ b/test/test_mechanism_algorithms.jl
@@ -124,7 +124,7 @@ end
             wrench = rand(Wrench{Float64}, frame_after(joint))
             τ = Vector{Float64}(num_velocities(joint))
             RigidBodyDynamics.joint_torque!(τ, joint, qjoint, wrench)
-            S = motion_subspace(joint, configuration(x, joint))
+            S = motion_subspace(joint, configuration(x, joint))::RigidBodyDynamics.motionsubspacetype(typeof(joint), Float64)
             @test isapprox(τ, torque(S, wrench))
         end
     end


### PR DESCRIPTION
Back to zero allocation. Fun bit of type system magic (some of it using undocumented Base functions, unfortunately).

Also remove `MotionSubspace` type alias; can just use straight `SMatrix`-backed `GeometricJacobian`s now.

Fixes #381.