### PR TITLE
Add and use SegmentedVector

### DIFF
--- a/src/RigidBodyDynamics.jl
+++ b/src/RigidBodyDynamics.jl
@@ -147,6 +147,10 @@ export
     dynamics!,
     simulate
 
+# Utility
+export
+    SegmentedVector
+
 include("custom_collections.jl")
 include("graphs/Graphs.jl")
 include("spatial/Spatial.jl")

--- a/src/custom_collections.jl
+++ b/src/custom_collections.jl
@@ -114,7 +114,6 @@ From https://github.com/rdeits/NNLS.jl/blob/0a9bf56774595b5735bc738723bd3cb94138
 end
 
 
-# TODO: remove
 mutable struct CacheElement{T}
     data::T
     dirty::Bool

--- a/src/dynamics_result.jl
+++ b/src/dynamics_result.jl
@@ -50,9 +50,11 @@ mutable struct DynamicsResult{T, M}
         rootframe = root_frame(mechanism)
         contactwrenches = BodyDict{Wrench{T}}(b => zero(Wrench{T}, rootframe) for b in bodies(mechanism))
         totalwrenches = BodyDict{Wrench{T}}(b => zero(Wrench{T}, rootframe) for b in bodies(mechanism))
-        accelerations = BodyDict{SpatialAcceleration{T}}(b => zero(SpatialAcceleration{T}, rootframe, rootframe, rootframe) for b in bodies(mechanism))
+        accelerations = BodyDict{SpatialAcceleration{T}}(
+            b => zero(SpatialAcceleration{T}, rootframe, rootframe, rootframe) for b in bodies(mechanism))
         jointwrenches = BodyDict{Wrench{T}}(b => zero(Wrench{T}, rootframe) for b in bodies(mechanism))
-        contact_state_derivs = BodyDict{Vector{Vector{DefaultSoftContactStateDeriv{T}}}}(b => Vector{Vector{DefaultSoftContactStateDeriv{T}}}() for b in bodies(mechanism))
+        contact_state_derivs = BodyDict{Vector{Vector{DefaultSoftContactStateDeriv{T}}}}(
+            b => Vector{Vector{DefaultSoftContactStateDeriv{T}}}() for b in bodies(mechanism))
         startind = 1
         for body in bodies(mechanism), point in contact_points(body)
             model = contact_model(point)
@@ -78,10 +80,17 @@ end
 
 DynamicsResult(mechanism::Mechanism{M}) where {M} = DynamicsResult{M}(mechanism)
 
-contact_state_derivatives(result::DynamicsResult, body::Union{<:RigidBody, BodyID}) = result.contact_state_derivatives[body]
-contact_wrench(result::DynamicsResult, body::Union{<:RigidBody, BodyID}) = result.contactwrenches[body]
-set_contact_wrench!(result::DynamicsResult, body::Union{<:RigidBody, BodyID}, wrench::Wrench) = (result.contactwrenches[body] = wrench)
-acceleration(result::DynamicsResult, body::Union{<:RigidBody, BodyID}) = result.accelerations[body]
-set_acceleration!(result::DynamicsResult, body::Union{<:RigidBody, BodyID}, accel::SpatialAcceleration) = (result.accelerations[body] = accel)
-joint_wrench(result::DynamicsResult, body::Union{<:RigidBody, BodyID}) = result.jointwrenches[body]
-set_joint_wrench!(result::DynamicsResult, body::Union{<:RigidBody, BodyID}, wrench::Wrench) = (result.jointwrenches[body] = wrench)
+contact_state_derivatives(result::DynamicsResult, body::Union{<:RigidBody, BodyID}) =
+    result.contact_state_derivatives[body]
+contact_wrench(result::DynamicsResult, body::Union{<:RigidBody, BodyID}) =
+    result.contactwrenches[body]
+set_contact_wrench!(result::DynamicsResult, body::Union{<:RigidBody, BodyID}, wrench::Wrench) =
+    (result.contactwrenches[body] = wrench)
+acceleration(result::DynamicsResult, body::Union{<:RigidBody, BodyID}) =
+    result.accelerations[body]
+set_acceleration!(result::DynamicsResult, body::Union{<:RigidBody, BodyID}, accel::SpatialAcceleration) =
+    (result.accelerations[body] = accel)
+joint_wrench(result::DynamicsResult, body::Union{<:RigidBody, BodyID}) =
+    result.jointwrenches[body]
+set_joint_wrench!(result::DynamicsResult, body::Union{<:RigidBody, BodyID}, wrench::Wrench) =
+    (result.jointwrenches[body] = wrench)

--- a/src/mechanism_algorithms.jl
+++ b/src/mechanism_algorithms.jl
@@ -309,8 +309,8 @@ function spatial_accelerations!(out::Associative{BodyID, SpatialAcceleration{T}}
     mechanism = state.mechanism
     root = root_body(mechanism)
     joints = state.type_sorted_tree_joints
-    qs = values(state.qs)
-    vs = values(state.vs)
+    qs = values(segments(state.q))
+    vs = values(segments(state.v))
 
     # Compute joint accelerations
     foreach_with_extra_args(state, out, vd, joints, qs, vs) do state, accels, vd, joint, qjoint, vjoint # TODO: use closure once it doesn't allocate


### PR DESCRIPTION
`SegmentedVector` stores both a flat `AbstractVector` (its `parent`), as well as an `IndexDict` containing views into the parent (which together cover the parent).

Replace `state.q` and `state.qs` with a single `SegmentedVector` (same for `v`).

Next step is to replace `AbstractVector` input arguments such as `v̇` and `τ` with `SegmentedVector`s, so that we can get rid of `fastview`, as well as use `broadcast!` instead of the `foreach_with_extra_args` hack.

On top of https://github.com/tkoolen/RigidBodyDynamics.jl/pull/388 (bug fixed).