### PR TITLE
Store constraint wrench subspaces in a TSC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ notifications:
 before_install:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
 script:
-  - julia -e 'ENV["PYTHON"]=""; Pkg.clone(pwd()); Pkg.build("RigidBodyDynamics"); Pkg.test("RigidBodyDynamics"; coverage=true)'
+  - julia -e 'ENV["PYTHON"]=""; Pkg.clone(pwd()); Pkg.checkout("TypeSortedCollections"); Pkg.build("RigidBodyDynamics"); Pkg.test("RigidBodyDynamics"; coverage=true)'
   # Note: PYTHON env is to ensure that PyCall uses the Conda.jl package's Miniconda distribution within Julia. Otherwise the sympy Python module won't be installed/imported properly.
 after_success:
   - julia -e 'cd(Pkg.dir("RigidBodyDynamics")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/src/joint.jl
+++ b/src/joint.jl
@@ -64,6 +64,7 @@ joint_type(joint::Joint) = joint.joint_type
 joint_to_predecessor(joint::Joint) = joint.joint_to_predecessor[]
 joint_to_successor(joint::Joint) = joint.joint_to_successor[]
 motionsubspacetype(::Type{J}, ::Type{X}) where {JT, J<:Joint{<:Any, JT}, X} = motionsubspacetype(JT, X)
+wrenchsubspacetype(::Type{J}, ::Type{X}) where {JT, J<:Joint{<:Any, JT}, X} = wrenchsubspacetype(JT, X)
 
 """
 $(SIGNATURES)

--- a/src/joint_types.jl
+++ b/src/joint_types.jl
@@ -10,11 +10,20 @@ Base.@pure _num_constraints(N::Int) = 6 - N
 
 function motionsubspacetype(::Type{JT}, ::Type{X}) where {T, JT<:JointType{T}, X}
     N = num_velocities(JT)
-    L = _motionsubspacelength(N)
+    L = _3x(N)
     C = promote_type(T, X)
     GeometricJacobian{SMatrix{3, N, C, L}}
 end
-Base.@pure _motionsubspacelength(N::Int) = 3 * N
+
+function wrenchsubspacetype(::Type{JT}, ::Type{X}) where {T, JT<:JointType{T}, X}
+    N = num_constraints(JT)
+    L = _3x(N)
+    C = promote_type(T, X)
+    WrenchMatrix{SMatrix{3, N, C, L}}
+end
+
+Base.@pure _3x(N::Int) = 3 * N
+
 
 # Default implementations
 isfloating(::Type{<:JointType}) = false

--- a/src/mechanism_algorithms.jl
+++ b/src/mechanism_algorithms.jl
@@ -740,7 +740,10 @@ function dynamics!(result::DynamicsResult{T, M}, state::MechanismState{X, M},
     end
     dynamics_bias!(result, state)
     mass_matrix!(result, state)
-    has_loops(state.mechanism) && constraint_jacobian_and_bias!(result, state)
+    if has_loops(state.mechanism)
+        constraint_jacobian!(result, state)
+        constraint_bias!(result, state)
+    end
     dynamics_solve!(result, torques)
     nothing
 end

--- a/src/spatial/Spatial.jl
+++ b/src/spatial/Spatial.jl
@@ -20,10 +20,6 @@ export
     Wrench,
     SpatialInertia
 
-# aliases
-export
-    WrenchSubspace # TODO: remove
-
 # functions
 export
     transform,

--- a/src/spatial/spatialforce.jl
+++ b/src/spatial/spatialforce.jl
@@ -25,13 +25,6 @@ expressed in a centroidal frame.
 """
 MomentumMatrix
 
-# WrenchSubspace is the return type of e.g. constraint_wrench_subspace(::Joint, ...)
-const WrenchSubspace{T} = WrenchMatrix{ContiguousSMatrixColumnView{3, 6, T, 18}}
-function WrenchSubspace(frame::CartesianFrame3D, angular, linear)
-    WrenchMatrix(frame, smatrix3x6view(angular), smatrix3x6view(linear))
-end
-WrenchSubspace(mat::WrenchMatrix) = WrenchSubspace(mat.frame, angular(mat), linear(mat))
-
 for ForceSpaceMatrix in (:MomentumMatrix, :WrenchMatrix)
     @eval begin
         Base.convert(::Type{$ForceSpaceMatrix{A}}, mat::$ForceSpaceMatrix{A}) where {A} = mat

--- a/src/spatial/util.jl
+++ b/src/spatial/util.jl
@@ -50,25 +50,6 @@ Return a matrix `A` such that `A[:, i] == f(mat[:, i], vec)`.
     end
 end
 
-## Functionality related to turning a 3xN SMatrix into a view of a 3x6 SMatrix
-const ContiguousSMatrixColumnView{S1, S2, T, L} = SubArray{T,2,SMatrix{S1, S2, T, L},Tuple{Base.Slice{Base.OneTo{Int}},UnitRange{Int}},true}
-
-@inline smatrix3x6view(mat::StaticMatrix) = _smatrix3x6view(Size(mat), mat)
-
-@generated function _smatrix3x6view(::Size{S}, mat::StaticMatrix) where {S}
-    Snew = (S[1], 6)
-    S[1] == 3 || error()
-    (0 <= S[2] <= Snew[2]) || error()
-    fillercols = Snew[2] - S[2]
-    fillerlength = S[1] * fillercols
-    T = eltype(mat)
-    exprs = vcat([:(mat[$i]) for i = 1 : prod(S)], [:(zero($T)) for i = 1 : fillerlength])
-    return quote
-        Base.@_inline_meta
-        @inbounds return view(similar_type(mat, Size($Snew))(tuple($(exprs...))), :, 1 : $S[2])
-    end
-end
-
 @inline function vector_to_skew_symmetric(v::SVector{3, T}) where {T}
     @SMatrix [zero(T) -v[3] v[2];
             v[3] zero(T) -v[1];

--- a/src/state_cache.jl
+++ b/src/state_cache.jl
@@ -38,15 +38,6 @@ function StateCache(mechanism::Mechanism{M}) where M
     StateCache{M, JointCollection}(mechanism, [], [])
 end
 
-function motionsubspacetypes(JointTypes, ::Type{X}) where X
-    Base.tuple_type_cons(motionsubspacetype(Base.tuple_type_head(JointTypes), X), motionsubspacetypes(Base.tuple_type_tail(JointTypes), X))
-end
-motionsubspacetypes(::Type{Tuple{}}, ::Type) = Tuple{}
-
-function motionsubspacecollectiontype(::Type{TypeSortedCollection{D, N}}, ::Type{X}) where {D, N, X}
-    TypeSortedCollection{vectortypes(motionsubspacetypes(eltypes(D), X)), N}
-end
-
 @inline function Base.getindex(c::StateCache{M, JC}, ::Type{X}) where {M, JC, X}
     C = promote_type(X, M)
     MSC = motionsubspacecollectiontype(JC, X)

--- a/src/state_cache.jl
+++ b/src/state_cache.jl
@@ -38,20 +38,10 @@ function StateCache(mechanism::Mechanism{M}) where M
     StateCache{M, JointCollection}(mechanism, [], [])
 end
 
-function eltypes(TupleOfVectors) # TODO: consider moving to TSC
-    Base.tuple_type_cons(eltype(Base.tuple_type_head(TupleOfVectors)), eltypes(Base.tuple_type_tail(TupleOfVectors)))
-end
-eltypes(::Type{Tuple{}}) = Tuple{}
-
 function motionsubspacetypes(JointTypes, ::Type{X}) where X
     Base.tuple_type_cons(motionsubspacetype(Base.tuple_type_head(JointTypes), X), motionsubspacetypes(Base.tuple_type_tail(JointTypes), X))
 end
 motionsubspacetypes(::Type{Tuple{}}, ::Type) = Tuple{}
-
-function vectortypes(Eltypes) # TODO: consider moving to TSC
-    Base.tuple_type_cons(Vector{Base.tuple_type_head(Eltypes)}, vectortypes(Base.tuple_type_tail(Eltypes)))
-end
-vectortypes(::Type{Tuple{}}) = Tuple{}
 
 function motionsubspacecollectiontype(::Type{TypeSortedCollection{D, N}}, ::Type{X}) where {D, N, X}
     TypeSortedCollection{vectortypes(motionsubspacetypes(eltypes(D), X)), N}

--- a/src/state_cache.jl
+++ b/src/state_cache.jl
@@ -41,7 +41,8 @@ end
 @inline function Base.getindex(c::StateCache{M, JC}, ::Type{X}) where {M, JC, X}
     C = promote_type(X, M)
     MSC = motionsubspacecollectiontype(JC, X)
-    ReturnType = MechanismState{X, M, C, JC, MSC}
+    WSC = wrenchsubspacecollectiontype(JC, X)
+    ReturnType = MechanismState{X, M, C, JC, MSC, WSC}
     key = (object_id(X), Threads.threadid())
     @inbounds for i = 1 : length(c.keys)
         if c.keys[i] === key


### PR DESCRIPTION
Similar to `MotionSubspaceCollection`. Make `WrenchSubspaceCollection` a `MechanismState` type parameter. Remove crud related to previous implementation (storage as views of `SMatrix{3, 6}`-backed `WrenchSubspace`s).

Also redo the `MechanismState` constructors a bit. Now everything is type-inferrable once the `JointCollection` type has been established.